### PR TITLE
New argument to trio.run: restrict_keyboard_interrupt_to_checkpoints

### DIFF
--- a/docs/source/history.rst
+++ b/docs/source/history.rst
@@ -3,6 +3,13 @@ Release history
 
 .. currentmodule:: trio
 
+v0.2.0 (????-??-??)
+-------------------
+
+* New argument to :func:`trio.run`:
+  ``restrict_keyboard_interrupt_to_checkpoints``.
+
+
 v0.1.0 (2017-03-10)
 -------------------
 

--- a/docs/source/reference-core.rst
+++ b/docs/source/reference-core.rst
@@ -13,8 +13,8 @@ If you want to use trio, then the first thing you have to do is call
 .. autofunction:: run
 
 
-General notes
--------------
+General principle
+-----------------
 
 .. _checkpoints:
 
@@ -314,7 +314,7 @@ It's also important in any long-running code to make sure that you
 regularly check for cancellation, because otherwise timeouts won't
 work! This happens implicitly every time you call a cancellable
 operation; see :ref:`below <cancellable-primitives>` for details. If
-you have a task that has to do a lot of work without any IO, then you
+you have a task that has to do a lot of work without any I/O, then you
 can use ``await sleep(0)`` to insert an explicit cancel+schedule
 point.
 

--- a/trio/_core/_ki.py
+++ b/trio/_core/_ki.py
@@ -158,7 +158,7 @@ disable_ki_protection.__name__ = "disable_ki_protection"
 _hazmat(disable_ki_protection)
 
 @contextmanager
-def ki_manager(deliver_cb):
+def ki_manager(deliver_cb, restrict_keyboard_interrupt_to_checkpoints):
     if (threading.current_thread() != threading.main_thread()
           or signal.getsignal(signal.SIGINT) != signal.default_int_handler):
         yield
@@ -167,7 +167,7 @@ def ki_manager(deliver_cb):
     def handler(signum, frame):
         assert signum == signal.SIGINT
         protection_enabled = ki_protection_enabled(frame)
-        if protection_enabled:
+        if protection_enabled or restrict_keyboard_interrupt_to_checkpoints:
             deliver_cb()
         else:
             raise KeyboardInterrupt


### PR DESCRIPTION
There are two main strategies for handling control-C:

- Accept that a KeyboardInterrupt will be raised "asynchronously" (in
  the sense of "asynchronous exceptions", nothing to do with
  async/await). It's essentially impossible to write fully correct
  code under this model (see many rants by Java folks), but it does
  something more-or-less reasonable 99% of the time, and it's what
  Python developers expect.

- Use some sort of explicit handler for KeyboardInterrupt, and only
  deal with them at carefully chosen places in your code where you
  know it's safe to do so. This makes it possible to write fully
  correct code, but doesn't make it easy; such code tends to be
  difficult to write and fragile. It's not *as* bad in trio because we
  have nice abstractions like cancellation and trio.catch_signals, but
  there are still gotchas (e.g. catch_signals raises an error if you
  try to call it outside the main thread; that's pretty easy to miss
  in testing!).

I realized that it's pretty trivial for us to provide a nice third
option combines many of the advantages of these two approaches: we
already have the machinery to route KeyboardInterrupt through the
cancellation machinery when necessary, so this patch adds a flag that
lets the user request that this happen all the time. Flipping on this
flag gives you most of the advantages of the "explicit handler" model,
without having to write any code.