### PR TITLE
Typo fix

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -794,7 +794,7 @@ And the second task's job is to process the data the server sends back:
    :pyobject: receiver
 
 It repeatedly calls ``await client_sock.recv(...)`` to get more data
-from the server, and then checks to see if the server hass closed the
+from the server, and then checks to see if the server has closed the
 connection. ``recv`` only returns an empty bytestring if the
 connection has been closed; if there's no data available, then it
 blocks until more data arrives.


### PR DESCRIPTION
Hi,

Besides a small typo there's a problem in `There are only 4 lines of code that really do anything here. On line 17, we use [...] ` paragraph. Even though in `tasks-intro.py` relevant code chunk starts from line 15, rtd.io starts it with line 16, making mentioning lines 17, 19 and 22 in the paragraph bogus.