### PR TITLE
Yet another attempt to make test_ki_wakes_us_up reliable on Windows

### DIFF
--- a/trio/_core/tests/test_ki.py
+++ b/trio/_core/tests/test_ki.py
@@ -472,6 +472,11 @@ def test_ki_wakes_us_up():
                     print("waiting for lock")
                     with lock:
                         print("got lock")
+                    # And then we want to force a PyErr_CheckSignals. Which is
+                    # not so easy on Windows. Weird kluge: builtin_repr calls
+                    # PyObject_Repr, which does an unconditional
+                    # PyErr_CheckSignals for some reason.
+                    print(repr(None))
         finally:
             print("joining thread", sys.exc_info())
             thread.join()


### PR DESCRIPTION
It failed yet again, even with all our countermeasures:
  https://ci.appveyor.com/project/njsmith/trio/build/1.0.341/job/r356mgh7mi103lip

Current theory: the two ki_self()'s are running, and each is
synchronously running the C-level signal handler in the kill_soon
thread (because ki_self() uses raise() and I think it works like
that). And then the main thread is taking the lock, to try to
guarantee that it runs some inside the test after *both* ki_self()'s,
so that any Python-level handlers that are going to run, run inside
the test.

But, maybe somehow the main thread is not noticing that the C-level
handler has requested that the Python-level handler be run, because
PyEval_EvalFrameEx only checks every once in a while? I'm skeptical
because it's supposed to notice promptly after the C-level signal
handler runs, but maybe somehow this isn't working? So this adds an
explicit call to PyErr_CheckSignals. Except of course we can't write
it like that, because that's a C function. Instead we call repr(),
which should trigger it.

We're a long way down the rabbit hole.