### PR TITLE
Set __returns_acontextmanager__ = True in @acontextmanager

### DIFF
--- a/trio/_util.py
+++ b/trio/_util.py
@@ -135,4 +135,6 @@ def acontextmanager(func):
     @wraps(func)
     def helper(*args, **kwds):
         return _AsyncGeneratorContextManager(func, args, kwds)
+    # A hint for sphinxcontrib-trio:
+    helper.__returns_acontextmanager__ = True
     return helper


### PR DESCRIPTION
This works as a hint to sphinxcontrib-trio that functions decorated
with @acontextmanager should be documented as async context managers,
and *not* async iterators (like they're currently being detected).

See: https://github.com/python-trio/sphinxcontrib-trio/commit/2d9e65187dc7a08863b68a78bdee4fb051f0b99e