### PR TITLE
Remove quasi-public APIs from trio socket interface

### DIFF
--- a/docs/source/reference-io.rst
+++ b/docs/source/reference-io.rst
@@ -410,6 +410,15 @@ Socket objects
 
       `Not implemented yet! <https://github.com/python-trio/trio/issues/45>`__
 
+   We also keep track of an extra bit of state, because it turns out
+   to be useful for :class:`trio.SocketStream`:
+
+   .. attribute:: did_shutdown_SHUT_WR
+
+      This :class:`bool` attribute it True if you've called
+      ``sock.shutdown(SHUT_WR)`` or ``sock.shutdown(SHUT_RDWR)``, and
+      False otherwise.
+
    The following methods are identical to their equivalents in
    :func:`socket.socket`, except async, and the ones that take address
    arguments require pre-resolved addresses:

--- a/trio/_network.py
+++ b/trio/_network.py
@@ -94,7 +94,7 @@ class SocketStream(HalfCloseableStream):
                 pass
 
     async def send_all(self, data):
-        if self.socket._did_SHUT_WR:
+        if self.socket.did_shutdown_SHUT_WR:
             await _core.yield_briefly()
             raise ClosedStreamError("can't send data after sending EOF")
         with self._send_lock.sync:
@@ -112,7 +112,7 @@ class SocketStream(HalfCloseableStream):
         async with self._send_lock:
             # On MacOS, calling shutdown a second time raises ENOTCONN, but
             # send_eof needs to be idempotent.
-            if self.socket._did_SHUT_WR:
+            if self.socket.did_shutdown_SHUT_WR:
                 return
             with _translate_socket_errors_to_stream_errors():
                 self.socket.shutdown(tsocket.SHUT_WR)

--- a/trio/_network.py
+++ b/trio/_network.py
@@ -56,7 +56,7 @@ class SocketStream(HalfCloseableStream):
     def __init__(self, sock):
         if not tsocket.is_trio_socket(sock):
             raise TypeError("SocketStream requires trio socket object")
-        if sock._real_type != tsocket.SOCK_STREAM:
+        if tsocket._real_type(sock.type) != tsocket.SOCK_STREAM:
             raise ValueError("SocketStream requires a SOCK_STREAM socket")
         try:
             sock.getpeername()

--- a/trio/socket.py
+++ b/trio/socket.py
@@ -246,7 +246,7 @@ class _SocketType:
                 .format(type(sock).__name__))
         self._sock = sock
         self._sock.setblocking(False)
-        self._did_SHUT_WR = False
+        self._did_shutdown_SHUT_WR = False
 
         # Defaults:
         if self._sock.family == AF_INET6:
@@ -307,6 +307,10 @@ class _SocketType:
     def proto(self):
         return self._sock.proto
 
+    @property
+    def did_shutdown_SHUT_WR(self):
+        return self._did_shutdown_SHUT_WR
+
     def __repr__(self):
         return repr(self._sock).replace("socket.socket", "trio.socket.socket")
 
@@ -325,7 +329,7 @@ class _SocketType:
         self._sock.shutdown(flag)
         # only do this if the call succeeded:
         if flag in [SHUT_WR, SHUT_RDWR]:
-            self._did_SHUT_WR = True
+            self._did_shutdown_SHUT_WR = True
 
     async def wait_writable(self):
         await _core.wait_socket_writable(self._sock)

--- a/trio/tests/test_socket.py
+++ b/trio/tests/test_socket.py
@@ -323,10 +323,26 @@ async def test_SocketType_shutdown():
     with a, b:
         await a.sendall(b"xxx")
         assert await b.recv(3) == b"xxx"
+        assert not a.did_shutdown_SHUT_WR
+        assert not b.did_shutdown_SHUT_WR
         a.shutdown(tsocket.SHUT_WR)
+        assert a.did_shutdown_SHUT_WR
+        assert not b.did_shutdown_SHUT_WR
         assert await b.recv(3) == b""
         await b.sendall(b"yyy")
         assert await a.recv(3) == b"yyy"
+
+    a, b = tsocket.socketpair()
+    with a, b:
+        assert not a.did_shutdown_SHUT_WR
+        a.shutdown(tsocket.SHUT_RD)
+        assert not a.did_shutdown_SHUT_WR
+
+    a, b = tsocket.socketpair()
+    with a, b:
+        assert not a.did_shutdown_SHUT_WR
+        a.shutdown(tsocket.SHUT_RDWR)
+        assert a.did_shutdown_SHUT_WR
 
 
 @pytest.mark.parametrize("address, socket_type", [('127.0.0.1', tsocket.AF_INET), ('::1', tsocket.AF_INET6)])


### PR DESCRIPTION
There were some underscored attributes that were accessed from
SocketStream. Fix that, in preparation for gh-170.