### PR TITLE
Fix warnings filter

### DIFF
--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -880,7 +880,8 @@ def test_error_in_run_loop():
     # turned into errors. See:
     #   https://bugs.python.org/issue27811
     with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", message="was never awaited")
+        warnings.filterwarnings(
+            "ignore", message="coroutine '.*' was never awaited")
 
         with pytest.raises(_core.TrioInternalError):
             _core.run(main)


### PR DESCRIPTION
This is a fixup for 3b831cce397b13b7835bf9384cee75241ee71a73. It turns
out that warning message filters do an *anchored* match, so you have
to write a regexp that matches the beginning of the message. It only
seemed to work because the issue I was trying to fix was intermittent
to start with. Learn something every day...

Before this fix, on 3.5.0 I got a segfault once every ~2-4 runs. After
this fix, I ran 100 times and they all passed.

~/src/cpython/b/install/bin/pytest -W error -v trio -k test_error_in_run_loop --count=100