### PR TITLE
socket: ignore OSError during IPV6_V6ONLY-normalization

### DIFF
--- a/trio/socket.py
+++ b/trio/socket.py
@@ -188,7 +188,10 @@ class SocketType:
 
         # Defaults:
         if self._sock.family == AF_INET6:
-            self.setsockopt(IPPROTO_IPV6, IPV6_V6ONLY, False)
+            try:
+                self.setsockopt(IPPROTO_IPV6, IPV6_V6ONLY, False)
+            except OSError:
+                pass
 
         # See https://github.com/python-trio/trio/issues/39
         if _sys.platform == "win32":

--- a/trio/tests/test_socket.py
+++ b/trio/tests/test_socket.py
@@ -316,12 +316,13 @@ async def test_SocketType_shutdown():
         assert await a.recv(3) == b"yyy"
 
 
-async def test_SocketType_simple_server():
+@pytest.mark.parametrize("address, socket_type", [('127.0.0.1', tsocket.AF_INET), ('::1', tsocket.AF_INET6)])
+async def test_SocketType_simple_server(address, socket_type):
     # listen, bind, accept, connect, getpeername, getsockname
-    with tsocket.socket() as listener, tsocket.socket() as client:
-        listener.bind(("127.0.0.1", 0))
+    with tsocket.socket(socket_type) as listener, tsocket.socket(socket_type) as client:
+        listener.bind((address, 0))
         listener.listen(20)
-        addr = listener.getsockname()
+        addr = listener.getsockname()[:2]
         async with _core.open_nursery() as nursery:
             nursery.spawn(client.connect, addr)
             accept_task = nursery.spawn(listener.accept)


### PR DESCRIPTION
~This doesn't appear to work with all types of AF_INET6 sockets--it is likely better to have the caller handle this instead.~ I've now changed this to ignore OSError instead based on your feedback in #164.

Fixes #164.