### PR TITLE
We have too many ways to close things; remove the redundancy

### DIFF
--- a/docs/source/reference-io.rst
+++ b/docs/source/reference-io.rst
@@ -92,6 +92,8 @@ Abstract base classes
 .. autoclass:: trio.abc.AsyncResource
    :members:
 
+.. function:: trio.aclose_forcefully
+
 .. autoclass:: trio.abc.SendStream
    :members:
    :show-inheritance:

--- a/trio/_network.py
+++ b/trio/_network.py
@@ -129,11 +129,11 @@ class SocketStream(HalfCloseableStream):
         with _translate_socket_errors_to_stream_errors():
             return await self.socket.recv(max_bytes)
 
-    def forceful_close(self):
+    async def aclose(self):
         self.socket.close()
+        await _core.yield_briefly()
 
-    # graceful_close, __aenter__, __aexit__ inherited from HalfCloseableStream
-    # are OK
+    # __aenter__, __aexit__ inherited from HalfCloseableStream are OK
 
     def setsockopt(self, level, option, value):
         """Set an option on the underlying socket.

--- a/trio/_streams.py
+++ b/trio/_streams.py
@@ -2,15 +2,48 @@ import abc
 import contextlib
 
 import attr
+from async_generator import async_generator, yield_
 
 from . import _core
 from .abc import HalfCloseableStream
+from ._util import acontextmanager
 
 __all__ = [
+    "aclose_forcefully",
     "BrokenStreamError",
     "ClosedStreamError",
     "StapledStream",
 ]
+
+
+async def aclose_forcefully(resource):
+    """Close an async resource or async generator immediately, without
+    blocking to do any graceful cleanup.
+
+    :class:`~trio.abc.AsyncResource` objects guarantee that if their
+    :meth:`~trio.abc.AsyncResource.aclose` method is cancelled, then they will
+    still close the resource (albeit in a potentially ungraceful
+    fashion). :func:`aclose_forcefully` is a convenience function that
+    exploits this behavior to let you force a resource to be closed without
+    blocking: it works by calling ``await resource.aclose()`` and then
+    cancelling it immediately.
+
+    Most users won't need this, but it may be useful on cleanup paths where
+    you can't afford to block, or if you want to close an resource and don't
+    care about handling it gracefully. For example, if
+    :class:`~trio.ssl.SSLStream` encounters an error and cannot perform its
+    own graceful close, then there's no point in waiting to gracefully shut
+    down the underlying transport either, so it calls ``await
+    aclose_forcefully(self.transport_stream)``.
+
+    Note that this function is async, and that it acts as a checkpoint, but
+    unlike most async functions it cannot block indefinitely (at least,
+    assuming the underlying resource object is correctly implemented).
+
+    """
+    with _core.open_cancel_scope() as cs:
+        cs.cancel()
+        await resource.aclose()
 
 
 class BrokenStreamError(Exception):
@@ -31,12 +64,12 @@ class BrokenStreamError(Exception):
 
 
 class ClosedStreamError(Exception):
-    """Raised when an attempt to use a stream a stream fails because the
-    stream was already closed locally.
+    """Raised when an attempt to use a stream fails because the stream was
+    already closed locally.
 
     You *only* get this error if *your* code closed the stream object you're
     attempting to use by calling
-    :meth:`~trio.abc.AsyncResource.graceful_close` or
+    :meth:`~trio.abc.AsyncResource.aclose` or
     similar. (:meth:`~trio.abc.SendStream.send_all` might also raise this if
     you already called :meth:`~trio.abc.HalfCloseableStream.send_eof`.)
     Therefore this exception generally indicates a bug in your code.
@@ -63,8 +96,8 @@ class StapledStream(HalfCloseableStream):
        A silly way to make a stream that echoes back whatever you write to
        it::
 
-          sock1, sock2 = trio.socket.socketpair()
-          echo_stream = StapledStream(SocketStream(sock1), SocketStream(sock2))
+          left, right = trio.testing.memory_stream_pair()
+          echo_stream = StapledStream(SocketStream(left), SocketStream(right))
           await echo_stream.send_all(b"x")
           assert await echo_stream.receive_some(1) == b"x"
 
@@ -102,13 +135,13 @@ class StapledStream(HalfCloseableStream):
         """Shuts down the send side of the stream.
 
         If ``self.send_stream.send_eof`` exists, then calls it. Otherwise,
-        calls ``self.send_stream.graceful_close()``.
+        calls ``self.send_stream.aclose()``.
 
         """
         if hasattr(self.send_stream, "send_eof"):
             return await self.send_stream.send_eof()
         else:
-            return await self.send_stream.graceful_close()
+            return await self.send_stream.aclose()
 
     async def receive_some(self, max_bytes):
         """Calls ``self.receive_stream.receive_some``.
@@ -116,20 +149,11 @@ class StapledStream(HalfCloseableStream):
         """
         return await self.receive_stream.receive_some(max_bytes)
 
-    def forceful_close(self):
-        """Calls ``forceful_close`` on both underlying streams.
+    async def aclose(self):
+        """Calls ``aclose`` on both underlying streams.
 
         """
         try:
-            self.send_stream.forceful_close()
+            await self.send_stream.aclose()
         finally:
-            self.receive_stream.forceful_close()
-
-    async def graceful_close(self):
-        """Calls ``graceful_close`` on both underlying streams.
-
-        """
-        try:
-            await self.send_stream.graceful_close()
-        finally:
-            await self.receive_stream.graceful_close()
+            await self.receive_stream.aclose()

--- a/trio/tests/test_abc.py
+++ b/trio/tests/test_abc.py
@@ -11,29 +11,11 @@ async def test_AsyncResource_defaults():
     class MyAR(tabc.AsyncResource):
         record = attr.ib(default=attr.Factory(list))
 
-        def forceful_close(self):
-            self.record.append("fc")
+        async def aclose(self):
+            self.record.append("ac")
 
     async with MyAR() as myar:
         assert isinstance(myar, MyAR)
         assert myar.record == []
 
-    assert myar.record == ["fc"]
-
-    with assert_yields():
-        await myar.graceful_close()
-    assert myar.record == ["fc", "fc"]
-
-    @attr.s
-    class BadAR(tabc.AsyncResource):
-        record = attr.ib(default=attr.Factory(list))
-
-        def forceful_close(self):
-            self.record.append("boom")
-            raise KeyError
-
-    badar = BadAR()
-    with pytest.raises(KeyError):
-        with assert_yields():
-            await badar.graceful_close()
-    assert badar.record == ["boom"]
+    assert myar.record == ["ac"]

--- a/trio/tests/test_open_tcp_stream.py
+++ b/trio/tests/test_open_tcp_stream.py
@@ -78,7 +78,7 @@ async def test_open_tcp_stream_real_socket_smoketest():
     server_sock, _ = await listen_sock.accept()
     await client_stream.send_all(b"x")
     assert await server_sock.recv(1) == b"x"
-    client_stream.forceful_close()
+    await client_stream.aclose()
     server_sock.close()
 
 

--- a/trio/tests/test_ssl.py
+++ b/trio/tests/test_ssl.py
@@ -190,11 +190,8 @@ class PyOpenSSLEchoStream:
         else:
             self.sleeper = sleeper
 
-    def forceful_close(self):
+    async def aclose(self):
         self._conn.bio_shutdown()
-
-    async def graceful_close(self):
-        self.forceful_close()
 
     def renegotiate_pending(self):
         return self._conn.renegotiate_pending()
@@ -375,7 +372,7 @@ async def test_ssl_client_basics():
         assert not s.server_side
         await s.send_all(b"x")
         assert await s.receive_some(1) == b"x"
-        await s.graceful_close()
+        await s.aclose()
 
     # Didn't configure the CA file, should fail
     async with ssl_echo_server_raw(expect_fail=True) as sock:
@@ -424,7 +421,7 @@ async def test_ssl_server_basics():
         await server_transport.send_all(b"y")
         assert await server_transport.receive_some(1) == b"z"
         assert await server_transport.receive_some(1) == b""
-        await server_transport.graceful_close()
+        await server_transport.aclose()
 
         t.join()
 
@@ -531,7 +528,7 @@ async def test_full_duplex_basics():
             nursery.spawn(s.do_handshake)
             nursery.spawn(s.do_handshake)
 
-        await s.graceful_close()
+        await s.aclose()
 
     assert len(sent) == len(received) == EXPECTED
     assert sent == received
@@ -552,7 +549,7 @@ async def test_renegotiation_simple():
         await s.send_all(b"b")
         assert await s.receive_some(1) == b"b"
 
-        await s.graceful_close()
+        await s.aclose()
 
 
 @slow
@@ -646,7 +643,7 @@ async def test_renegotiation_randomized(mock_clock):
 
         await clear()
 
-        await s.graceful_close()
+        await s.aclose()
 
     # 2) Same, but now wait_send_all_might_not_block is stuck when
     # receive_some tries to send.
@@ -667,7 +664,7 @@ async def test_renegotiation_randomized(mock_clock):
 
         await clear()
 
-        await s.graceful_close()
+        await s.aclose()
 
 
 async def test_resource_busy_errors():
@@ -751,7 +748,7 @@ async def test_checkpoints():
     async with ssl_echo_server() as s:
         await s.do_handshake()
         with assert_yields():
-            await s.graceful_close()
+            await s.aclose()
 
 
 async def test_send_all_empty_string():
@@ -767,7 +764,7 @@ async def test_send_all_empty_string():
         await s.send_all(b"x")
         assert await s.receive_some(1) == b"x"
 
-        await s.graceful_close()
+        await s.aclose()
 
 
 @pytest.mark.parametrize("https_compatible", [False, True])
@@ -858,13 +855,13 @@ async def test_closing_nice_case():
     # we need to run them concurrently
     async def client_closer():
         with assert_yields():
-            await client_ssl.graceful_close()
+            await client_ssl.aclose()
 
     async def server_closer():
         assert await server_ssl.receive_some(10) == b""
         assert await server_ssl.receive_some(10) == b""
         with assert_yields():
-            await server_ssl.graceful_close()
+            await server_ssl.aclose()
 
     async with _core.open_nursery() as nursery:
         nursery.spawn(client_closer)
@@ -876,8 +873,9 @@ async def test_closing_nice_case():
 
     # once closed, it's OK to close again
     with assert_yields():
-        await client_ssl.graceful_close()
-    client_ssl.forceful_close()
+        await client_ssl.aclose()
+    with assert_yields():
+        await client_ssl.aclose()
 
     # Trying to send more data does not work
     with assert_yields():
@@ -906,10 +904,10 @@ async def test_closing_nice_case():
         with assert_yields():
             assert await server_ssl.receive_some(10) == b""
         with assert_yields():
-            await server_ssl.graceful_close()
+            await server_ssl.aclose()
 
     async with _core.open_nursery() as nursery:
-        nursery.spawn(client_ssl.graceful_close)
+        nursery.spawn(client_ssl.aclose)
         nursery.spawn(expect_eof_server)
 
 
@@ -939,7 +937,7 @@ async def test_send_all_fails_in_the_middle():
 
     client.transport_stream.send_stream.close_hook = close_hook
     client.transport_stream.receive_stream.close_hook = close_hook
-    await client.graceful_close()
+    await client.aclose()
 
     assert closed == 2
 
@@ -977,14 +975,14 @@ async def test_ssl_bad_shutdown():
         nursery.spawn(client.do_handshake)
         nursery.spawn(server.do_handshake)
 
-    client.forceful_close()
+    await trio.aclose_forcefully(client)
     # now the server sees a broken stream
     with pytest.raises(BrokenStreamError):
         await server.receive_some(10)
     with pytest.raises(BrokenStreamError):
         await server.send_all(b"x" * 10)
 
-    await server.graceful_close()
+    await server.aclose()
 
 
 async def test_ssl_bad_shutdown_but_its_ok():
@@ -997,13 +995,13 @@ async def test_ssl_bad_shutdown_but_its_ok():
         nursery.spawn(client.do_handshake)
         nursery.spawn(server.do_handshake)
 
-    client.forceful_close()
+    await trio.aclose_forcefully(client)
     # the server sees that as a clean shutdown
     assert await server.receive_some(10) == b""
     with pytest.raises(BrokenStreamError):
         await server.send_all(b"x" * 10)
 
-    await server.graceful_close()
+    await server.aclose()
 
 
 async def test_ssl_https_compatibility_disagreement():
@@ -1024,7 +1022,7 @@ async def test_ssl_https_compatibility_disagreement():
         assert isinstance(excinfo.value.__cause__, tssl.SSLEOFError)
 
     async with _core.open_nursery() as nursery:
-        nursery.spawn(client.graceful_close)
+        nursery.spawn(client.aclose)
         nursery.spawn(receive_and_expect_error)
 
 
@@ -1038,7 +1036,7 @@ async def test_https_mode_eof_before_handshake():
         assert await server.receive_some(10) == b""
 
     async with _core.open_nursery() as nursery:
-        nursery.spawn(client.graceful_close)
+        nursery.spawn(client.aclose)
         nursery.spawn(server_expect_clean_eof)
 
 

--- a/trio/tests/test_ssl_helpers.py
+++ b/trio/tests/test_ssl_helpers.py
@@ -36,7 +36,10 @@ class FakeSocket:
         return await self.stream.receive_some(max_bytes)
 
     def close(self):
-        self.stream.forceful_close()
+        # Memory{Send,Receive}Streams provide a synchronous close method just
+        # to support this case.
+        self.stream.receive_stream.close()
+        self.stream.send_stream.close()
 
     # Stubs to make SocketStream happy:
     def setsockopt(self, *args, **kwargs):
@@ -112,7 +115,7 @@ async def test_open_ssl_over_tcp_stream():
         )
         await stream.send_all(b"x")
         assert await stream.receive_some(1) == b"x"
-        await stream.graceful_close()
+        await stream.aclose()
 
         # Check https_compatible settings are being passed through
         assert not stream._https_compatible


### PR DESCRIPTION
There was a weird redundancy where there were 3 ways to close things:

- forceful_close: ungraceful, non-blocking, sync
- graceful_close: graceful, potentially blocking, async
- cancelled graceful_close: ungraceful, non-block, async

This is one too many, and we can't really simplify the graceful_close
semantics further, and async file objects can implement all of
graceful_close but *can't* really implement forceful_close (because
even their forceful_close can block momentarily to do some disk
I/O). Async generators ditto. So this commit:

- drops forceful_close
- renames graceful_close to aclose
- adds trio.aclose_forcefully as a convenience function for the cases
  where you might have wanted forceful_close

Closes gh-260