### PR TITLE
Hide the trio.socket.SocketType class

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,9 +17,9 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
+sys.path.insert(0, os.path.abspath('.'))
 
 # Warn about all references to unknown targets
 nitpicky = True
@@ -51,6 +51,7 @@ extensions = [
     'sphinx.ext.coverage',
     'sphinx.ext.napoleon',
     'sphinxcontrib_trio',
+    'local_customization',
 ]
 
 intersphinx_mapping = {

--- a/docs/source/local_customization.py
+++ b/docs/source/local_customization.py
@@ -1,0 +1,25 @@
+from docutils.parsers.rst import directives
+from sphinx import addnodes
+from sphinx.domains.python import PyClasslike
+from sphinx.ext.autodoc import (
+    FunctionDocumenter, MethodDocumenter, ClassLevelDocumenter, Options,
+)
+
+"""
+
+.. interface:: The nursery interface
+
+   .. attribute:: blahblah
+
+"""
+
+class Interface(PyClasslike):
+    def handle_signature(self, sig, signode):
+        signode += addnodes.desc_name(sig, sig)
+        return sig, ""
+
+    def get_index_text(self, modname, name_cls):
+        return "{} (interface in {})".format(name_cls[0], modname)
+
+def setup(app):
+    app.add_directive_to_domain("py", "interface", Interface)

--- a/docs/source/reference-core.rst
+++ b/docs/source/reference-core.rst
@@ -420,7 +420,7 @@ Of course, if you really want to make another blocking call in your
 cleanup handler, trio will let you; it's trying to prevent you from
 accidentally shooting yourself in the foot. Intentional foot-shooting
 is no problem (or at least – it's not trio's problem). To do this,
-create a new scope, and set its :attr:`~cancel_scope_interface.shield`
+create a new scope, and set its :attr:`~The cancel scope interface.shield`
 attribute to :data:`True`::
 
    with trio.move_on_after(TIMEOUT):
@@ -506,12 +506,7 @@ The primitive operation for creating a new cancellation scope is:
 
 Cancel scope objects provide the following interface:
 
-.. class:: cancel_scope_interface
-
-   (Note: there is no public class called
-   :class:`cancel_scope_interface`; this is a convenient fiction to
-   make our documentation generator happy. You get a cancel scope
-   object by calling :func:`open_cancel_scope`.)
+.. interface:: The cancel scope interface
 
    .. attribute:: deadline
 
@@ -890,11 +885,7 @@ The nursery API
 
 Nursery objects provide the following interface:
 
-.. class:: nursery_interface
-
-   (Note: there is no public class called :class:`nursery_interface`;
-   this is a convenient fiction to make our documentation generator
-   happy. You get a nursery object by calling :func:`open_nursery`.)
+.. interface:: The nursery interface
 
    .. method:: spawn(async_fn, *args, name=None)
 

--- a/docs/source/reference-core.rst
+++ b/docs/source/reference-core.rst
@@ -154,7 +154,7 @@ kind of issue looks like in real life, consider this function::
     async def recv_exactly(sock, nbytes):
         data = bytearray()
         while nbytes > 0:
-            # SocketType.recv() reads up to 'nbytes' bytes each time
+            # recv() reads up to 'nbytes' bytes each time
             chunk += await sock.recv(nbytes)
             if not chunk:
                 raise RuntimeError("socket unexpected closed")

--- a/docs/source/reference-core.rst
+++ b/docs/source/reference-core.rst
@@ -420,8 +420,8 @@ Of course, if you really want to make another blocking call in your
 cleanup handler, trio will let you; it's trying to prevent you from
 accidentally shooting yourself in the foot. Intentional foot-shooting
 is no problem (or at least – it's not trio's problem). To do this,
-create a new scope, and set its :attr:`shield` attribute to
-:data:`True`::
+create a new scope, and set its :attr:`~cancel_scope_interface.shield`
+attribute to :data:`True`::
 
    with trio.move_on_after(TIMEOUT):
        conn = make_connection()
@@ -504,9 +504,14 @@ The primitive operation for creating a new cancellation scope is:
 .. autofunction:: open_cancel_scope
    :with: cancel_scope
 
-   Cancel scope objects provide the following interface:
+Cancel scope objects provide the following interface:
 
-   .. currentmodule:: None
+.. class:: cancel_scope_interface
+
+   (Note: there is no public class called
+   :class:`cancel_scope_interface`; this is a convenient fiction to
+   make our documentation generator happy. You get a cancel scope
+   object by calling :func:`open_cancel_scope`.)
 
    .. attribute:: deadline
 
@@ -574,8 +579,6 @@ The primitive operation for creating a new cancellation scope is:
       the ``with`` block exited with a :exc:`~trio.Cancelled`
       exception, and (2) this scope is the one that was responsible
       for triggering this :exc:`~trio.Cancelled` exception.
-
-   .. currentmodule:: trio
 
 Trio also provides several convenience functions for the common
 situation of just wanting to impose a timeout on some code:
@@ -885,9 +888,13 @@ The nursery API
 .. autofunction:: open_nursery
    :async-with: nursery
 
-   Nursery objects provide the following interface:
+Nursery objects provide the following interface:
 
-   .. currentmodule:: None
+.. class:: nursery_interface
+
+   (Note: there is no public class called :class:`nursery_interface`;
+   this is a convenient fiction to make our documentation generator
+   happy. You get a nursery object by calling :func:`open_nursery`.)
 
    .. method:: spawn(async_fn, *args, name=None)
 
@@ -969,8 +976,6 @@ The nursery API
 
          nursery.reap(task)
          return task.result.unwrap()
-
-   .. currentmodule:: trio
 
 
 Task object API

--- a/trio/_network.py
+++ b/trio/_network.py
@@ -35,8 +35,8 @@ class SocketStream(HalfCloseableStream):
     interface based on a raw network socket.
 
     Args:
-      sock (trio.socket.SocketType): The trio socket object to wrap. Must have
-          type ``SOCK_STREAM``, and be connected.
+      sock: The trio socket object to wrap. Must have type ``SOCK_STREAM``,
+          and be connected.
 
     By default, :class:`SocketStream` enables ``TCP_NODELAY``, and (on
     platforms where it's supported) enables ``TCP_NOTSENT_LOWAT`` with a
@@ -50,12 +50,12 @@ class SocketStream(HalfCloseableStream):
 
     .. attribute:: socket
 
-       The :class:`trio.socket.SocketType` object that this stream wraps.
+       The Trio socket object that this stream wraps.
 
     """
     def __init__(self, sock):
-        if not isinstance(sock, tsocket.SocketType):
-            raise TypeError("SocketStream requires trio.socket.SocketType")
+        if not tsocket.is_trio_socket(sock):
+            raise TypeError("SocketStream requires trio socket object")
         if sock._real_type != tsocket.SOCK_STREAM:
             raise ValueError("SocketStream requires a SOCK_STREAM socket")
         try:


### PR DESCRIPTION
This is in preparation for #170.

The PR also gives a slightly better way to document hidden classes
like this.