### PR TITLE
test_socket: replace imaginary `ip` protocol with `udp`

### DIFF
--- a/trio/tests/test_socket.py
+++ b/trio/tests/test_socket.py
@@ -716,5 +716,5 @@ async def test_idna(monkeygai):
 async def test_getprotobyname():
     # These are the constants used in IP header fields, so the numeric values
     # had *better* be stable across systems...
-    assert await tsocket.getprotobyname("ip") == 0
+    assert await tsocket.getprotobyname("ipv4") == 4
     assert await tsocket.getprotobyname("tcp") == 6

--- a/trio/tests/test_socket.py
+++ b/trio/tests/test_socket.py
@@ -716,5 +716,5 @@ async def test_idna(monkeygai):
 async def test_getprotobyname():
     # These are the constants used in IP header fields, so the numeric values
     # had *better* be stable across systems...
-    assert await tsocket.getprotobyname("ipv4") == 4
+    assert await tsocket.getprotobyname("udp") == 17
     assert await tsocket.getprotobyname("tcp") == 6


### PR DESCRIPTION
Fixes #208.