### PR TITLE
Drop unrendered space literal

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -939,7 +939,7 @@ available; ``recv`` returns as soon as *any* data is available. If
 *probably* keep it all together in a single chunk, but there's no
 guarantee. If we send ``hello world`` then the other side might get
 ``hello world``, or ``hello`` ``world``, or ``h`` ``e`` ``l`` ``l``
-``o`` `` `` ``w`` ``o`` ``r`` ``l`` ``d``, or ... bottom line, if
+``o`` ``w`` ``o`` ``r`` ``l`` ``d``, or ... bottom line, if
 we're expecting 10 bytes of data, we need to be prepared to call
 ``recv`` up to 10 times to get all that data.
 


### PR DESCRIPTION
Gets rendered as
```
`` ``
```
on Read the Docs.