### PR TITLE
[test] Make '--run-slow' option default to true if unregistered

### DIFF
--- a/trio/_core/tests/tutil.py
+++ b/trio/_core/tests/tutil.py
@@ -4,7 +4,7 @@ import pytest
 
 # See trio/tests/conftest.py for the other half of this
 slow = pytest.mark.skipif(
-    not pytest.config.getoption("--run-slow"),
+    not pytest.config.getoption("--run-slow", True),
     reason="use --run-slow to run slow tests",
 )
 


### PR DESCRIPTION
Depending on pytest is called, it sometimes doesn't pick up our
--run-slow option. I find this sorta weird and mysterious, and
probably we should come up with a more robust workaround, but in the
mean time this commit should make it so that if it doesn't notice
--run-slow then it defaults to assuming its passed, instead of
crashing.