### PR TITLE
test_multierror: Use IPython's code_to_run instead of exec_lines

### DIFF
--- a/trio/_core/tests/test_multierror.py
+++ b/trio/_core/tests/test_multierror.py
@@ -419,7 +419,7 @@ def run_script(name, use_ipython=False):
         cmd = [sys.executable, "-u", "-m", "IPython",
                # no startup files
                "--quick",
-               "--TerminalIPythonApp.exec_lines=" + repr(lines),
+               "--TerminalIPythonApp.code_to_run=" + '\n'.join(lines),
         ]
     else:
         cmd = [sys.executable, "-u", str(script_path)]
@@ -475,27 +475,21 @@ else:
     have_ipython = True
 
 need_ipython = pytest.mark.skipif(not have_ipython, reason="need IPython")
-broken_on_appveyor = pytest.mark.skipif(
-    "APPVEYOR" in os.environ,
-    reason="For some reason this freezes on appveyor")
 
 @slow
 @need_ipython
-@broken_on_appveyor
 def test_ipython_exc_handler():
     completed = run_script("simple_excepthook.py", use_ipython=True)
     check_simple_excepthook(completed)
 
 @slow
 @need_ipython
-@broken_on_appveyor
 def test_ipython_imported_but_unused():
     completed = run_script("simple_excepthook_IPython.py")
     check_simple_excepthook(completed)
 
 @slow
 @need_ipython
-@broken_on_appveyor
 def test_ipython_custom_exc_handler():
     # Check we get a nice warning (but only one!) if the user is using IPython
     # and already has some other set_custom_exc handler installed.


### PR DESCRIPTION
The reason the tests "freeze" on AppVeyor should have been that
`exec_lines` runs the lines at IPython startup and then leaves the
python shell open, meaning that the process would never exit.  This
should no longer be the case with `code_to_run`, so remove the skip
marker as well.