### PR TITLE
path: add docstring for open

### DIFF
--- a/trio/_path.py
+++ b/trio/_path.py
@@ -147,6 +147,11 @@ class Path(metaclass=AsyncAutoWrapperType):
             return str(self)
 
     async def open(self, *args, **kwargs):
+        """Open the file pointed to by the path, like the :func:`trio.open_file`
+        function does.
+
+        """
+
         func = partial(self._wrapped.open, *args, **kwargs)
         value = await trio.run_in_worker_thread(func)
         return trio.wrap_file(value)


### PR DESCRIPTION
I noticed this was missing, and it's the only special-case in `Path`, so it probably needs this.