### PR TITLE
Run yapf

### DIFF
--- a/trio/_core/_parking_lot.py
+++ b/trio/_core/_parking_lot.py
@@ -122,6 +122,7 @@ class ParkingLot:
         def abort(_):
             del self._parked[task]
             return _core.Abort.SUCCEEDED
+
         return abort
 
     # XX this currently returns None


### PR DESCRIPTION
Fixes a formatting problem that snuck in with gh-287, whose CI ran
before we added the formatting checks, but then was merged after.