### PR TITLE
Stop interning Cancelled exceptions

### DIFF
--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -592,12 +592,10 @@ async def test_cancel_edge_cases():
     with _core.open_cancel_scope() as scope:
         # Check level-triggering
         scope.cancel()
-        with pytest.raises(_core.Cancelled) as excinfo1:
+        with pytest.raises(_core.Cancelled):
             await sleep_forever()
-        with pytest.raises(_core.Cancelled) as excinfo2:
+        with pytest.raises(_core.Cancelled):
             await sleep_forever()
-        # Same exception both times, to ensure complete tracebacks:
-        assert excinfo1.value is excinfo2.value
 
 
 async def test_cancel_scope_multierror_filtering():


### PR DESCRIPTION
Cancel scopes used to jump through hoops to make sure that if you had
some code like:

```python
  with open_cancel_scope as cs:
      cs.cancel()
      try:
          await sleep(1)
      except Cancelled as exc1:
          try:
              await sleep(1)
          except Cancelled as exc2:
              assert exc1 is exc2
```

then not only did both of the sleep() calls raise a Cancelled
exception, but they both raised *the same exception object* (i.e., the
assertion above passed). This was motivated by some idea that it would
lead to more complete tracebacks, but in fact I think it just makes
tracebacks more confusing, plus creates nasty things like `__context__`
loops (in the above example, `exc2.__context__ is exc1 is exc2`), plus
it's just surprising if you're used to how things are done in Python
normally.

This commit drops that code; now each sleep() gets its own Cancelled
object created just for it.