### PR TITLE
Use set_wakeup_fd to react to control-C on Windows

### DIFF
--- a/trio/_core/_io_windows.py
+++ b/trio/_core/_io_windows.py
@@ -135,32 +135,9 @@ class WindowsIOManager:
 
         # This is necessary to allow control-C to interrupt select().
         # https://github.com/python-trio/trio/issues/42
-        #
-        # Basically it's doing the same thing as signal.set_wakeup_fd, except
-        # for some reason when I do it here it works, which I can't say for
-        # set_wakeup_fd. I don't know why.
-        #
-        # caveat 1: if there are subinterpreters in use, the callback always
-        # runs in the main interpreter, which might be very broken. (Or might
-        # work fine? who knows)
-        # caveat 2: this callback running means that Python's signal
-        # handlers will be run soon... but there's a race condition; we might
-        # go back to sleep again before the signal handler actually
-        # runs. (Hitting control-C again will work though.)
-        # caveat 3: there's no test for this, because I can't figure out how
-        # to reliably generate a synthetic control-C on windows. Manual test:
-        #
-        #    python -c "import trio; trio.run(trio.sleep_forever)"
-        #
-        # then hit control-C.
         if threading.current_thread() == threading.main_thread():
-            @ffi.callback("BOOL WINAPI(DWORD)")
-            def cb(dwCtrlType):
-                self._main_thread_waker.wakeup_thread_and_signal_safe()
-                # 0 = FALSE = keep running handlers after this
-                return 0
-            self._cb = cb
-            kernel32.SetConsoleCtrlHandler(self._cb, 1)
+            fileno = self._main_thread_waker.write_sock.fileno()
+            self._old_signal_wakeup_fd = signal.set_wakeup_fd(fileno)
 
     def statistics(self):
         return _WindowsStatistics(
@@ -179,7 +156,7 @@ class WindowsIOManager:
                 self._iocp_thread.join()
             self._main_thread_waker.close()
             if threading.current_thread() == threading.main_thread():
-                kernel32.SetConsoleCtrlHandler(self._cb, 0)
+                signal.set_wakeup_fd(self._old_signal_wakeup_fd)
 
     def __del__(self):
         # Need to make sure we clean up self._iocp (raw handle) and the IOCP

--- a/trio/_core/_wakeup_socketpair.py
+++ b/trio/_core/_wakeup_socketpair.py
@@ -4,9 +4,9 @@ from .. import _core
 
 class WakeupSocketpair:
     def __init__(self):
-        self.wakeup_sock, self._write_sock = socket.socketpair()
+        self.wakeup_sock, self.write_sock = socket.socketpair()
         self.wakeup_sock.setblocking(False)
-        self._write_sock.setblocking(False)
+        self.write_sock.setblocking(False)
         # This somewhat reduces the amount of memory wasted queueing up data
         # for wakeups. With these settings, maximum number of 1-byte sends
         # before getting BlockingIOError:
@@ -16,11 +16,11 @@ class WakeupSocketpair:
         # Windows you're weird. (And on Windows setting SNDBUF to 0 makes send
         # blocking, even on non-blocking sockets, so don't do that.)
         self.wakeup_sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 1)
-        self._write_sock.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, 1)
+        self.write_sock.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, 1)
 
     def wakeup_thread_and_signal_safe(self):
         try:
-            self._write_sock.send(b"\x00")
+            self.write_sock.send(b"\x00")
         except BlockingIOError:
             pass
 
@@ -37,4 +37,4 @@ class WakeupSocketpair:
 
     def close(self):
         self.wakeup_sock.close()
-        self._write_sock.close()
+        self.write_sock.close()


### PR DESCRIPTION
As compared to the CFFI-based code that this replaces, it's (a) less
race-y (the Python C-level signal handler writes to the
wakeup_fd *after* setting the flag to run the Python-level signal
handler, whereas our old code ran before), (b) avoids arcane CFFI
stuff that might be broken in the presence of subinterpreters, (c)
slightly less code.

The downside of set_wakeup_fd is that writing to the wakeup socket
fails with EWOULDBLOCK, then in our context the correct thing to do is
to ignore that error (we just want to guarantee a wakeup, and if the
send buffer is full then we are definitely going to wake up), but the
hardcoded behavior in signalmodule.c is to print a spurious warning to
stderr. IMO this is makes it useless to us on Unix-likes, because they
get signals all the time, and we configure out wakeup socket to use a
tiny send buffer to save on kernel memory. But on Windows the
trade-offs are different: Windows insists on using a gargantuan send
buffer (see comments in _wakeup_socketpair.py), and the only signal is
control-C. It's not that big a deal if someone gets a spurious error
message in an extremely rare case when responding to an explicit
control-C. (Though it still would be nicer to not have this error
message...)

See gh-42 for more details.