### PR TITLE
The echo server thread in test_ssl had unnoticed errors

### DIFF
--- a/trio/_core/tests/tutil.py
+++ b/trio/_core/tests/tutil.py
@@ -2,13 +2,26 @@
 
 import pytest
 
+import gc
+
 # See trio/tests/conftest.py for the other half of this
 slow = pytest.mark.skipif(
     not pytest.config.getoption("--run-slow", True),
     reason="use --run-slow to run slow tests",
 )
 
-from ... import _core
+def gc_collect_harder():
+    # In the test suite we sometimes want to call gc.collect() to make sure
+    # that any objects with noisy __del__ methods (e.g. unawaited coroutines)
+    # get collected before we continue, so their noise doesn't leak into
+    # unrelated tests.
+    #
+    # On PyPy, coroutine objects (for example) can survive at least 1 round of
+    # garbage collection, because executing their __del__ method to print the
+    # warning can cause them to be resurrected. So we call collect a few times
+    # to make sure.
+    for _ in range(4):
+        gc.collect()
 
 # template is like:
 #   [1, {2.1, 2.2}, 3] -> matches [1, 2.1, 3] or [1, 2.2, 3]

--- a/trio/tests/test_ssl.py
+++ b/trio/tests/test_ssl.py
@@ -5,8 +5,10 @@ import threading
 import socket as stdlib_socket
 import ssl as stdlib_ssl
 from contextlib import contextmanager
+from functools import partial
 
 from OpenSSL import SSL
+from async_generator import async_generator, yield_
 
 import trio
 from .. import _core
@@ -14,7 +16,7 @@ from .. import _network
 from .._streams import BrokenStreamError, ClosedStreamError
 from .. import ssl as tssl
 from .. import socket as tsocket
-from .._util import UnLock
+from .._util import UnLock, acontextmanager
 
 from .._core.tests.tutil import slow
 
@@ -63,8 +65,13 @@ def ssl_echo_serve_sync(sock, *, expect_fail=False):
         while True:
             data = wrapped.recv(4096)
             if not data:
-                # graceful shutdown
-                wrapped.unwrap()
+                # other side has initiated a graceful shutdown; we try to
+                # respond in kind but it's legal for them to have already gone
+                # away.
+                try:
+                    wrapped.unwrap()
+                except BrokenPipeError:
+                    pass
                 return
             wrapped.sendall(data)
     except Exception as exc:
@@ -74,37 +81,38 @@ def ssl_echo_serve_sync(sock, *, expect_fail=False):
             raise
     else:
         if expect_fail:  # pragma: no cover
-            print("failed to fail?!")
+            raise RuntimeError("failed to fail?")
 
 
 # Fixture that gives a raw socket connected to a trio-test-1 echo server
 # (running in a thread). Useful for testing making connections with different
 # SSLContexts.
-@contextmanager
-def ssl_echo_server_raw(**kwargs):
+#
+# This way of writing it is pretty janky, with the nursery hidden inside the
+# fixture and no proper parental supervision. Don't copy this code; it was
+# written this way before we knew better.
+@acontextmanager
+@async_generator
+async def ssl_echo_server_raw(**kwargs):
     a, b = stdlib_socket.socketpair()
-    with a, b:
-        t = threading.Thread(
-            target=ssl_echo_serve_sync,
-            args=(b,),
-            kwargs=kwargs,
-        )
-        t.start()
+    async with trio.open_nursery() as nursery:
+        with a, b:
+            nursery.spawn(
+                trio.run_in_worker_thread,
+                partial(ssl_echo_serve_sync, b, **kwargs))
 
-        yield _network.SocketStream(tsocket.from_stdlib_socket(a))
-
-    # exiting the context manager closes the sockets, which should force the
-    # thread to shut down (possibly with an error)
-    t.join()
-
+            await yield_(_network.SocketStream(tsocket.from_stdlib_socket(a)))
+        # exiting the 'with a, b' context manager closes the sockets, which
+        # should force the thread to shut down (possibly with an error)
 
 # Fixture that gives a properly set up SSLStream connected to a trio-test-1
 # echo server (running in a thread)
-@contextmanager
-def ssl_echo_server(**kwargs):
-    with ssl_echo_server_raw(**kwargs) as sock:
-        yield tssl.SSLStream(
-            sock, CLIENT_CTX, server_hostname="trio-test-1.example.org")
+@acontextmanager
+@async_generator
+async def ssl_echo_server(**kwargs):
+    async with ssl_echo_server_raw(**kwargs) as sock:
+        await yield_(tssl.SSLStream(
+            sock, CLIENT_CTX, server_hostname="trio-test-1.example.org"))
 
 
 # The weird in-memory server ... thing.
@@ -326,14 +334,14 @@ def test_exports():
 # certificate checking (even though this is really Python's responsibility)
 async def test_ssl_client_basics():
     # Everything OK
-    with ssl_echo_server() as s:
+    async with ssl_echo_server() as s:
         assert not s.server_side
         await s.send_all(b"x")
         assert await s.receive_some(1) == b"x"
         await s.graceful_close()
 
     # Didn't configure the CA file, should fail
-    with ssl_echo_server_raw(expect_fail=True) as sock:
+    async with ssl_echo_server_raw(expect_fail=True) as sock:
         client_ctx = stdlib_ssl.create_default_context()
         s = tssl.SSLStream(
             sock, client_ctx, server_hostname="trio-test-1.example.org")
@@ -343,7 +351,7 @@ async def test_ssl_client_basics():
         assert isinstance(excinfo.value.__cause__, tssl.SSLError)
 
     # Trusted CA, but wrong host name
-    with ssl_echo_server_raw(expect_fail=True) as sock:
+    async with ssl_echo_server_raw(expect_fail=True) as sock:
         s = tssl.SSLStream(
             sock, CLIENT_CTX, server_hostname="trio-test-2.example.org")
         assert not s.server_side
@@ -380,7 +388,7 @@ async def test_ssl_server_basics():
 
 
 async def test_attributes():
-    with ssl_echo_server_raw(expect_fail=True) as sock:
+    async with ssl_echo_server_raw(expect_fail=True) as sock:
         good_ctx = CLIENT_CTX
         bad_ctx = stdlib_ssl.create_default_context()
         s = tssl.SSLStream(
@@ -470,7 +478,7 @@ async def test_full_duplex_basics():
             chunk = await s.receive_some(CHUNK_SIZE // 2)
             received += chunk
 
-    with ssl_echo_server() as s:
+    async with ssl_echo_server() as s:
         async with _core.open_nursery() as nursery:
             nursery.spawn(sender, s)
             nursery.spawn(receiver, s)
@@ -672,7 +680,7 @@ async def test_wait_writable_calls_underlying_wait_writable():
 
 
 async def test_checkpoints():
-    with ssl_echo_server() as s:
+    async with ssl_echo_server() as s:
         with assert_yields():
             await s.do_handshake()
         with assert_yields():
@@ -694,14 +702,14 @@ async def test_checkpoints():
         with assert_yields():
             await s.unwrap()
 
-    with ssl_echo_server() as s:
+    async with ssl_echo_server() as s:
         await s.do_handshake()
         with assert_yields():
             await s.graceful_close()
 
 
 async def test_send_all_empty_string():
-    with ssl_echo_server() as s:
+    async with ssl_echo_server() as s:
         await s.do_handshake()
 
         # underlying SSLObject interprets writing b"" as indicating an EOF,


### PR DESCRIPTION
This commit

- Fixes the problem (by ignoring BrokenPipeError after receiving a
  close_notify, necessary because of our decision in 8b0a252e463 to
  close the socket immediately after sending close_notify).

- Changes how we run the server thread so that errors can't pass
  unnoticed in the future, but will instead propagate back into the
  main thread.