### PR TITLE
Fix test broken by async_generator 1.7 release

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -310,7 +310,7 @@ time. In the first part, we define two async functions ``child1`` and
    :linenos:
    :lineno-match:
    :start-at: async def child1
-   :end-at: child2 exiting
+   :end-at: child2: exiting
 
 Next, we define ``parent`` as an async function that's going to call
 ``child1`` and ``child2`` concurrently:


### PR DESCRIPTION
In v1.7, async_generator.isasyncgenfunction became pickier, to match
inspect.isasyncgenfunction and because this was needed to fix the trio
docs. Apparently this bit of trio's test suite was relying on the old
laxity...

In general we could also make acontextmanager more lenient, and that
might make sense if it were a public API, but for now the extra
pickiness seems fine.