### PR TITLE
Clearer error message if async context manager used synchronously

### DIFF
--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -93,7 +93,7 @@ async def test_nursery_warn_use_async_with():
     with pytest.raises(RuntimeError) as excinfo:
         on = _core.open_nursery()
         with on as nursery:
-            pass # pragma: no-cover
+            pass  # pragma: no cover
     excinfo.match(r"use 'async with open_nursery\(...\)', not 'with open_nursery\(...\)'")
                   
     # avoid unawaited coro.

--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -89,6 +89,16 @@ async def test_basic_spawn_wait():
         await task.wait()
         assert task.result.unwrap() == 20
 
+async def test_nursery_warn_use_async_with():
+    with pytest.raises(RuntimeError) as excinfo:
+        on = _core.open_nursery()
+        with on as nursery:
+            pass # pragma: no-cover
+    excinfo.match(r"use 'async with open_nursery\(...\)', not 'with open_nursery\(...\)'")
+                  
+    # avoid unawaited coro.
+    async with on:
+        pass
 
 async def test_child_crash_basic():
     exc = ValueError("uh oh")

--- a/trio/_util.py
+++ b/trio/_util.py
@@ -139,8 +139,8 @@ class _AsyncGeneratorContextManager:
     def __enter__(self):
         raise RuntimeError("use 'async with {func_name}(...)', not 'with {func_name}(...)'".format(func_name=self._func_name))
 
-    def __exit__(self):
-        assert False, """Never called, but should be defined""" # pragma: no-cover
+    def __exit__(self):  # pragma: no cover
+        assert False, """Never called, but should be defined"""
 
 
 def acontextmanager(func):

--- a/trio/_util.py
+++ b/trio/_util.py
@@ -83,6 +83,7 @@ def aiter_compat(aiter_impl):
 # Copyright © 2001-2017 Python Software Foundation; All Rights Reserved
 class _AsyncGeneratorContextManager:
     def __init__(self, func, args, kwds):
+        self._func_name = func.__name__
         self._agen = func(*args, **kwds).__aiter__()
 
     async def __aenter__(self):
@@ -134,6 +135,13 @@ class _AsyncGeneratorContextManager:
                 #
                 if sys.exc_info()[1] is not value:
                     raise
+
+    def __enter__(self):
+        raise RuntimeError("use 'async with {func_name}(...)', not 'with {func_name}(...)'".format(func_name=self._func_name))
+
+    def __exit__(self):
+        assert False, """Never called, but should be defined""" # pragma: no-cover
+
 
 def acontextmanager(func):
     """Like @contextmanager, but async."""


### PR DESCRIPTION
Otherwise it says it does not have `__enter__` which is obvious for
advanced pythonista. Still a tiny bit clearer is likely better.

I guess this _might_ fool static type checkers, but I'm unaware of any
that would flag that.