### PR TITLE
Correct the example in wait_all_tasks_blocked

### DIFF
--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -1084,17 +1084,21 @@ class Runner:
                  lock = trio.Lock()
                  await lock.acquire()
                  async with trio.open_nursery() as nursery:
-                     nursery.spawn(lock_taker, lock)
-                     # child hasn't run yet
-                     assert not lock.locked()
-                     await trio.testing.wait_all_tasks_blocked()
-                     # now the child has run
+                     child = nursery.spawn(lock_taker, lock)
+                     # child hasn't run yet, we have the lock
                      assert lock.locked()
+                     assert lock._owner is trio.current_task()
+                     await trio.testing.wait_all_tasks_blocked()
+                     # now the child has run and is blocked on lock.acquire(), we
+                     # still have the lock
+                     assert lock.locked()
+                     assert lock._owner is trio.current_task()
                      lock.release()
                      try:
                          # The child has a prior claim, so we can't have it
                          lock.acquire_nowait()
                      except trio.WouldBlock:
+                         assert lock._owner is child
                          print("PASS")
                      else:
                          print("FAIL")


### PR DESCRIPTION
The previous example had a small thinko and asserted the lock wasn't locked when in fact we had just acquired it.

Fix the example, and add a couple of assertions about lock ownership to attempt to clarify things a little.

Fixes #224 but doesn't attempt to find a simpler example to use instead.