### PR TITLE
Remove re-export of socket.getprotobyname

### DIFF
--- a/trio/socket.py
+++ b/trio/socket.py
@@ -80,7 +80,7 @@ if _sys.platform == "win32":
 ################################################################
 
 for _name in [
-        "gaierror", "herror", "gethostname", "getprotobyname", "ntohs",
+        "gaierror", "herror", "gethostname", "ntohs",
         "htonl", "htons", "inet_aton", "inet_ntoa",
         "inet_pton", "inet_ntop", "sethostname", "if_nameindex",
         "if_nametoindex", "if_indextoname",


### PR DESCRIPTION
We have a proper async wrapper for it now, which was overwriting this
reexport in any case, so this commit doesn't change anything
semantically.