### PR TITLE
Raise at next Checkpoint if Non-awaited coroutine found.

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -209,7 +209,7 @@ this, that tries to call an async function but leaves out the
        sleep_time = time.time() - start_time
        print("Woke up after {:.2f} seconds, feeling well rested!".format(sleep_time))
 
-   trio.run(broken_double_sleep, 3)
+   trio.run(broken_double_sleep, 3, allow_unawaited_coroutines=True)
 
 You might think that Python would raise an error here, like it does
 for other kinds of mistakes we sometimes make when calling a
@@ -220,11 +220,12 @@ you actually get is:
 
 .. code-block:: none
 
-   >>> trio.run(broken_double_sleep, 3)
+   >>> trio.run(broken_double_sleep, 3, allow_unawaited_coroutines=True)
    *yawn* Going to sleep
    Woke up again after 0.00 seconds, feeling well rested!
    __main__:4: RuntimeWarning: coroutine 'sleep' was never awaited
    >>>
+
 
 This is clearly broken – 0.00 seconds is not long enough to feel well
 rested! Yet the code acts like it succeeded – no exception was
@@ -238,7 +239,7 @@ runs:
 .. code-block:: none
 
    # On PyPy:
-   >>>> trio.run(broken_double_sleep, 3)
+   >>>> trio.run(broken_double_sleep, 3, allow_unawaited_coroutines=True)
    *yawn* Going to sleep
    Woke up again after 0.00 seconds, feeling well rested!
    >>>> # what the ... ?? not even a warning!
@@ -268,6 +269,48 @@ don't need to know, I just need to fix my function!
 well, *I* didn't mention coroutines, Python did. Take it up with
 Guido! But seriously, this is unfortunately a place where the internal
 implementation details do leak out a bit.)
+
+Thus we strongly recommend that you run trio by setting the
+``allow_unawaited_coroutines`` to ``False``. with this flag set trio
+will error as soon as possible when we detect that your code is
+missing an ``await``. Unfortunately this check often happen at a later
+time, and it can be difficult to find where the non-awaited  is. Now
+at least you will get an error message.
+
+.. code-block:: none
+
+   >>> trio.run(broken_double_sleep, 3, allow_unawaited_coroutines=False)
+   *yawn* Going to sleep
+   Woke up after 0.00 seconds, feeling well rested!
+   Traceback (most recent call last):
+     File "/Users/bussonniermatthias/dev/trio/trio/_core/_run.py", line 1378, in run_impl
+       msg = task.coro.send(next_send)
+   StopIteration
+
+   The above exception was the direct cause of the following exception:
+
+   Traceback (most recent call last):
+     File "foo.py", line 14, in <module>
+       trio.run(broken_double_sleep, 3)
+     ...
+       raise self.error
+     File "~/trio/_core/_run.py", line 785, in task_exited
+       raise protector.make_non_awaited_coroutines_error(task._unawaited_coros) from stop_iteration
+   trio.NonAwaitedCoroutines: One or more coroutines where not awaited:
+
+    - <coroutine object sleep at 0x108e24780>
+
+   Trio has detected that at least a coroutine has not been between awaited
+   between this checkpoint point and previous one. This is may be due
+   to a missing `await`.
+
+
+Whether this flag will default to ``True`` or ``False`` in the long
+term is unclear, so we suggest you always set it. Tip, if you encounter
+an error and are using CPython, try rerunning after ``import
+tracemalloc(); tracemalloc.start()``, the error will attempt to give
+you more informations about where the un awaited coroutines were
+created.
 
 Why does this happen? In Trio, every time we use ``await`` it's to
 call an async function, and every time we call an async function we

--- a/trio/_core/_exceptions.py
+++ b/trio/_core/_exceptions.py
@@ -7,6 +7,7 @@ __all__ = [
     "WouldBlock",
     "Cancelled",
     "ResourceBusyError",
+    "NonAwaitedCoroutines",
 ]
 
 
@@ -41,6 +42,16 @@ class RunFinishedError(RuntimeError):
 
     """
     pass
+
+
+@pretend_module_is_trio
+class NonAwaitedCoroutines(RuntimeError):
+    """Raised by blocking calls if a non-awaited coroutine detected in current task
+    """
+
+    def __init__(self, *args, coroutines=None, **kwargs):
+        self.coroutines = set(coroutines)
+        super().__init__(*args, **kwargs)
 
 
 @pretend_module_is_trio

--- a/trio/_core/_multierror.py
+++ b/trio/_core/_multierror.py
@@ -130,7 +130,7 @@ class MultiErrorCatcher:
 
         original_exc = exc
         if protector.has_unawaited_coroutines():
-            exc =  protector.make_non_awaited_coroutines_error(
+            exc = protector.make_non_awaited_coroutines_error(
                 protector.pop_all_unawaited_coroutines()
             )
 

--- a/trio/_core/_multierror.py
+++ b/trio/_core/_multierror.py
@@ -128,31 +128,32 @@ class MultiErrorCatcher:
 
     def __exit__(self, etype, exc, tb):
 
-        force_raise = False
+        original_exc = exc
         if protector.has_unawaited_coroutines():
             exc =  protector.make_non_awaited_coroutines_error(
                 protector.pop_all_unawaited_coroutines()
             )
-            force_raise = True
+
         if exc is not None:
-            filtered_exc = MultiError.filter(self._handler, exc)
-            if filtered_exc is exc and not force_raise:
-                # Let the interpreter re-raise it
-                return False
-            if filtered_exc is None:
-                # Swallow the exception
-                return True
-            # When we raise filtered_exc, Python will unconditionally blow
-            # away its __context__ attribute and replace it with the original
-            # exc we caught. So after we raise it, we have to pause it while
-            # it's in flight to put the correct __context__ back.
-            old_context = filtered_exc.__context__
-            try:
-                raise filtered_exc
-            finally:
-                _, value, _ = sys.exc_info()
-                assert value is filtered_exc
-                value.__context__ = old_context
+            exc = MultiError.filter(self._handler, exc)
+        if exc is None:
+            # Swallow the exception
+            return True
+        if exc is original_exc:
+            # Let the interpreter re-raise it
+            return False
+
+        # When we raise filtered_exc, Python will unconditionally blow
+        # away its __context__ attribute and replace it with the original
+        # exc we caught. So after we raise it, we have to pause it while
+        # it's in flight to put the correct __context__ back.
+        old_context = exc.__context__
+        try:
+            raise exc
+        finally:
+            _, value, _ = sys.exc_info()
+            assert value is exc
+            value.__context__ = old_context
 
 
 class MultiError(BaseException):

--- a/trio/_core/_non_awaited_coroutines.py
+++ b/trio/_core/_non_awaited_coroutines.py
@@ -26,7 +26,8 @@ from ._exceptions import NonAwaitedCoroutines
 
 try:
     from tracemalloc import get_object_traceback as _get_tb
-except ImportError: # Not available on, for example, PyPy
+except ImportError:  # Not available on, for example, PyPy
+
     def _get_tb(obj):
         return None
 
@@ -36,6 +37,7 @@ __all__ = ["CoroProtector", "protector"]
 ################################################################
 # Protection against non-awaited coroutines
 ################################################################
+
 
 class CoroProtector:
     """
@@ -53,7 +55,7 @@ class CoroProtector:
         """
         Coroutine wrapper to track creation of coroutines.
         """
-        if self._enabled :
+        if self._enabled:
             self._pending_test.add(coro)
         if not self._previous_coro_wrapper:
             return coro
@@ -66,7 +68,6 @@ class CoroProtector:
         """
         self._pending_test.discard(coro)
         return coro
-
 
     def install(self) -> None:
         """install a coroutine wrapper to track created coroutines.
@@ -91,7 +92,10 @@ class CoroProtector:
 
     def get_all_unawaited_coroutines(self):
         state = inspect.getcoroutinestate
-        self._pending_test = {coro for coro in self._pending_test if state(coro) == 'CORO_CREATED'}
+        self._pending_test = {
+            coro
+            for coro in self._pending_test if state(coro) == 'CORO_CREATED'
+        }
         return set(self._pending_test)
 
     def forget(self, coroutines) -> None:
@@ -114,16 +118,18 @@ class CoroProtector:
         Construct a nice NonAwaitedCoroutines error messages with the origin of the
         coroutine if possible.
         """
-        err =[]
+        err = []
         for coro in coros:
             tb = _get_tb(coro)
             if tb:
-                err.append(' - {coro} ({tb})'.format(coro=coro, tb=tb)) # pragma: no cover
+                err.append(' - {coro} ({tb})'.format(coro=coro, tb=tb)
+                           )  # pragma: no cover
             else:
                 err.append(' - {coro}'.format(coro=coro))
         err = '\n'.join(err)
-        return NonAwaitedCoroutines(textwrap.dedent(
-            '''
+        return NonAwaitedCoroutines(
+            textwrap.dedent(
+                '''
             One or more coroutines where not awaited:
 
             {err}
@@ -131,6 +137,10 @@ class CoroProtector:
             Trio has detected that at least a coroutine has not been between awaited
             between this checkpoint point and previous one. This is may be due
             to a missing `await`.
-            '''[1:]).format(err=err), coroutines=coros)
+            ''' [1:]
+            ).format(err=err),
+            coroutines=coros
+        )
+
 
 protector = CoroProtector()

--- a/trio/_core/_non_awaited_coroutines.py
+++ b/trio/_core/_non_awaited_coroutines.py
@@ -1,0 +1,120 @@
+"""
+This module provides utilities to protect against non-awaited coroutine.
+
+Mostly it provide a protector which can install itself with
+`sys.set_coroutine_wrapper` and track the creation of all coroutines.
+
+Every now and then we can go over all the coroutines we have reference to, and
+check their state. In trio, the trio-runner will do that, at least on every
+checkpoint, but that's not the responsibility of this module.
+
+If the coroutine have been awaited at least once, we discard them.
+
+A :class:`CoroProtector` also provide a convenience method
+:meth:`await_later(coro)` that return the coroutine unchanged but will ignore it
+if not-awaited at next checkpoint.
+
+A default instance of coroutine protector is provided under the attribute `protector`,
+and is shared between `trio.run` and the `MultiError.catch`
+
+"""
+
+import sys
+import inspect
+import textwrap
+from ._exceptions import NonAwaitedCoroutines
+
+try:
+    from tracemalloc import get_object_traceback as _get_tb
+except ImportError: # Not available on, for example, PyPy
+    def _get_tb(obj):
+        return None
+
+
+__all__ = ["CoroProtector", "protector"]
+
+################################################################
+# Protection against non-awaited coroutines
+################################################################
+
+class CoroProtector:
+    """
+    Protector preventing the creation of non-awaited coroutines
+    between two checkpoints.
+    """
+
+    def __init__(self):
+        self._enabled = True
+        self._pending_test = set()
+        self._key = object()
+
+    def coro_wrapper(self, coro):
+        """
+        Coroutine wrapper to track creation of coroutines.
+        """
+        if self._enabled :
+            self._pending_test.add(coro)
+        return coro
+
+    def await_later(self, coro):
+        """
+        Mark a coroutine as safe to no be awaited, and return it.
+        """
+        self._pending_test.discard(coro)
+        return coro
+
+
+    def install(self):
+        """install a coroutine wrapper to track created coroutines.
+        """
+        sys.set_coroutine_wrapper(self.coro_wrapper)
+
+    def has_unawaited_coroutines(self):
+        """
+        Return whether there are unawaited coroutines.
+
+        Flush all internally tracked awaited coroutine. Does not discard non-awaited
+        ones. You need to call `pop_all_unawaited_coroutines` to do that.
+        """
+        state = inspect.getcoroutinestate
+        self._pending_test = {coro for coro in self._pending_test if state(coro) == 'CORO_CREATED'}
+        return len(self._pending_test) > 0
+
+    def pop_all_unawaited_coroutines(self, error=True):
+        """
+        Check that since last invocation no coroutine has been left unawaited.
+
+        Return a list of unawaited coroutines since last call to this function,
+        and stop tracking them.
+        """
+        pending = self._pending_test
+        state = inspect.getcoroutinestate
+        self._pending_test = set()
+        return [coro for coro in pending if state(coro) == 'CORO_CREATED']
+
+    @staticmethod
+    def make_non_awaited_coroutines_error(coros):
+        """
+        Construct a nice NonAwaitedCoroutines error messages with the origin of the
+        coroutine if possible.
+        """
+        err =[]
+        for coro in coros:
+            tb = _get_tb(coro)
+            if tb:
+                err.append(' - {coro} ({tb})'.format(coro=coro, tb=tb)) # pragma: no cover
+            else:
+                err.append(' - {coro}'.format(coro=coro))
+        err = '\n'.join(err)
+        return NonAwaitedCoroutines(textwrap.dedent(
+            '''
+            One or more coroutines where not awaited:
+
+            {err}
+
+            Trio has detected that at least a coroutine has not been between awaited
+            between this checkpoint point and previous one. This is may be due
+            to a missing `await`.
+            '''[1:]).format(err=err), coroutines=coros)
+
+protector = CoroProtector()

--- a/trio/_core/_non_awaited_coroutines.py
+++ b/trio/_core/_non_awaited_coroutines.py
@@ -30,8 +30,6 @@ except ImportError: # Not available on, for example, PyPy
     def _get_tb(obj):
         return None
 
-from typing import Coroutine, Set
-
 
 __all__ = ["CoroProtector", "protector"]
 
@@ -51,7 +49,7 @@ class CoroProtector:
         self._key = object()
         self._previous_coro_wrapper = None
 
-    def _coro_wrapper(self, coro:Coroutine):
+    def _coro_wrapper(self, coro):
         """
         Coroutine wrapper to track creation of coroutines.
         """
@@ -62,7 +60,7 @@ class CoroProtector:
         else:
             return self._previous_coro_wrapper(coro)
 
-    def await_later(self, coro:Coroutine) -> Coroutine :
+    def await_later(self, coro):
         """
         Mark a coroutine as safe to no be awaited, and return it.
         """
@@ -91,15 +89,15 @@ class CoroProtector:
         """
         return len(self.get_all_unawaited_coroutines()) > 0
 
-    def get_all_unawaited_coroutines(self) ->  Set[Coroutine]:
+    def get_all_unawaited_coroutines(self):
         state = inspect.getcoroutinestate
         self._pending_test = {coro for coro in self._pending_test if state(coro) == 'CORO_CREATED'}
         return set(self._pending_test)
 
-    def forget(self, coroutines: Set[Coroutine] ) -> None:
+    def forget(self, coroutines) -> None:
         self._pending_test.difference_update(coroutines)
 
-    def pop_all_unawaited_coroutines(self) ->  Set[Coroutine]:
+    def pop_all_unawaited_coroutines(self):
         """
         Check that since last invocation no coroutine has been left unawaited.
 

--- a/trio/_core/_result.py
+++ b/trio/_core/_result.py
@@ -32,7 +32,7 @@ class Result(metaclass=abc.ABCMeta):
 
         """
         try:
-            result =  Value(sync_fn(*args))
+            result = Value(sync_fn(*args))
         except BaseException as exc:
             result = Error(exc)
         finally:
@@ -44,8 +44,6 @@ class Result(metaclass=abc.ABCMeta):
                     exc.__context__ = result.error
                 result = Error(exc)
         return result
-
-
 
     @staticmethod
     async def acapture(async_fn, *args):
@@ -64,12 +62,11 @@ class Result(metaclass=abc.ABCMeta):
                 exc = protector.make_non_awaited_coroutines_error(
                     protector.pop_all_unawaited_coroutines()
                 )
-                
+
                 if type(result) is Error:
                     exc.__context__ = result.error
                 result = Error(exc)
         return result
-
 
     @abc.abstractmethod
     def unwrap(self):

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -1318,7 +1318,7 @@ def run(
         # To guarantee that we never swallow a KeyboardInterrupt, we have to
         # check for pending ones once more after leaving the context manager:
         if not allow_unawaited_coroutines:
-            protector.install()
+            protector.uninstall()
         if runner.ki_pending:
             # Implicitly chains with any exception from result.unwrap():
             raise KeyboardInterrupt

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -356,7 +356,8 @@ class Nursery:
                     raise mexc
 
     def __del__(self):
-        assert not self.children and not self.zombies, "Children: {} and Zombies : {}".format(self.children, self.zombies)
+        assert not self.children and not self.zombies,\
+            "Children: {} and Zombies : {}".format(self.children, self.zombies)
 
 
 ################################################################
@@ -794,12 +795,13 @@ class Runner:
 
     def task_exited(self, task, result, stop_iteration=None):
         if task._unawaited_coros:
-            try:
-                raise protector.make_non_awaited_coroutines_error(task._unawaited_coros) from stop_iteration
-            except NonAwaitedCoroutines as e:
-                task.result = Error(e)
+            exc = protector.make_non_awaited_coroutines_error(task._unawaited_coros)
+            if type(result) is Error:
+                exc.__context__ = result.error
+            task.result = Error(exc)
         else:
             task.result = result
+
         while task._cancel_stack:
             task._cancel_stack[-1]._remove_task(task)
         self.tasks.remove(task)

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -1539,7 +1539,7 @@ async def yield_briefly():
 
     """
     with open_cancel_scope(deadline=-inf) as scope:
-        await _core.yield_indefinitely(lambda _: _core.Abort.SUCCEEDED)
+        await yield_indefinitely(lambda _: _core.Abort.SUCCEEDED)
 
 
 @_hazmat
@@ -1553,8 +1553,10 @@ async def yield_if_cancelled():
     task = current_task()
     if (task._pending_cancel_scope() is not None or
         (task is task._runner.main_task and task._runner.ki_pending)
-        or task._unawaited_coros):
+        or task._unawaited_coros
+        or protector.has_unawaited_coroutines()):
         await _core.yield_briefly()
+        print('Yielding briefly')
         assert False  # pragma: no cover
     task._cancel_points += 1
 

--- a/trio/_core/tests/test_result.py
+++ b/trio/_core/tests/test_result.py
@@ -128,11 +128,12 @@ async def test_Result_asend():
     with pytest.raises(StopAsyncIteration):
         await my_agen.asend(None)
 
+
 async def unawaited():  # pragma: no cover
     pass
 
-def test_capture_raise_unawaited_value():
 
+def test_capture_raise_unawaited_value():
     def computation():
         unawaited()
         return 'Ok'
@@ -146,7 +147,6 @@ def test_capture_raise_unawaited_value():
 
 
 def test_capture_raise_unawaited_error():
-
     def computation():
         unawaited()
         raise ValueError(...)
@@ -154,13 +154,12 @@ def test_capture_raise_unawaited_error():
     async def run_me():
         return Result.capture(computation).unwrap()
 
-
     with ignore_coroutine_never_awaited_warnings():
         with pytest.raises(_core.NonAwaitedCoroutines):
             _core.run(run_me, allow_unawaited_coroutines=False)
 
-def test_acapture_raise_unawaited_value():
 
+def test_acapture_raise_unawaited_value():
     async def computation():
         unawaited()
         return 'Ok'
@@ -168,20 +167,18 @@ def test_acapture_raise_unawaited_value():
     async def run_me():
         return Result.acapture(computation).unwrap()
 
-
     with ignore_coroutine_never_awaited_warnings():
         with pytest.raises(_core.NonAwaitedCoroutines):
             _core.run(run_me, allow_unawaited_coroutines=False)
 
-def test_acapture_raise_unawaited_error():
 
+def test_acapture_raise_unawaited_error():
     async def computation():
         unawaited()
         raise ValueError(...)
 
     async def run_me():
         return Result.acapture(computation).unwrap()
-
 
     with ignore_coroutine_never_awaited_warnings():
         with pytest.raises(_core.NonAwaitedCoroutines):

--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -1803,7 +1803,10 @@ def test_run_with_allow_non_awaited_coroutine_true():
     async def run_me():
 
         def handler(exc):
-            return exc
+            """
+            This will actually not be called, as there will be no errors.
+            """
+            return exc  # pragma: no cover
 
         async def unawaited():
             pass  # pragma: no cover

--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -23,6 +23,7 @@ from ... import _core
 
 from .._multierror import MultiError
 
+
 # slightly different from _timeouts.sleep_forever because it returns the value
 # its rescheduled with, which is really only useful for tests of
 # rescheduling...
@@ -1636,7 +1637,9 @@ async def test_trivial_yields():
     with assert_yields():
         await t.wait()
 
+
 # Various test that non awaited coroutines end up as error states on task
+
 
 def test_raise_task_end():
     """
@@ -1654,6 +1657,7 @@ def test_raise_task_end():
     async def consume():
         for c in err.value.coroutines:
             await c
+
     _core.run(consume, allow_unawaited_coroutines=False)
 
 
@@ -1662,6 +1666,7 @@ def test_raise_task_end_raise():
     Test that asynchronous functions that raise after forgetting to await
     coroutine still raise a NonAwaitedCoroutines error.
     """
+
     async def coro_fun():
         sleep(0)
         raise ValueError('...')
@@ -1672,6 +1677,7 @@ def test_raise_task_end_raise():
     async def consume():
         for c in err.value.coroutines:
             await c
+
     _core.run(consume, allow_unawaited_coroutines=False)
 
 
@@ -1684,7 +1690,7 @@ def test_raise_task_middle():
     async def coro_fun():
         sleep(0)
         await sleep(0)
-        assert False # pragma: no cover
+        assert False  # pragma: no cover
 
     with pytest.raises(_core.NonAwaitedCoroutines) as err:
         _core.run(coro_fun, allow_unawaited_coroutines=False)
@@ -1692,6 +1698,7 @@ def test_raise_task_middle():
     async def consume():
         for c in err.value.coroutines:
             await c
+
     _core.run(consume, allow_unawaited_coroutines=False)
 
 
@@ -1700,6 +1707,7 @@ def test_raise_task_before_return():
     Test that asynchronous functions that forgets to await a coroutine just before returning
     raises a NonAwaitedCoroutines error.
     """
+
     async def coro_fun():
         await sleep(0)
         sleep(0)
@@ -1711,12 +1719,12 @@ def test_raise_task_before_return():
     async def consume():
         for c in err.value.coroutines:
             await c
+
     _core.run(consume, allow_unawaited_coroutines=False)
 
+
 def test_non_awaited_caught_in_multierror():
-
     async def run():
-
         async def task(exception):
             raise exception('just because')
 
@@ -1738,9 +1746,7 @@ def test_non_awaited_caught_in_multierror():
 
 
 def test_non_awaited_caught_in_multierror_II():
-
     async def run():
-
         async def unawaited():
             pass  # pragma: no cover
 
@@ -1756,9 +1762,7 @@ def test_non_awaited_caught_in_multierror_II():
 
 
 def test_non_awaited_caught_in_multierror_swallow_nonawaited():
-
     async def run():
-
         async def unawaited():
             pass  # pragma: no cover
 
@@ -1771,10 +1775,12 @@ def test_non_awaited_caught_in_multierror_swallow_nonawaited():
     with ignore_coroutine_never_awaited_warnings():
         _core.run(run, allow_unawaited_coroutines=False)
 
+
 def test_user_wrapper_restored():
     """check that trio.run correctly restore user-set coroutine wrappers"""
 
     called = False
+
     def _coro_wrapper(coro):
         nonlocal called
         called = True
@@ -1792,19 +1798,19 @@ def test_user_wrapper_restored():
     with ignore_coroutine_never_awaited_warnings():
         _core.run(run)
 
-    assert called is True , "original coro wrapper got called"
+    assert called is True, "original coro wrapper got called"
     current_coro_wrapper = sys.get_coroutine_wrapper()
-    assert current_coro_wrapper == _coro_wrapper , "coroutine wrapper correctly reinstated on exit of run"
+    assert current_coro_wrapper == _coro_wrapper, "coroutine wrapper correctly reinstated on exit of run"
 
 
 async def unawaited():  # pragma: no cover
     pass
 
+
 def test_run_with_allow_non_awaited_coroutine_true():
     "Check that both checkpoint an multierror do not raise"
 
     async def run_me():
-
         def handler(exc):
             """
             This will actually not be called, as there will be no errors.
@@ -1820,6 +1826,7 @@ def test_run_with_allow_non_awaited_coroutine_true():
 
     with ignore_coroutine_never_awaited_warnings():
         _core.run(run_me, allow_unawaited_coroutines=True)
+
 
 def test_unawaited_coro_trigger_yield_if_cancelled():
     """
@@ -1837,7 +1844,7 @@ def test_unawaited_coro_trigger_yield_if_cancelled():
     async def run_me():
         unawaited()
         await _core.yield_if_cancelled()
-        not_reached()   # pragma: no cover
+        not_reached()  # pragma: no cover
 
     with ignore_coroutine_never_awaited_warnings():
         with pytest.raises(_core.NonAwaitedCoroutines):

--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -1797,6 +1797,9 @@ def test_user_wrapper_restored():
     assert current_coro_wrapper == _coro_wrapper , "coroutine wrapper correctly reinstated on exit of run"
 
 
+async def unawaited():  # pragma: no cover
+    pass
+
 def test_run_with_allow_non_awaited_coroutine_true():
     "Check that both checkpoint an multierror do not raise"
 
@@ -1807,9 +1810,6 @@ def test_run_with_allow_non_awaited_coroutine_true():
             This will actually not be called, as there will be no errors.
             """
             return exc  # pragma: no cover
-
-        async def unawaited():
-            pass  # pragma: no cover
 
         with MultiError.catch(handler):
             unawaited()
@@ -1833,9 +1833,6 @@ def test_unawaited_coro_trigger_yield_if_cancelled():
         nonlocal called
         called = True
         pass
-
-    async def unawaited():
-        pass  # pragma: no cover
 
     async def run_me():
         unawaited()

--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -1649,12 +1649,12 @@ def test_raise_task_end():
         return 'ok'
 
     with pytest.raises(_core.NonAwaitedCoroutines) as err:
-        _core.run(coro_fun)
+        _core.run(coro_fun, allow_unawaited_coroutines=False)
 
     async def consume():
         for c in err.value.coroutines:
             await c
-    _core.run(consume)
+    _core.run(consume, allow_unawaited_coroutines=False)
 
 
 def test_raise_task_end_raise():
@@ -1667,12 +1667,12 @@ def test_raise_task_end_raise():
         raise ValueError('...')
 
     with pytest.raises(_core.NonAwaitedCoroutines) as err:
-        _core.run(coro_fun)
+        _core.run(coro_fun, allow_unawaited_coroutines=False)
 
     async def consume():
         for c in err.value.coroutines:
             await c
-    _core.run(consume)
+    _core.run(consume, allow_unawaited_coroutines=False)
 
 
 def test_raise_task_middle():
@@ -1687,12 +1687,12 @@ def test_raise_task_middle():
         assert False # pragma: no cover
 
     with pytest.raises(_core.NonAwaitedCoroutines) as err:
-        _core.run(coro_fun)
+        _core.run(coro_fun, allow_unawaited_coroutines=False)
 
     async def consume():
         for c in err.value.coroutines:
             await c
-    _core.run(consume)
+    _core.run(consume, allow_unawaited_coroutines=False)
 
 
 def test_raise_task_before_return():
@@ -1706,12 +1706,12 @@ def test_raise_task_before_return():
         return 'ok'
 
     with pytest.raises(_core.NonAwaitedCoroutines) as err:
-        _core.run(coro_fun)
+        _core.run(coro_fun, allow_unawaited_coroutines=False)
 
     async def consume():
         for c in err.value.coroutines:
             await c
-    _core.run(consume)
+    _core.run(consume, allow_unawaited_coroutines=False)
 
 def test_non_awaited_caught_in_multierror():
 
@@ -1734,7 +1734,7 @@ def test_non_awaited_caught_in_multierror():
 
     with ignore_coroutine_never_awaited_warnings():
         with pytest.raises(_core.NonAwaitedCoroutines):
-            _core.run(run)
+            _core.run(run, allow_unawaited_coroutines=False)
 
 
 def test_non_awaited_caught_in_multierror_II():
@@ -1752,7 +1752,7 @@ def test_non_awaited_caught_in_multierror_II():
 
     with ignore_coroutine_never_awaited_warnings():
         with pytest.raises(_core.NonAwaitedCoroutines):
-            _core.run(run)
+            _core.run(run, allow_unawaited_coroutines=False)
 
 
 def test_non_awaited_caught_in_multierror_swallow_nonawaited():
@@ -1769,7 +1769,7 @@ def test_non_awaited_caught_in_multierror_swallow_nonawaited():
             unawaited()
 
     with ignore_coroutine_never_awaited_warnings():
-        _core.run(run)
+        _core.run(run, allow_unawaited_coroutines=False)
 
 def test_user_wrapper_restored():
     """check that trio.run correctly restore user-set coroutine wrappers"""

--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -1837,8 +1837,7 @@ def test_unawaited_coro_trigger_yield_if_cancelled():
     async def run_me():
         unawaited()
         await _core.yield_if_cancelled()
-        not_reached()
-
+        not_reached()   # pragma: no cover
 
     with ignore_coroutine_never_awaited_warnings():
         with pytest.raises(_core.NonAwaitedCoroutines):


### PR DESCRIPTION
right now that works only if the task is not finisehd. Not sure what to
do if the task is done as you have no occasions to throw in it. Should
we still return the `final_result` as a Result , or make it an `Error()`
?

Debugging is still a bit weird as you need to find the checkpoint in the
middle of the stacktrace (I guess we can improve that). Othe question
would be is there a way to get the previous checkpoint of the current
task to narrow tings down.

It's still hard to debug when the non-awaited coroutine is not at the
same stacklevel than the schedule point. We may be able to do better by
inspecting unawaited coro frames maybe ?

The await_later and context managers to relax/enforce await are not
exposed, and I'm unsure whether we want to have custom CoroProtectors
(likely yes for testing). We may also want to list all the unawaited
coroutines in the error message, and so far I have not tried with many
tasks, but the internals of Trio are still unfamiliar.

Docs and Tests are still missing.