### PR TITLE
Fix custom supervisor example in documentation

### DIFF
--- a/docs/source/reference-core.rst
+++ b/docs/source/reference-core.rst
@@ -745,7 +745,8 @@ first::
                nursery.spawn(async_fn)
            task_batch = await nursery.monitor.get_batch()
            nursery.cancel_scope.cancel()
-           return task_batch[0].reap_and_unwrap(finished_task)
+           finished_task = task_batch[0]
+           return nursery.reap_and_unwrap(finished_task)
 
 This works by waiting until at least one task has finished, then
 cancelling all remaining tasks and returning the result from the first


### PR DESCRIPTION
I believe this PR fixes the broken example in the Custom Supervisor example in the docs, where ``finished_task`` is an undeclared variable and ``reap_and_unwrap`` should be called on the ``nursery``.

While this is a solid example and this PR should fix the immediate error, I was wondering if you would be open to making this example a little more expressive. For me, this type of monitoring demonstrates some of the most elegant parts of the trio API. What I had in mind would be expanding the example to something like

```python
import functools
import trio


async def sleep_and_return_num(num):
    await trio.sleep(num)
    return num


async def race(*async_fns):
    if not async_fns:
        raise ValueError("must pass at least one argument")

    async with trio.open_nursery() as nursery:
        for async_fn in async_fns:
            nursery.spawn(async_fn)

        task_batch = await nursery.monitor.get_batch()
        nursery.cancel_scope.cancel()

        finished_task = task_batch[0]
        return nursery.reap_and_unwrap(finished_task)


async def main():
    winner = await race(
        functools.partial(sleep_and_return_num, 1),
        functools.partial(sleep_and_return_num, 2),
        functools.partial(sleep_and_return_num, 3)
    )

    print('The winner is', winner)


if __name__ == '__main__':
    trio.run(main)
```

This sample, when run, prints out ``The winner is 1``. While this may be a bit long for inlining in the main documentation, would you be open to having a collection of snippets somewhere and link to examples like this?