### PR TITLE
[travis] skip pypy3 nightly when the downloaded tarball is empty

### DIFF
--- a/ci/travis.sh
+++ b/ci/travis.sh
@@ -18,7 +18,19 @@ if [ "$TRAVIS_OS_NAME" = "osx" ]; then
 fi
 
 if [ "$USE_PYPY_NIGHTLY" = "1" ]; then
-    curl -Lo pypy.tar.bz2 http://buildbot.pypy.org/nightly/py3.5/pypy-c-jit-latest-linux64.tar.bz2
+    curl -fLo pypy.tar.bz2 http://buildbot.pypy.org/nightly/py3.5/pypy-c-jit-latest-linux64.tar.bz2
+    if [ ! -s pypy.tar.bz2 ]; then
+        # We know:
+        # - curl succeeded (200 response code; -f means "exit with error if
+        # server returns 4xx or 5xx")
+        # - nonetheless, pypy.tar.bz2 does not exist, or contains no data
+        # This isn't going to work, and the failure is not informative of
+        # anything involving trio.
+        ls -l
+        echo "PyPy3 nightly build failed to download – something is wrong on their end."
+        echo "Skipping testing against the nightly build for right now."
+        exit 0
+    fi
     tar xaf pypy.tar.bz2
     # something like "pypy-c-jit-89963-748aa3022295-linux64"
     PYPY_DIR=$(echo pypy-c-jit-*)
@@ -30,7 +42,7 @@ if [ "$USE_PYPY_NIGHTLY" = "1" ]; then
 fi
 
 if [ "$USE_PYPY_RELEASE" = "1" ]; then
-    curl -Lo pypy.tar.bz2 https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.5-5.8-beta-linux_x86_64-portable.tar.bz2
+    curl -fLo pypy.tar.bz2 https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.5-5.8-beta-linux_x86_64-portable.tar.bz2
     tar xaf pypy.tar.bz2
     # something like "pypy3.5-5.7.1-beta-linux_x86_64-portable"
     PYPY_DIR=$(echo pypy3.5-*)


### PR DESCRIPTION
Like it is today: https://travis-ci.org/python-trio/trio/jobs/242286426