### PR TITLE
Deprecations for #136 and #284

### DIFF
--- a/docs/source/design.rst
+++ b/docs/source/design.rst
@@ -417,9 +417,9 @@ Specific style guidelines
   and the ``nowait`` version raises :exc:`trio.WouldBlock` if it would block.
 
 * The word ``monitor`` is used for APIs that involve an
-  :class:`UnboundedQueue` receiving some kind of events. (Examples:
-  nursery ``.monitor`` attribute, some of the low-level I/O functions in
-  :mod:`trio.hazmat`.)
+  :class:`trio.hazmat.UnboundedQueue` receiving some kind of events.
+  (Examples: nursery ``.monitor`` attribute, some of the low-level I/O
+  functions in :mod:`trio.hazmat`.)
 
 * ...we should, but currently don't, have a solid convention to
   distinguish between functions that take an async callable and those

--- a/docs/source/design.rst
+++ b/docs/source/design.rst
@@ -466,7 +466,7 @@ There are three notable sub-modules that are largely independent of
 the rest of trio, and could (possibly should?) be extracted into their
 own independent packages:
 
-* ``_result.py``: Defines :class:`Result`.
+* ``_result.py``: Defines :class:`~trio.hazmat.Result`.
 
 * ``_multierror.py``: Implements :class:`MultiError` and associated
   infrastructure.

--- a/docs/source/design.rst
+++ b/docs/source/design.rst
@@ -309,7 +309,7 @@ where it motivates the use of "nurseries"::
 
    async def parent():
        async with trio.open_nursery() as nursery:
-           nursery.spawn(child)
+           nursery.start_soon(child)
 
 (See :ref:`tasks` for full details.)
 
@@ -326,7 +326,7 @@ In `the blog post
 <https://vorpus.org/blog/some-thoughts-on-asynchronous-api-design-in-a-post-asyncawait-world/#c-c-c-c-causality-breaker>`__
 I called out a nice feature of curio's spawning API, which is that
 since spawning is the only way to break causality, and in curio
-``spawn`` is async, this means that in curio sync functions are
+``spawn`` is async, which means that in curio sync functions are
 guaranteed to be causal. One limitation though is that this invariant
 is actually not very predictive: in curio there are lots of async
 functions that could spawn off children and violate causality, but
@@ -338,11 +338,11 @@ one. In trio:
 * Sync functions can't create nurseries, because nurseries require an
   ``async with``
 
-* Any async function can create a nursery and spawn new tasks... but
-  creating a nursery *allows task spawning without allowing causality
-  breaking*, because the children have to exit before the function is
-  allowed to return. So we can preserve causality without having to
-  give up concurrency!
+* Any async function can create a nursery and start new tasks... but
+  creating a nursery *allows task starting but does not permit
+  causality breaking*, because the children have to exit before the
+  function is allowed to return. So we can preserve causality without
+  having to give up concurrency!
 
 * The only way to violate causality (which is an important feature,
   just one that needs to be handled carefully) is to explicitly create

--- a/docs/source/design.rst
+++ b/docs/source/design.rst
@@ -478,8 +478,9 @@ The most important submodule, where everything is integrated, is
 ``_run.py``. (This is also by far the largest submodule; it'd be nice
 to factor bits of it out with possible, but it's tricky because the
 core functionality genuinely is pretty intertwined.) Notably, this is
-where cancel scopes, nurseries, and :class:`Task` are defined; it's
-also where the scheduler state and :func:`trio.run` live.
+where cancel scopes, nurseries, and :class:`~trio.hazmat.Task` are
+defined; it's also where the scheduler state and :func:`trio.run`
+live.
 
 The one thing that *isn't* in ``_run.py`` is I/O handling. This is
 delegated to an ``IOManager`` class, of which there are currently

--- a/docs/source/reference-core.rst
+++ b/docs/source/reference-core.rst
@@ -1052,25 +1052,6 @@ you return a new exception object, then the new object's
 exception.
 
 
-Result objects
-++++++++++++++
-
-.. autoclass:: Result
-   :members:
-
-.. autoclass:: Value
-   :members:
-
-.. autoclass:: Error
-   :members:
-
-.. note::
-
-   Since :class:`Result` objects are simple immutable data structures
-   that don't otherwise interact with the trio machinery, it's safe to
-   create and access :class:`Result` objects from any thread you like.
-
-
 Task-local storage
 ------------------
 

--- a/docs/source/reference-core.rst
+++ b/docs/source/reference-core.rst
@@ -956,9 +956,14 @@ Nursery objects provide the following interface:
       other things, e.g. if you want to explicitly cancel all children
       in response to some external event.
 
+   The last two attributes are mainly to enable introspection of the
+   task tree, for example in debuggers.
 
+   .. attribute:: parent_task
 
+      The :class:`~trio.Task` that opened this nursery.
 
+   .. attribute:: child_tasks
 
       A :class:`frozenset` containing all the child
       :class:`~trio.Task` objects which are still running.
@@ -1012,6 +1017,10 @@ Task object API
       trace.
 
    .. autoattribute:: parent_task
+
+   .. autoattribute:: parent_nursery
+
+   .. autoattribute:: child_nurseries
 
 
 Working with :exc:`MultiError`\s

--- a/docs/source/reference-core.rst
+++ b/docs/source/reference-core.rst
@@ -874,7 +874,8 @@ Nursery objects provide the following interface:
       Creates a new child task inside this nursery, and sets it up to
       run ``await async_fn(*args)``.
 
-      This is *the* method for creating concurrent tasks in trio.
+      This and :meth:`start` are the two fundamental methods for
+      creating concurrent tasks in trio.
 
       Note that this is a synchronous function: it sets up the new
       task, but then returns immediately, *before* it has a chance to
@@ -955,51 +956,13 @@ Nursery objects provide the following interface:
       other things, e.g. if you want to explicitly cancel all children
       in response to some external event.
 
-   The remaining attributes and methods are mainly used for
-   implementing new types of task supervisor:
 
-   .. attribute:: monitor
 
-      A :class:`~trio.UnboundedQueue` which receives each child
-      :class:`~trio.Task` object when it exits.
 
-      It also receives a ``None`` value after each call to
-      :meth:`start`.
-
-   .. attribute:: children
 
       A :class:`frozenset` containing all the child
       :class:`~trio.Task` objects which are still running.
 
-   .. attribute:: zombies
-
-      A :class:`frozenset` containing all the child
-      :class:`~trio.Task` objects which have exited, but not yet been
-      reaped.
-
-   .. method:: reap(task)
-
-      Removes the given task from the :attr:`zombies` set.
-
-      Calling this method indicates to the nursery that you have taken
-      care of any cleanup needed. In particular, if the task exited
-      with an exception and you don't call this method, then
-      ``__aexit__`` will eventually re-raise that exception. If you do
-      call this method, then ``__aexit__`` won't do anything.
-
-      Once you call this method, then as far as trio is concerned the
-      :class:`~trio.Task` object no longer exists. You can hold onto a
-      reference to it as long as you like, but trio no longer has any
-      record of it.
-
-      :raises ValueError: If the given ``task`` is not in :attr:`zombies`.
-
-   .. method:: reap_and_unwrap(task)
-
-      A convenience shorthand for::
-
-         nursery.reap(task)
-         return task.result.unwrap()
 
 .. attribute:: STATUS_IGNORED
 

--- a/docs/source/reference-core.rst
+++ b/docs/source/reference-core.rst
@@ -1291,8 +1291,8 @@ you'll see that the two tasks politely take turns::
    async def main():
        async with trio.open_nursery() as nursery:
            lock = trio.Lock()
-           nursery.spawn(loopy_child, 1, lock)
-           nursery.spawn(loopy_child, 2, lock)
+           nursery.start_soon(loopy_child, 1, lock)
+           nursery.start_soon(loopy_child, 2, lock)
 
    trio.run(main)
 
@@ -1327,10 +1327,10 @@ have a queue with two producers and one consumer::
        queue = trio.HypotheticalQueue()
        async with trio.open_nursery() as nursery:
            # Two producers
-           nursery.spawn(producer, queue)
-           nursery.spawn(producer, queue)
+           nursery.start_soon(producer, queue)
+           nursery.start_soon(producer, queue)
            # One consumer
-           nursery.spawn(consumer, queue)
+           nursery.start_soon(consumer, queue)
 
    trio.run(main)
 

--- a/docs/source/reference-core.rst
+++ b/docs/source/reference-core.rst
@@ -971,46 +971,17 @@ Nursery objects provide the following interface:
 
    .. attribute:: parent_task
 
-      The :class:`~trio.Task` that opened this nursery.
+      The :class:`~trio.hazmat.Task` that opened this nursery.
 
    .. attribute:: child_tasks
 
       A :class:`frozenset` containing all the child
-      :class:`~trio.Task` objects which are still running.
+      :class:`~trio.hazmat.Task` objects which are still running.
 
 
 .. attribute:: STATUS_IGNORED
 
    See :meth:`~The nursery interface.start`.
-
-
-Task object API
-+++++++++++++++
-
-.. autofunction:: current_task()
-
-.. class:: Task()
-
-   A :class:`Task` object represents a concurrent "thread" of
-   execution.
-
-   Its public members are mostly useful for introspection and
-   debugging:
-
-   .. attribute:: name
-
-      String containing this :class:`Task`\'s name. Usually the name
-      of the function this :class:`Task` is running, but can be
-      overridden by passing ``name=`` to ``start`` or ``start_soon``.
-
-   .. attribute:: coro
-
-      This task's coroutine object. Example usage: extracting a stack
-      trace.
-
-   .. autoattribute:: parent_nursery
-
-   .. autoattribute:: child_nurseries
 
 
 Working with :exc:`MultiError`\s
@@ -1613,8 +1584,8 @@ Debugging and instrumentation
 -----------------------------
 
 Trio tries hard to provide useful hooks for debugging and
-instrumentation. Some are documented above (:attr:`Task.name`,
-:meth:`Queue.statistics`, etc.). Here are some more:
+instrumentation. Some are documented above (the nursery introspection
+attributes, :meth:`Queue.statistics`, etc.). Here are some more:
 
 
 Global statistics

--- a/docs/source/reference-core/tasklocal-example.py
+++ b/docs/source/reference-core/tasklocal-example.py
@@ -19,8 +19,8 @@ async def handle_request(tag):
     log("Request handler started")
     await trio.sleep(random.random())
     async with trio.open_nursery() as nursery:
-        nursery.spawn(concurrent_helper, "a")
-        nursery.spawn(concurrent_helper, "b")
+        nursery.start_soon(concurrent_helper, "a")
+        nursery.start_soon(concurrent_helper, "b")
     await trio.sleep(random.random())
     log("Request received finished")
 
@@ -34,6 +34,6 @@ async def concurrent_helper(job):
 async def main():
     async with trio.open_nursery() as nursery:
         for i in range(3):
-            nursery.spawn(handle_request, i)
+            nursery.start_soon(handle_request, i)
 
 trio.run(main)

--- a/docs/source/reference-hazmat.rst
+++ b/docs/source/reference-hazmat.rst
@@ -255,6 +255,43 @@ These transitions are accomplished using two function decorators:
 .. autofunction:: currently_ki_protected
 
 
+Result objects
+==============
+
+Trio provides some simple classes for representing the result of a
+Python function call, so that it can be passed around. The basic rule
+is::
+
+    result = Result.capture(f, *args)
+    x = result.unwrap()
+
+is the same as::
+
+    x = f(*args)
+
+even if ``f`` raises an error. And there's also
+:meth:`Result.acapture`, which is like ``await f(*args)``.
+
+There's nothing really dangerous about this system – it's actually
+very general and quite handy! But mostly it's used for things like
+implementing :func:`trio.run_sync_in_worker_thread`, or for getting
+values to pass to :func:`reschedule`, so we put it in
+:mod:`trio.hazmat` to avoid cluttering up the main API.
+
+Since :class:`Result` objects are simple immutable data structures
+that don't otherwise interact with the trio machinery, it's safe to
+create and access :class:`Result` objects from any thread you like.
+
+.. autoclass:: Result
+   :members:
+
+.. autoclass:: Value
+   :members:
+
+.. autoclass:: Error
+   :members:
+
+
 Sleeping and waking
 ===================
 

--- a/docs/source/reference-hazmat.rst
+++ b/docs/source/reference-hazmat.rst
@@ -1,36 +1,52 @@
-=========================================
- Low-level operations in ``trio.hazmat``
-=========================================
+=======================================================
+ Introspecting and extending Trio with ``trio.hazmat``
+=======================================================
 
 .. module:: trio.hazmat
 
 .. warning::
-   ⚠️ DANGER DANGER DANGER ⚠️
-
    You probably don't want to use this module.
 
-The :mod:`trio.hazmat` API is public and stable (or at least, `as
-stable as anything in trio is!
-<https://github.com/python-trio/trio/issues/1>`__), but it has `nasty
-big pointy teeth
+:mod:`trio.hazmat` contains APIs useful for introspecting and
+extending Trio. If you're writing ordinary, everyday code, then you
+can ignore this module completely. But sometimes it's what you need.
+Here are some examples of situations where you should reach for
+:mod:`trio.hazmat`:
+
+* You want to implement a new :ref:`synchronization primitive
+  <synchronization>` that Trio doesn't (yet) provide, like a
+  reader-writer lock.
+* You want to extract low-level metrics to monitor the health of your
+  application.
+* You're wrapping some low-level operating system interfaces that Trio
+  doesn't (yet) expose, like watching a filesystem directory for
+  changes.
+* You want to implement an interface for calling between Trio and
+  another event loop within the same process.
+* You're writing a debugger and want to visualize Trio's task tree.
+* You need to interoperate with a C library whose API exposes raw file
+  descriptors.
+
+Using :mod:`trio.hazmat` is perfectly safe, *if* you take proper
+precautions. In fact, you're already using it – it's how most of the
+functionality described in previous chapters is implemented. The APIs
+described here have strictly defined and carefully documented
+semantics. But some of them have `nasty big pointy teeth
 <https://en.wikipedia.org/wiki/Rabbit_of_Caerbannog>`__. Mistakes may
 not be handled gracefully; rules and conventions that are followed
-strictly in the rest of trio do not always apply. Read and tread
-carefully.
-
-But if you find yourself needing to, for example, implement new
-synchronization primitives or expose new low-level I/O functionality,
-then you're in the right place.
+strictly in the rest of Trio do not always apply. Read and tread
+carefully: using this module makes it your responsibility to handle
+the nasty cases and expose a friendly Trio-style API to your users.
 
 
 Low-level I/O primitives
 ========================
 
 Different environments expose different low-level APIs for performing
-async I/O. :mod:`trio.hazmat` attempts to expose these APIs in a
-relatively direct way, so as to allow maximum power and flexibility
-for higher level code. However, this means that the exact API provided
-may vary depending on what system trio is running on.
+async I/O. :mod:`trio.hazmat` exposes these APIs in a relatively
+direct way, so as to allow maximum power and flexibility for higher
+level code. However, this means that the exact API provided may vary
+depending on what system trio is running on.
 
 
 Universally available API
@@ -111,8 +127,9 @@ Unix-like systems provide the following functions:
 Kqueue-specific API
 -------------------
 
-TODO: these are currently more of a sketch than anything real. See
-`#26 <https://github.com/python-trio/trio/issues/26>`__.
+TODO: these are implemented, but are currently more of a sketch than
+anything real. See `#26
+<https://github.com/python-trio/trio/issues/26>`__.
 
 .. function:: current_kqueue()
 
@@ -126,8 +143,9 @@ TODO: these are currently more of a sketch than anything real. See
 Windows-specific API
 --------------------
 
-TODO: these are currently more of a sketch than anything real. See
-`#26 <https://github.com/python-trio/trio/issues/26>`__ and `#52
+TODO: these are implemented, but are currently more of a sketch than
+anything real. See `#26
+<https://github.com/python-trio/trio/issues/26>`__ and `#52
 <https://github.com/python-trio/trio/issues/52>`__.
 
 .. function:: register_with_iocp(handle)

--- a/docs/source/reference-hazmat.rst
+++ b/docs/source/reference-hazmat.rst
@@ -330,9 +330,9 @@ first to make sure that the whole thing is a checkpoint.
 Low-level blocking
 ------------------
 
+.. autofunction:: yield_indefinitely
 .. autoclass:: Abort
 .. autofunction:: reschedule
-.. autofunction:: yield_indefinitely
 
 Here's an example lock class implemented using
 :func:`yield_indefinitely` directly. This implementation has a number
@@ -364,3 +364,35 @@ this does serve to illustrate the basic structure of the
            if self._blocked_tasks:
                woken_task = self._blocked_tasks.popleft()
                trio.hazmat.reschedule(woken_task)
+
+
+Task API
+--------
+
+.. autofunction:: current_task()
+
+.. class:: Task()
+
+   A :class:`Task` object represents a concurrent "thread" of
+   execution. It has no public constructor; Trio internally creates a
+   :class:`Task` object for each call to ``nursery.start(...)`` or
+   ``nursery.start_soon(...)``.
+
+   Its public members are mostly useful for introspection and
+   debugging:
+
+   .. attribute:: name
+
+      String containing this :class:`Task`\'s name. Usually the name
+      of the function this :class:`Task` is running, but can be
+      overridden by passing ``name=`` to ``start`` or ``start_soon``.
+
+   .. attribute:: coro
+
+      This task's coroutine object. Example usage: extracting a stack
+      trace.
+
+   .. autoattribute:: parent_nursery
+
+   .. autoattribute:: child_nurseries
+

--- a/docs/source/reference-io.rst
+++ b/docs/source/reference-io.rst
@@ -79,7 +79,7 @@ create complex transport configurations. Here's some examples:
 
 * The :mod:`trio.testing` module provides a set of :ref:`flexible
   in-memory stream object implementations <testing-streams>`, so if
-  you have a protocol implementation to test then you can can spawn
+  you have a protocol implementation to test then you can can start
   two tasks, set up a virtual "socket" connecting them, and then do
   things like inject random-but-repeatable delays into the connection.
 

--- a/docs/source/reference-testing/across-realtime.py
+++ b/docs/source/reference-testing/across-realtime.py
@@ -41,8 +41,8 @@ async def task2():
 
 async def main():
     async with trio.open_nursery() as nursery:
-        nursery.spawn(task1)
-        nursery.spawn(task2)
+        nursery.start_soon(task1)
+        nursery.start_soon(task2)
 
 def run_example(clock):
     real_start = time.time()

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -869,7 +869,7 @@ thing, and then we'll discuss the pieces:
    :linenos:
 
 Let's start with ``echo_server``. As we'll see below, each time an
-echo client connects, our server will spawn a child task running
+echo client connects, our server will start a child task running
 ``echo_server``; there might be lots of these running at once if lots
 of clients are connected. Its job is to read data from its particular
 client, and then echo it back. It should be pretty straightforward to
@@ -909,7 +909,7 @@ But where do these ``echo_server`` tasks come from? An important part
 of writing a trio program is deciding how you want to organize your
 tasks. In the examples we've seen so far, this was simple, because the
 set of tasks was fixed. Here, we want to wait for clients to connect,
-and then spawn a new task for each one. The tricky part is that like
+and then start a new task for each one. The tricky part is that like
 we mentioned above, managing a nursery is a full time job: you don't
 want the task that has the nursery and is supervising the child tasks
 to do anything else, like listen for new connections.
@@ -923,7 +923,7 @@ and then *passes the nursery object to the child task*:
    :lineno-match:
    :pyobject: parent
 
-Now ``echo_listener`` can spawn "siblings" instead of children – even
+Now ``echo_listener`` can start "siblings" instead of children – even
 though the ``echo_listener`` is the one spawning ``echo_server``
 tasks, we end up with a task tree that looks like:
 

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -377,13 +377,13 @@ Now that we understand ``async with``, let's look at ``parent`` again:
 
 There are only 4 lines of code that really do anything here. On line
 17, we use :func:`trio.open_nursery` to get a "nursery" object, and
-then inside the ``async with`` block we call ``nursery.spawn`` twice,
+then inside the ``async with`` block we call ``nursery.start_soon`` twice,
 on lines 19 and 22. There are actually two ways to call an async
 function: the first one is the one we already saw, using ``await
-async_fn()``; the new one is ``nursery.spawn(async_fn)``: it asks trio
+async_fn()``; the new one is ``nursery.start_soon(async_fn)``: it asks trio
 to start running this async function, *but then returns immediately
 without waiting for the function to finish*. So after our two calls to
-``nursery.spawn``, ``child1`` and ``child2`` are now running in the
+``nursery.start_soon``, ``child1`` and ``child2`` are now running in the
 background. And then at line 25, the commented line, we hit the end of
 the ``async with`` block, and the nursery's ``__aexit__`` function
 runs. What this does is force ``parent`` to stop here and wait for all
@@ -402,7 +402,7 @@ parenting is a full-time job! Any given piece of code manage a nursery
 – which means opening it, spawning some children, and then sitting in
 ``__aexit__`` to supervise them – or it can do actual work, but you
 shouldn't try to do both at the same time in the same function. If you
-find yourself tempted to do some work in the parent, then ``spawn``
+find yourself tempted to do some work in the parent, then ``start_soon``
 another child and have it do the work. In trio, children are cheap.
 
 Ok! Let's try running it and see what we get:
@@ -827,7 +827,7 @@ I'm running on", so ``(127.0.0.1, PORT)`` means that we want to
 connect to whatever program on the current computer is using ``PORT``
 as its contact point. And then once the connection is made, we pass
 the connected client socket into the two child tasks. (This is also a
-good example of how ``nursery.spawn`` lets you pass positional
+good example of how ``nursery.start_soon`` lets you pass positional
 arguments to the spawned function.)
 
 Our first task's job is to send data to the server:

--- a/docs/source/tutorial/echo-client-low-level.py
+++ b/docs/source/tutorial/echo-client-low-level.py
@@ -35,9 +35,9 @@ async def parent():
         await client_sock.connect(("127.0.0.1", PORT))
         async with trio.open_nursery() as nursery:
             print("parent: spawning sender...")
-            nursery.spawn(sender, client_sock)
+            nursery.start_soon(sender, client_sock)
 
             print("parent: spawning receiver...")
-            nursery.spawn(receiver, client_sock)
+            nursery.start_soon(receiver, client_sock)
 
 trio.run(parent)

--- a/docs/source/tutorial/echo-server-low-level.py
+++ b/docs/source/tutorial/echo-server-low-level.py
@@ -42,11 +42,11 @@ async def echo_listener(nursery):
             server_sock, _ = await listen_sock.accept()
             print("echo_listener: got new connection, spawning echo_server")
             ident += 1
-            nursery.spawn(echo_server, server_sock, ident)
+            nursery.start_soon(echo_server, server_sock, ident)
 
 async def parent():
     async with trio.open_nursery() as nursery:
         print("parent: spawning echo_listener")
-        nursery.spawn(echo_listener, nursery)
+        nursery.start_soon(echo_listener, nursery)
 
 trio.run(parent)

--- a/docs/source/tutorial/tasks-intro.py
+++ b/docs/source/tutorial/tasks-intro.py
@@ -16,10 +16,10 @@ async def parent():
     print("parent: started!")
     async with trio.open_nursery() as nursery:
         print("parent: spawning child1...")
-        nursery.spawn(child1)
+        nursery.start_soon(child1)
 
         print("parent: spawning child2...")
-        nursery.spawn(child2)
+        nursery.start_soon(child2)
 
         print("parent: waiting for children to finish...")
         # -- we exit the nursery block here --

--- a/docs/source/tutorial/tasks-with-trace.py
+++ b/docs/source/tutorial/tasks-with-trace.py
@@ -16,10 +16,10 @@ async def parent():
     print("parent: started!")
     async with trio.open_nursery() as nursery:
         print("parent: spawning child1...")
-        nursery.spawn(child1)
+        nursery.start_soon(child1)
 
         print("parent: spawning child2...")
-        nursery.spawn(child2)
+        nursery.start_soon(child2)
 
         print("parent: waiting for children to finish...")
         # -- we exit the nursery block here --

--- a/notes-to-self/loopy.py
+++ b/notes-to-self/loopy.py
@@ -10,8 +10,8 @@ async def loopy():
         print("KI!")
 
 async def main():
-    await trio.spawn(loopy)
-    await trio.spawn(loopy)
-    await trio.spawn(loopy)
+    await trio.start_soon(loopy)
+    await trio.start_soon(loopy)
+    await trio.start_soon(loopy)
 
 trio.run(main)

--- a/notes-to-self/lots-of-tasks.py
+++ b/notes-to-self/lots-of-tasks.py
@@ -7,6 +7,6 @@ COUNT = int(COUNT_STR)
 async def main():
     async with trio.open_nursery() as nursery:
         for _ in range(COUNT):
-            nursery.spawn(trio.sleep, 1)
+            nursery.start_soon(trio.sleep, 1)
 
 trio.run(main)

--- a/notes-to-self/schedule-timing.py
+++ b/notes-to-self/schedule-timing.py
@@ -31,7 +31,7 @@ async def report_loop():
 
 async def main():
     async with trio.open_nursery() as nursery:
-        nursery.spawn(reschedule_loop, 10)
-        nursery.spawn(report_loop)
+        nursery.start_soon(reschedule_loop, 10)
+        nursery.start_soon(report_loop)
 
 trio.run(main)

--- a/notes-to-self/trivial-err.py
+++ b/notes-to-self/trivial-err.py
@@ -8,8 +8,8 @@ async def child1():
 
 async def child2():
     async with trio.open_nursery() as nursery:
-        nursery.spawn(grandchild1)
-        nursery.spawn(grandchild2)
+        nursery.start_soon(grandchild1)
+        nursery.start_soon(grandchild2)
 
 async def grandchild1():
     raise KeyError
@@ -19,8 +19,8 @@ async def grandchild2():
 
 async def main():
     async with trio.open_nursery() as nursery:
-        nursery.spawn(child1)
-        nursery.spawn(child2)
-        #nursery.spawn(grandchild1)
+        nursery.start_soon(child1)
+        nursery.start_soon(child2)
+        #nursery.start_soon(grandchild1)
 
 trio.run(main)

--- a/trio/__init__.py
+++ b/trio/__init__.py
@@ -76,6 +76,11 @@ from . import abc
 from . import ssl
 # Not imported by default: testing
 
+# Stuff that got moved:
+@_deprecate.deprecated("0.2.0", instead="trio.hazmat.current_task", issue=136)
+def current_task():
+    return hazmat.current_task()
+
 # Having the public path in .__module__ attributes is important for:
 # - exception names in printed tracebacks
 # - sphinx :show-inheritance:

--- a/trio/__init__.py
+++ b/trio/__init__.py
@@ -86,6 +86,12 @@ __deprecated_attributes__ = {
         _deprecate.DeprecatedAttribute(
             hazmat.current_task, "0.2.0", issue=136
         ),
+    "Result":
+        _deprecate.DeprecatedAttribute(hazmat.Result, "0.2.0", issue=136),
+    "Value":
+        _deprecate.DeprecatedAttribute(hazmat.Value, "0.2.0", issue=136),
+    "Error":
+        _deprecate.DeprecatedAttribute(hazmat.Error, "0.2.0", issue=136),
     "run_in_worker_thread":
         _deprecate.DeprecatedAttribute(
             run_sync_in_worker_thread, "0.2.0", issue=68

--- a/trio/__init__.py
+++ b/trio/__init__.py
@@ -92,6 +92,10 @@ __deprecated_attributes__ = {
         _deprecate.DeprecatedAttribute(hazmat.Value, "0.2.0", issue=136),
     "Error":
         _deprecate.DeprecatedAttribute(hazmat.Error, "0.2.0", issue=136),
+    "UnboundedQueue":
+        _deprecate.DeprecatedAttribute(
+            hazmat.UnboundedQueue, "0.2.0", issue=136
+        ),
     "run_in_worker_thread":
         _deprecate.DeprecatedAttribute(
             run_sync_in_worker_thread, "0.2.0", issue=68

--- a/trio/__init__.py
+++ b/trio/__init__.py
@@ -77,9 +77,20 @@ from . import ssl
 # Not imported by default: testing
 
 # Stuff that got moved:
-@_deprecate.deprecated("0.2.0", instead="trio.hazmat.current_task", issue=136)
-def current_task():
-    return hazmat.current_task()
+_deprecate.enable_attribute_deprecations(__name__)
+
+__deprecated_attributes__ = {
+    "Task":
+        _deprecate.DeprecatedAttribute(hazmat.Task, "0.2.0", issue=136),
+    "current_task":
+        _deprecate.DeprecatedAttribute(
+            hazmat.current_task, "0.2.0", issue=136
+        ),
+    "run_in_worker_thread":
+        _deprecate.DeprecatedAttribute(
+            run_sync_in_worker_thread, "0.2.0", issue=68
+        ),
+}
 
 # Having the public path in .__module__ attributes is important for:
 # - exception names in printed tracebacks

--- a/trio/_abc.py
+++ b/trio/_abc.py
@@ -91,7 +91,7 @@ class Instrument(metaclass=ABCMeta):
         """Called when the given task is created.
 
         Args:
-            task (trio.Task): The new task.
+            task (trio.hazmat.Task): The new task.
 
         """
 
@@ -102,7 +102,7 @@ class Instrument(metaclass=ABCMeta):
         runnable tasks ahead of it.
 
         Args:
-            task (trio.Task): The task that became runnable.
+            task (trio.hazmat.Task): The task that became runnable.
 
         """
 
@@ -110,7 +110,7 @@ class Instrument(metaclass=ABCMeta):
         """Called immediately before we resume running the given task.
 
         Args:
-            task (trio.Task): The task that is about to run.
+            task (trio.hazmat.Task): The task that is about to run.
 
         """
 
@@ -118,7 +118,7 @@ class Instrument(metaclass=ABCMeta):
         """Called when we return to the main run loop after a task has yielded.
 
         Args:
-            task (trio.Task): The task that just ran.
+            task (trio.hazmat.Task): The task that just ran.
 
         """
 
@@ -126,7 +126,7 @@ class Instrument(metaclass=ABCMeta):
         """Called when the given task exits.
 
         Args:
-            task (trio.Task): The finished task.
+            task (trio.hazmat.Task): The finished task.
 
         """
 

--- a/trio/_core/_local.py
+++ b/trio/_core/_local.py
@@ -62,13 +62,14 @@ class TaskLocal(_LocalBase):
     Instances of this class have no particular attributes or methods. Instead,
     they serve as a blank slate to which you can add whatever attributes you
     like. Modifications made within one task will only be visible to that task
-    – with one exception: when you ``spawn`` a new task, then any
-    :class:`TaskLocal` attributes that are visible in the spawning task will
-    be inherited by the child. This inheritance takes the form of a shallow
-    copy: further changes in the parent will *not* affect the child, and
-    changes in the child will not affect the parent. (If you're familiar with
-    how environment variables are inherited across processes, then
-    :class:`TaskLocal` inheritance is somewhat similar.)
+    – with one exception: when you start a new task, then any
+    :class:`TaskLocal` attributes that are visible in the task that called
+    ``start`` or ``start_soon`` will be inherited by the child. This
+    inheritance takes the form of a shallow copy: further changes in the
+    parent will *not* affect the child, and changes in the child will not
+    affect the parent. (If you're familiar with how environment variables are
+    inherited across processes, then :class:`TaskLocal` inheritance is
+    somewhat similar.)
 
     If you're familiar with :class:`threading.local`, then
     :class:`trio.TaskLocal` is very similar, except adapted to work with tasks

--- a/trio/_core/_parking_lot.py
+++ b/trio/_core/_parking_lot.py
@@ -183,7 +183,7 @@ class ParkingLot:
                lot1 = trio.hazmat.ParkingLot()
                lot2 = trio.hazmat.ParkingLot()
                async with trio.open_nursery() as nursery:
-                   nursery.spawn(lot1)
+                   nursery.start_soon(lot1)
                    await trio.testing.wait_all_tasks_blocked()
                    assert len(lot1) == 1
                    assert len(lot2) == 0

--- a/trio/_core/_result.py
+++ b/trio/_core/_result.py
@@ -1,9 +1,12 @@
 import abc
 import attr
 
+from . import _hazmat
+
 __all__ = ["Result", "Value", "Error"]
 
 
+@_hazmat
 @attr.s(slots=True, frozen=True)
 class Result(metaclass=abc.ABCMeta):
     """An abstract class representing the result of a Python computation.
@@ -81,6 +84,7 @@ class Result(metaclass=abc.ABCMeta):
         """
 
 
+@_hazmat
 @attr.s(slots=True, frozen=True, repr=False)
 class Value(Result):
     """Concrete :class:`Result` subclass representing a regular value.
@@ -103,6 +107,7 @@ class Value(Result):
         return await agen.asend(self.value)
 
 
+@_hazmat
 @attr.s(slots=True, frozen=True, repr=False)
 class Error(Result):
     """Concrete :class:`Result` subclass representing a raised exception.

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -385,8 +385,12 @@ class Nursery:
         GLOBAL_RUN_CONTEXT.runner.spawn_impl(async_fn, args, self, name)
 
     # Returns the task, unlike start_soon
-    @deprecated("0.2.0", thing="nursery.spawn", instead="nursery.start_soon",
-    issue=284)
+    @deprecated(
+        "0.2.0",
+        thing="nursery.spawn",
+        instead="nursery.start_soon",
+        issue=284
+    )
     def spawn(self, async_fn, *args, name=None):
         return GLOBAL_RUN_CONTEXT.runner.spawn_impl(async_fn, args, self, name)
 
@@ -1029,8 +1033,9 @@ class Runner:
                 self.call_soon_task, name="<call soon task>"
             )
 
-            self.main_task = self.spawn_impl(async_fn, args,
-                                             self.system_nursery, name=None)
+            self.main_task = self.spawn_impl(
+                async_fn, args, self.system_nursery, name=None
+            )
             async for task_batch in system_nursery._monitor:
                 for task in task_batch:
                     if task is self.main_task:

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -826,7 +826,8 @@ class Runner:
     @_public
     @_hazmat
     def reschedule(self, task, next_send=Value(None)):
-        """Reschedule the given task with the given :class:`~trio.Result`.
+        """Reschedule the given task with the given
+        :class:`~trio.hazmat.Result`.
 
         See :func:`yield_indefinitely` for the gory details.
 
@@ -838,7 +839,7 @@ class Runner:
         Args:
           task (trio.hazmat.Task): the task to be rescheduled. Must be blocked
             in a call to :func:`yield_indefinitely`.
-          next_send (trio.Result): the value (or error) to return (or
+          next_send (trio.hazmat.Result): the value (or error) to return (or
             raise) from :func:`yield_indefinitely`.
 
         """

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -856,7 +856,7 @@ class Runner:
         try:
             coro = async_fn(*args)
         except TypeError:
-            # Give good error for: nursery.spawn(trio.sleep(1))
+            # Give good error for: nursery.start_soon(trio.sleep(1))
             if inspect.iscoroutine(async_fn):
                 raise TypeError(
                     "trio was expecting an async function, but instead it got "
@@ -864,17 +864,17 @@ class Runner:
                     "\n"
                     "Probably you did something like:\n"
                     "\n"
-                    "  trio.run({async_fn.__name__}(...))       # incorrect!\n"
-                    "  nursery.spawn({async_fn.__name__}(...))  # incorrect!\n"
+                    "  trio.run({async_fn.__name__}(...))            # incorrect!\n"
+                    "  nursery.start_soon({async_fn.__name__}(...))  # incorrect!\n"
                     "\n"
                     "Instead, you want (notice the parentheses!):\n"
                     "\n"
-                    "  trio.run({async_fn.__name__}, ...)       # correct!\n"
-                    "  nursery.spawn({async_fn.__name__}, ...)  # correct!"
+                    "  trio.run({async_fn.__name__}, ...)            # correct!\n"
+                    "  nursery.start_soon({async_fn.__name__}, ...)  # correct!"
                     .format(async_fn=async_fn)
                 ) from None
 
-            # Give good error for: nursery.spawn(asyncio.sleep(1))
+            # Give good error for: nursery.start_soon(asyncio.sleep(1))
             if _return_value_looks_like_wrong_library(async_fn):
                 raise TypeError(
                     "trio was expecting an async function, but instead it got "
@@ -891,15 +891,15 @@ class Runner:
         # function. So we have to just call it and then check whether the
         # result is a coroutine object.
         if not inspect.iscoroutine(coro):
-            # Give good error for: nursery.spawn(asyncio.sleep, 1)
+            # Give good error for: nursery.start_soon(asyncio.sleep, 1)
             if _return_value_looks_like_wrong_library(coro):
                 raise TypeError(
-                    "spawn got unexpected {!r} – are you trying to use a "
+                    "start_soon got unexpected {!r} – are you trying to use a "
                     "library written for asyncio/twisted/tornado or similar? "
                     "That won't work without some sort of compatibility shim."
                     .format(coro)
                 )
-            # Give good error for: nursery.spawn(some_sync_fn)
+            # Give good error for: nursery.start_soon(some_sync_fn)
             raise TypeError(
                 "trio expected an async function, but {!r} appears to be "
                 "synchronous"
@@ -1264,7 +1264,7 @@ class Runner:
 
         Example:
           Here's an example of one way to test that trio's locks are fair: we
-          take the lock in the parent, spawn a child, wait for the child to be
+          take the lock in the parent, start a child, wait for the child to be
           blocked waiting for the lock (!), and then check that we can't
           release and immediately re-acquire the lock::
 
@@ -1276,7 +1276,7 @@ class Runner:
                  lock = trio.Lock()
                  await lock.acquire()
                  async with trio.open_nursery() as nursery:
-                     child = nursery.spawn(lock_taker, lock)
+                     child = nursery.start_soon(lock_taker, lock)
                      # child hasn't run yet, we have the lock
                      assert lock.locked()
                      assert lock._owner is trio.current_task()

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -386,7 +386,7 @@ class Nursery:
 
     # Returns the task, unlike start_soon
     @deprecated("0.2.0", thing="nursery.spawn", instead="nursery.start_soon",
-    issue=136)
+    issue=284)
     def spawn(self, async_fn, *args, name=None):
         return GLOBAL_RUN_CONTEXT.runner.spawn_impl(async_fn, args, self, name)
 

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -359,7 +359,7 @@ class Nursery:
         self._children = set()
         self._pending_starts = 0
         self._zombies = set()
-        self.monitor = _core.UnboundedQueue()
+        self._monitor = _core.UnboundedQueue()
         self._closed = False
 
     @property
@@ -367,19 +367,26 @@ class Nursery:
         return frozenset(self._children)
 
     @property
+    @deprecated("0.2.0", instead=None, issue=136)
     def zombies(self):
         return frozenset(self._zombies)
+
+    @property
+    @deprecated("0.2.0", instead=None, issue=136)
+    def monitor(self):
+        return self._monitor
 
     def _child_finished(self, task):
         self._children.remove(task)
         self._zombies.add(task)
-        self.monitor.put_nowait(task)
+        self._monitor.put_nowait(task)
 
     def start_soon(self, async_fn, *args, name=None):
         GLOBAL_RUN_CONTEXT.runner.spawn_impl(async_fn, args, self, name)
 
     # Returns the task, unlike start_soon
-    #@deprecated("nursery.spawn", version="0.2.0", "nursery.start_soon")
+    @deprecated("0.2.0", thing="nursery.spawn", instead="nursery.start_soon",
+    issue=136)
     def spawn(self, async_fn, *args, name=None):
         return GLOBAL_RUN_CONTEXT.runner.spawn_impl(async_fn, args, self, name)
 
@@ -402,17 +409,25 @@ class Nursery:
             return task_status._value
         finally:
             self._pending_starts -= 1
-            self.monitor.put_nowait(None)
+            self._monitor.put_nowait(None)
 
-    def reap(self, task):
+    def _reap(self, task):
         try:
             self._zombies.remove(task)
         except KeyError:
             raise ValueError("{} is not a zombie in this nursery".format(task))
 
+    @deprecated("0.2.0", instead=None, issue=136)
+    def reap(self, task):
+        return self._reap(task)
+
+    def _reap_and_unwrap(self, task):
+        self._reap(task)
+        return task._result.unwrap()
+
+    @deprecated("0.2.0", instead=None, issue=136)
     def reap_and_unwrap(self, task):
-        self.reap(task)
-        return task.result.unwrap()
+        return self._reap_and_unwrap(task)
 
     async def _clean_up(self, pending_exc):
         cancelled_children = False
@@ -435,22 +450,22 @@ class Nursery:
                 # of remaining tasks, so we have to check first before
                 # blocking on the monitor queue.
                 for task in list(self._zombies):
-                    if type(task.result) is Error:
-                        exceptions.append(task.result.error)
-                    self.reap(task)
+                    if type(task._result) is Error:
+                        exceptions.append(task._result.error)
+                    self._reap(task)
 
                 if exceptions and not cancelled_children:
                     self.cancel_scope.cancel()
                     clean_up_scope.shield = True
                     cancelled_children = True
 
-                if self.children or self._pending_starts:
+                if self._children or self._pending_starts:
                     try:
                         # We ignore the return value here, and will pick up
                         # the actual tasks from the zombies set after looping
                         # around. (E.g. it's possible there are tasks in the
                         # queue that were already reaped.)
-                        await self.monitor.get_batch()
+                        await self._monitor.get_batch()
                     except (Cancelled, KeyboardInterrupt) as exc:
                         exceptions.append(exc)
 
@@ -483,7 +498,7 @@ class Nursery:
                     raise mexc
 
     def __del__(self):
-        assert not self.children and not self.zombies
+        assert not self._children and not self._zombies
 
 
 ################################################################
@@ -513,7 +528,7 @@ class Task:
     # Invariant:
     # - for unfinished tasks, result is None
     # - for finished tasks, result is a Result object
-    result = attr.ib(default=None)
+    _result = attr.ib(default=None)
     # Invariant:
     # - for unscheduled tasks, _next_send is None
     # - for scheduled tasks, _next_send is a Result object
@@ -537,6 +552,11 @@ class Task:
     def __repr__(self):
         return ("<Task {!r} at {:#x}>".format(self.name, id(self)))
 
+    @property
+    @deprecated("0.2.0", instead=None, issue=136)
+    def result(self):
+        return self._result
+
     # For debugging and visualization:
     @property
     def parent_task(self):
@@ -555,6 +575,7 @@ class Task:
 
     _monitors = attr.ib(default=attr.Factory(set))
 
+    @deprecated("0.2.0", instead=None, issue=136)
     def add_monitor(self, queue):
         """Register to be notified when this task exits.
 
@@ -567,6 +588,9 @@ class Task:
           ValueError: if ``queue`` is already registered with this task
 
         """
+        return self._add_monitor(queue)
+
+    def _add_monitor(self, queue):
         # Rationale: (a) don't particularly want to create a
         # callback-in-disguise API by allowing people to stick in some
         # arbitrary object with a put_nowait method, (b) don't want to have to
@@ -577,11 +601,12 @@ class Task:
             raise TypeError("monitor must be an UnboundedQueue object")
         if queue in self._monitors:
             raise ValueError("can't add same monitor twice")
-        if self.result is not None:
+        if self._result is not None:
             queue.put_nowait(self)
         else:
             self._monitors.add(queue)
 
+    @deprecated("0.2.0", instead=None, issue=136)
     def discard_monitor(self, queue):
         """Unregister the given queue from being notified about this task
         exiting.
@@ -596,16 +621,17 @@ class Task:
 
         self._monitors.discard(queue)
 
+    @deprecated("0.2.0", instead=None, issue=136)
     async def wait(self):
         """Wait for this task to exit.
 
         """
         q = _core.UnboundedQueue()
-        self.add_monitor(q)
+        self._add_monitor(q)
         try:
             await q.get_batch()
         finally:
-            self.discard_monitor(q)
+            self._monitors.discard(q)
 
     ################
     # Cancellation
@@ -916,7 +942,7 @@ class Runner:
         return task
 
     def task_exited(self, task, result):
-        task.result = result
+        task._result = result
         while task._cancel_stack:
             task._cancel_stack[-1]._remove_task(task)
         self.tasks.remove(task)
@@ -1002,14 +1028,16 @@ class Runner:
             self.spawn_system_task(
                 self.call_soon_task, name="<call soon task>"
             )
-            self.main_task = system_nursery.spawn(async_fn, *args)
-            async for task_batch in system_nursery.monitor:
+
+            self.main_task = self.spawn_impl(async_fn, args,
+                                             self.system_nursery, name=None)
+            async for task_batch in system_nursery._monitor:
                 for task in task_batch:
                     if task is self.main_task:
                         system_nursery.cancel_scope.cancel()
-                        return system_nursery.reap_and_unwrap(task)
+                        return system_nursery._reap_and_unwrap(task)
                     else:
-                        system_nursery.reap_and_unwrap(task)
+                        system_nursery._reap_and_unwrap(task)
 
     ################
     # Outside Context Problems
@@ -1194,7 +1222,7 @@ class Runner:
         # same time -- so even if KI arrives before main_task is created, we
         # won't get here until afterwards.
         assert self.main_task is not None
-        if self.main_task.result is not None:
+        if self.main_task._result is not None:
             # We're already in the process of exiting -- leave ki_pending set
             # and we'll check it again on our way out of run().
             return
@@ -1606,7 +1634,7 @@ def run_impl(runner, async_fn, args):
             runner.instrument("after_task_step", task)
             del GLOBAL_RUN_CONTEXT.task
 
-    return runner.init_task.result
+    return runner.init_task._result
 
 
 ################################################################

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -532,6 +532,7 @@ def _pending_cancel_scope(cancel_stack):
     return pending_scope
 
 
+@_hazmat
 @attr.s(slots=True, cmp=False, hash=False, repr=False)
 class Task:
     _parent_nursery = attr.ib()
@@ -835,10 +836,10 @@ class Runner:
         to calling :func:`reschedule` once.)
 
         Args:
-          task (trio.Task): the task to be rescheduled. Must be blocked in a
-            call to :func:`yield_indefinitely`.
-          next_send (trio.Result): the value (or error) to return (or raise)
-            from :func:`yield_indefinitely`.
+          task (trio.hazmat.Task): the task to be rescheduled. Must be blocked
+            in a call to :func:`yield_indefinitely`.
+          next_send (trio.Result): the value (or error) to return (or
+            raise) from :func:`yield_indefinitely`.
 
         """
         assert task._runner is self
@@ -1688,6 +1689,7 @@ class _StatusIgnored:
 STATUS_IGNORED = _StatusIgnored()
 
 
+@_hazmat
 def current_task():
     """Return the :class:`Task` object representing the current task.
 

--- a/trio/_core/_traps.py
+++ b/trio/_core/_traps.py
@@ -66,7 +66,7 @@ def yield_indefinitely(abort_func):
     """Put the current task to sleep, with cancellation support.
 
     This is the lowest-level API for blocking in trio. Every time a
-    :class:`~trio.Task` blocks, it does so by calling this function.
+    :class:`~trio.hazmat.Task` blocks, it does so by calling this function.
 
     This is a tricky interface with no guard rails. If you can use
     :class:`ParkingLot` or the built-in I/O wait functions instead, then you

--- a/trio/_core/_unbounded_queue.py
+++ b/trio/_core/_unbounded_queue.py
@@ -14,6 +14,7 @@ class _UnboundedQueueStats:
     tasks_waiting = attr.ib()
 
 
+@_hazmat
 class UnboundedQueue:
     """An unbounded queue suitable for certain unusual forms of inter-task
     communication.
@@ -25,8 +26,8 @@ class UnboundedQueue:
     "batches". If a consumer task processes each batch without yielding, then
     this helps achieve (but does not guarantee) an effective bound on the
     queue's memory use, at the cost of potentially increasing system latencies
-    in general. You should generally prefer to use a :class:`Queue` instead if
-    you can.
+    in general. You should generally prefer to use a :class:`trio.Queue`
+    instead if you can.
 
     Currently each batch completely empties the queue, but `this may change in
     the future <https://github.com/python-trio/trio/issues/51>`__.
@@ -99,10 +100,10 @@ class UnboundedQueue:
         Returns:
           list: A list of dequeued items, in order. On a successful call this
               list is always non-empty; if it would be empty we raise
-              :exc:`WouldBlock` instead.
+              :exc:`~trio.WouldBlock` instead.
 
         Raises:
-          WouldBlock: if the queue is empty.
+          ~trio.WouldBlock: if the queue is empty.
 
         """
         if not self._can_get:

--- a/trio/_core/tests/test_epoll.py
+++ b/trio/_core/tests/test_epoll.py
@@ -41,11 +41,11 @@ async def test_epoll_statistics():
         fill_socket(a1)
         fill_socket(a3)
         async with _core.open_nursery() as nursery:
-            nursery.spawn(_core.wait_writable, a1)
-            nursery.spawn(_core.wait_readable, a2)
-            nursery.spawn(_core.wait_readable, b2)
-            nursery.spawn(_core.wait_writable, a3)
-            nursery.spawn(_core.wait_readable, a3)
+            nursery.start_soon(_core.wait_writable, a1)
+            nursery.start_soon(_core.wait_readable, a2)
+            nursery.start_soon(_core.wait_readable, b2)
+            nursery.start_soon(_core.wait_writable, a3)
+            nursery.start_soon(_core.wait_readable, a3)
 
             await wait_all_tasks_blocked()
 

--- a/trio/_core/tests/test_io.py
+++ b/trio/_core/tests/test_io.py
@@ -156,7 +156,7 @@ async def test_double_read(socketpair, wait_readable):
 
     # You can't have two tasks trying to read from a socket at the same time
     async with _core.open_nursery() as nursery:
-        nursery.spawn(wait_readable, a)
+        nursery.start_soon(wait_readable, a)
         await wait_all_tasks_blocked()
         with assert_yields():
             with pytest.raises(_core.ResourceBusyError):
@@ -171,7 +171,7 @@ async def test_double_write(socketpair, wait_writable):
     # You can't have two tasks trying to write to a socket at the same time
     fill_socket(a)
     async with _core.open_nursery() as nursery:
-        nursery.spawn(wait_writable, a)
+        nursery.start_soon(wait_writable, a)
         await wait_all_tasks_blocked()
         with assert_yields():
             with pytest.raises(_core.ResourceBusyError):

--- a/trio/_core/tests/test_ki.py
+++ b/trio/_core/tests/test_ki.py
@@ -62,7 +62,7 @@ async def test_ki_enabled():
     await aprotected()
 
     # make sure that the decorator here overrides the automatic manipulation
-    # that spawn() does:
+    # that start_soon() does:
     async with _core.open_nursery() as nursery:
         nursery.start_soon(aprotected)
         nursery.start_soon(aunprotected)

--- a/trio/_core/tests/test_ki.py
+++ b/trio/_core/tests/test_ki.py
@@ -252,7 +252,9 @@ def test_ki_protection_works():
         async with _core.open_nursery() as nursery:
             nursery.start_soon(sleeper, "s1", record)
             nursery.start_soon(sleeper, "s2", record)
-            nursery.start_soon(_core.enable_ki_protection(raiser), "r1", record)
+            nursery.start_soon(
+                _core.enable_ki_protection(raiser), "r1", record
+            )
             # __aexit__ blocks, and then receives the KI
 
     with pytest.raises(KeyboardInterrupt):

--- a/trio/_core/tests/test_ki.py
+++ b/trio/_core/tests/test_ki.py
@@ -64,8 +64,8 @@ async def test_ki_enabled():
     # make sure that the decorator here overrides the automatic manipulation
     # that spawn() does:
     async with _core.open_nursery() as nursery:
-        nursery.spawn(aprotected)
-        nursery.spawn(aunprotected)
+        nursery.start_soon(aprotected)
+        nursery.start_soon(aunprotected)
 
     @_core.enable_ki_protection
     def gen_protected():
@@ -235,9 +235,9 @@ def test_ki_protection_works():
 
     async def check_unprotected_kill():
         async with _core.open_nursery() as nursery:
-            nursery.spawn(sleeper, "s1", record)
-            nursery.spawn(sleeper, "s2", record)
-            nursery.spawn(raiser, "r1", record)
+            nursery.start_soon(sleeper, "s1", record)
+            nursery.start_soon(sleeper, "s2", record)
+            nursery.start_soon(raiser, "r1", record)
 
     with pytest.raises(KeyboardInterrupt):
         _core.run(check_unprotected_kill)
@@ -250,9 +250,9 @@ def test_ki_protection_works():
 
     async def check_protected_kill():
         async with _core.open_nursery() as nursery:
-            nursery.spawn(sleeper, "s1", record)
-            nursery.spawn(sleeper, "s2", record)
-            nursery.spawn(_core.enable_ki_protection(raiser), "r1", record)
+            nursery.start_soon(sleeper, "s1", record)
+            nursery.start_soon(sleeper, "s2", record)
+            nursery.start_soon(_core.enable_ki_protection(raiser), "r1", record)
             # __aexit__ blocks, and then receives the KI
 
     with pytest.raises(KeyboardInterrupt):

--- a/trio/_core/tests/test_local.py
+++ b/trio/_core/tests/test_local.py
@@ -40,7 +40,7 @@ async def test_local_smoketest():
             assert local.b == 2
 
         async with _core.open_nursery() as nursery:
-            nursery.spawn(child)
+            nursery.start_soon(child)
 
 
 async def test_local_isolation():
@@ -73,8 +73,8 @@ async def test_local_isolation():
             rlocal.a = "run child2"
 
     async with _core.open_nursery() as nursery:
-        nursery.spawn(child1)
-        nursery.spawn(child2)
+        nursery.start_soon(child1)
+        nursery.start_soon(child2)
 
     assert tlocal.a == "task root"
     assert rlocal.a == "run child2"
@@ -148,13 +148,13 @@ async def test_local_inheritance_from_spawner_not_supervisor():
 
     async def spawner(nursery):
         t.x = "spawner"
-        nursery.spawn(child)
+        nursery.start_soon(child)
 
     async def child():
         assert t.x == "spawner"
 
     async with _core.open_nursery() as nursery:
-        nursery.spawn(spawner, nursery)
+        nursery.start_soon(spawner, nursery)
 
 
 async def test_local_defaults():

--- a/trio/_core/tests/test_parking_lot.py
+++ b/trio/_core/tests/test_parking_lot.py
@@ -20,7 +20,7 @@ async def test_parking_lot_basic():
         assert len(lot) == 0
         assert lot.statistics().tasks_waiting == 0
         for i in range(3):
-            nursery.spawn(waiter, i, lot)
+            nursery.start_soon(waiter, i, lot)
         await wait_all_tasks_blocked()
         assert len(record) == 3
         assert bool(lot)
@@ -41,7 +41,7 @@ async def test_parking_lot_basic():
     async with _core.open_nursery() as nursery:
         record = []
         for i in range(3):
-            nursery.spawn(waiter, i, lot)
+            nursery.start_soon(waiter, i, lot)
             await wait_all_tasks_blocked()
         assert len(record) == 3
         for i in range(3):
@@ -66,7 +66,7 @@ async def test_parking_lot_basic():
     async with _core.open_nursery() as nursery:
         record = []
         for i in range(3):
-            nursery.spawn(waiter, i, lot)
+            nursery.start_soon(waiter, i, lot)
             await wait_all_tasks_blocked()
         lot.unpark(count=2)
         await wait_all_tasks_blocked()

--- a/trio/_core/tests/test_parking_lot.py
+++ b/trio/_core/tests/test_parking_lot.py
@@ -83,7 +83,7 @@ async def test_parking_lot_basic():
 
 async def cancellable_waiter(name, lot, scopes, record):
     with _core.open_cancel_scope() as scope:
-        scopes[_core.current_task()] = scope
+        scopes[name] = scope
         record.append("sleep {}".format(name))
         try:
             await lot.park()
@@ -99,15 +99,15 @@ async def test_parking_lot_cancel():
 
     async with _core.open_nursery() as nursery:
         lot = ParkingLot()
-        w1 = nursery.spawn(cancellable_waiter, 1, lot, scopes, record)
+        nursery.start_soon(cancellable_waiter, 1, lot, scopes, record)
         await wait_all_tasks_blocked()
-        w2 = nursery.spawn(cancellable_waiter, 2, lot, scopes, record)
+        nursery.start_soon(cancellable_waiter, 2, lot, scopes, record)
         await wait_all_tasks_blocked()
-        w3 = nursery.spawn(cancellable_waiter, 3, lot, scopes, record)
+        nursery.start_soon(cancellable_waiter, 3, lot, scopes, record)
         await wait_all_tasks_blocked()
         assert len(record) == 3
 
-        scopes[w2].cancel()
+        scopes[2].cancel()
         await wait_all_tasks_blocked()
         assert len(record) == 4
         lot.unpark_all()
@@ -135,11 +135,11 @@ async def test_parking_lot_repark():
         lot1.repark([])
 
     async with _core.open_nursery() as nursery:
-        w1 = nursery.spawn(cancellable_waiter, 1, lot1, scopes, record)
+        nursery.start_soon(cancellable_waiter, 1, lot1, scopes, record)
         await wait_all_tasks_blocked()
-        w2 = nursery.spawn(cancellable_waiter, 2, lot1, scopes, record)
+        nursery.start_soon(cancellable_waiter, 2, lot1, scopes, record)
         await wait_all_tasks_blocked()
-        w3 = nursery.spawn(cancellable_waiter, 3, lot1, scopes, record)
+        nursery.start_soon(cancellable_waiter, 3, lot1, scopes, record)
         await wait_all_tasks_blocked()
         assert len(record) == 3
 
@@ -156,7 +156,7 @@ async def test_parking_lot_repark():
         assert len(lot1) == 0
         assert len(lot2) == 2
 
-        scopes[w2].cancel()
+        scopes[2].cancel()
         await wait_all_tasks_blocked()
         assert len(lot2) == 1
         assert record == [
@@ -176,11 +176,11 @@ async def test_parking_lot_repark_with_count():
     lot1 = ParkingLot()
     lot2 = ParkingLot()
     async with _core.open_nursery() as nursery:
-        w1 = nursery.spawn(cancellable_waiter, 1, lot1, scopes, record)
+        nursery.start_soon(cancellable_waiter, 1, lot1, scopes, record)
         await wait_all_tasks_blocked()
-        w2 = nursery.spawn(cancellable_waiter, 2, lot1, scopes, record)
+        nursery.start_soon(cancellable_waiter, 2, lot1, scopes, record)
         await wait_all_tasks_blocked()
-        w3 = nursery.spawn(cancellable_waiter, 3, lot1, scopes, record)
+        nursery.start_soon(cancellable_waiter, 3, lot1, scopes, record)
         await wait_all_tasks_blocked()
         assert len(record) == 3
 

--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -1907,9 +1907,14 @@ async def test_some_deprecated_but_uncovered_methods(recwarn):
 
     async with _core.open_nursery() as nursery:
         assert not nursery.zombies
+        assert not nursery.children
+
         nursery.start_soon(noop)
+        assert len(nursery.children) == 1
+
         await wait_all_tasks_blocked()
         assert len(nursery.zombies) == 1
+        assert not nursery.children
 
         batch = await nursery.monitor.get_batch()
         for task in batch:

--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -127,6 +127,7 @@ async def test_child_crash_basic_deprecated(recwarn):
         assert task.result.error is exc
         nursery.reap(task)
 
+
 async def test_child_crash_basic_deprecated(recwarn):
     exc = ValueError("uh oh")
 
@@ -702,13 +703,13 @@ async def test_cancel_scope_multierror_filtering():
             try:
                 async with _core.open_nursery() as nursery:
                     # Two children that get cancelled by the nursery scope
-                    nursery.start_soon(child)    # t1
-                    nursery.start_soon(child)    # t2
+                    nursery.start_soon(child)  # t1
+                    nursery.start_soon(child)  # t2
                     nursery.cancel_scope.cancel()
                     with _core.open_cancel_scope(shield=True):
                         await wait_all_tasks_blocked()
                     # One child that gets cancelled by the outer scope
-                    nursery.start_soon(child)    # t3
+                    nursery.start_soon(child)  # t3
                     outer.cancel()
                     # And one that raises a different error
                     nursery.start_soon(crasher)  # t4

--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -115,6 +115,7 @@ async def test_nursery_warn_use_async_with():
         pass
 
 
+# can remove after 0.2.0
 async def test_child_crash_basic_deprecated(recwarn):
     exc = ValueError("uh oh")
 
@@ -1850,3 +1851,21 @@ async def test_nursery_start_keeps_nursery_open(autojump_clock):
             nursery1.start_soon(start_sleep_then_crash, nursery2)
             await wait_all_tasks_blocked()
         assert _core.current_time() - t0 == 7
+
+
+# can remove after 0.2.0
+async def test_some_deprecated_but_uncovered_methods(recwarn):
+    async def noop():
+        return 33
+
+    async with _core.open_nursery() as nursery:
+        assert not nursery.zombies
+        nursery.start_soon(noop)
+        await wait_all_tasks_blocked()
+        assert len(nursery.zombies) == 1
+
+        batch = await nursery.monitor.get_batch()
+        for task in batch:
+            assert nursery.reap_and_unwrap(task) == 33
+
+        assert not nursery.zombies

--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -128,7 +128,7 @@ async def test_child_crash_basic_deprecated(recwarn):
         nursery.reap(task)
 
 
-async def test_child_crash_basic_deprecated(recwarn):
+async def test_child_crash_basic(recwarn):
     exc = ValueError("uh oh")
 
     async def erroring():

--- a/trio/_core/tests/test_unbounded_queue.py
+++ b/trio/_core/tests/test_unbounded_queue.py
@@ -73,6 +73,7 @@ async def test_UnboundedQueue_fairness():
     assert q.get_batch_nowait() == [1, 2]
 
     result = None
+
     async def get_batch(q):
         nonlocal result
         result = await q.get_batch()

--- a/trio/_core/tests/test_unbounded_queue.py
+++ b/trio/_core/tests/test_unbounded_queue.py
@@ -49,7 +49,7 @@ async def test_UnboundedQueue_blocking():
     for consumer in (get_batch_consumer, aiter_consumer):
         record.clear()
         async with _core.open_nursery() as nursery:
-            task = nursery.spawn(consumer)
+            nursery.start_soon(consumer)
             await _core.wait_all_tasks_blocked()
             stats = q.statistics()
             assert stats.qsize == 0
@@ -72,16 +72,20 @@ async def test_UnboundedQueue_fairness():
     q.put_nowait(2)
     assert q.get_batch_nowait() == [1, 2]
 
+    result = None
+    async def get_batch(q):
+        nonlocal result
+        result = await q.get_batch()
+
     # But if someone else is waiting to read, then they get dibs
     async with _core.open_nursery() as nursery:
-        t = nursery.spawn(q.get_batch)
+        nursery.start_soon(get_batch, q)
         await _core.wait_all_tasks_blocked()
         q.put_nowait(3)
         q.put_nowait(4)
         with pytest.raises(_core.WouldBlock):
             q.get_batch_nowait()
-        await t.wait()
-        assert t.result.unwrap() == [3, 4]
+    assert result == [3, 4]
 
     # If two tasks are trying to read, they alternate
     record = []
@@ -91,9 +95,9 @@ async def test_UnboundedQueue_fairness():
             record.append((name, await q.get_batch()))
 
     async with _core.open_nursery() as nursery:
-        nursery.spawn(reader, "a")
+        nursery.start_soon(reader, "a")
         await _core.wait_all_tasks_blocked()
-        nursery.spawn(reader, "b")
+        nursery.start_soon(reader, "b")
         await _core.wait_all_tasks_blocked()
 
         for i in range(20):
@@ -129,17 +133,15 @@ async def test_UnboundedQueue_no_spurious_wakeups():
 
     async with _core.open_nursery() as nursery:
         q = _core.UnboundedQueue()
-        t1 = nursery.spawn(getter, q, 1)
+        nursery.start_soon(getter, q, 1)
         await wait_all_tasks_blocked()
-        t2 = nursery.spawn(getter, q, 2)
+        nursery.start_soon(getter, q, 2)
         await wait_all_tasks_blocked()
 
         for i in range(10):
             q.put_nowait(i)
         await wait_all_tasks_blocked()
 
-        assert t1.result is not None
-        assert t2.result is None
         assert record == [(1, list(range(10)))]
 
         nursery.cancel_scope.cancel()

--- a/trio/_core/tests/test_windows.py
+++ b/trio/_core/tests/test_windows.py
@@ -24,7 +24,7 @@ async def test_completion_key_listen():
 
     with _core.monitor_completion_key() as (key, queue):
         async with _core.open_nursery() as nursery:
-            task = nursery.spawn(post, key)
+            nursery.start_soon(post, key)
             i = 0
             print("loop")
             async for batch in queue:  # pragma: no branch

--- a/trio/_highlevel_open_tcp_stream.py
+++ b/trio/_highlevel_open_tcp_stream.py
@@ -272,7 +272,7 @@ async def open_tcp_stream(
 
         # Then kick off the next attempt.
         this_attempt_failed = trio.Event()
-        nursery.spawn(attempt_connect, nursery, this_attempt_failed)
+        nursery.start_soon(attempt_connect, nursery, this_attempt_failed)
 
         # Then make this invocation's attempt
         try:
@@ -293,7 +293,7 @@ async def open_tcp_stream(
 
     # Kick off the chain of connection attempts.
     async with trio.open_nursery() as nursery:
-        nursery.spawn(attempt_connect, nursery, None)
+        nursery.start_soon(attempt_connect, nursery, None)
 
     # All connection attempts complete, and no unexpected errors escaped. So
     # at this point the oserrors and winning_sockets lists are filled in.

--- a/trio/_signals.py
+++ b/trio/_signals.py
@@ -113,10 +113,7 @@ def catch_signals(signals):
 
     The async iterator blocks until at least one signal has arrived, and then
     yields a :class:`set` containing all of the signals that were received
-    since the last iteration. (This is generally similar to how
-    :class:`UnboundedQueue` works, but since Unix semantics are that identical
-    signals can/should be coalesced, here we use a :class:`set` for storage
-    instead of a :class:`list`.)
+    since the last iteration.
 
     Note that if you leave the ``with`` block while the iterator has
     unextracted signals still pending inside it, then they will be

--- a/trio/_socket.py
+++ b/trio/_socket.py
@@ -394,7 +394,6 @@ def real_socket_type(type_num):
     return type_num & _SOCK_TYPE_MASK
 
 
-@_add_to_all
 class _SocketType:
     def __init__(self, sock):
         if type(sock) is not _stdlib_socket.socket:

--- a/trio/_sync.py
+++ b/trio/_sync.py
@@ -808,8 +808,7 @@ class Queue:
     """A bounded queue suitable for inter-task communication.
 
     This class is generally modelled after :class:`queue.Queue`, but with the
-    major difference that it is always bounded. For an unbounded queue, see
-    :class:`trio.UnboundedQueue`.
+    major difference that it is always bounded.
 
     A :class:`Queue` object can be used as an asynchronous iterator, that
     dequeues objects one at a time. I.e., these two loops are equivalent::

--- a/trio/_sync.py
+++ b/trio/_sync.py
@@ -232,8 +232,8 @@ class CapacityLimiter:
         blocking.
 
         Args:
-          borrower: A :class:`Task` or arbitrary opaque object used to record
-             who is borrowing this token. This is used by
+          borrower: A :class:`trio.hazmat.Task` or arbitrary opaque object
+             used to record who is borrowing this token. This is used by
              :func:`run_sync_in_worker_thread` to allow threads to "hold
              tokens", with the intention in the future of using it to `allow
              deadlock detection and other useful things
@@ -272,8 +272,8 @@ class CapacityLimiter:
         necessary.
 
         Args:
-          borrower: A :class:`Task` or arbitrary opaque object used to record
-             who is borrowing this token; see
+          borrower: A :class:`trio.hazmat.Task` or arbitrary opaque object
+             used to record who is borrowing this token; see
              :meth:`acquire_on_behalf_of_nowait` for details.
 
         Raises:
@@ -579,8 +579,8 @@ class Lock:
         Currently the following fields are defined:
 
         * ``locked``: boolean indicating whether the lock is held.
-        * ``owner``: the :class:`Task` currently holding the lock, or None if
-          the lock is not held.
+        * ``owner``: the :class:`trio.hazmat.Task` currently holding the lock,
+          or None if the lock is not held.
         * ``tasks_waiting``: The number of tasks blocked on this lock's
           :meth:`acquire` method.
 

--- a/trio/_threads.py
+++ b/trio/_threads.py
@@ -13,7 +13,6 @@ __all__ = [
     "current_run_in_trio_thread",
     "run_sync_in_worker_thread",
     "current_default_worker_thread_limiter",
-    "run_in_worker_thread",
 ]
 
 
@@ -340,8 +339,3 @@ async def run_sync_in_worker_thread(
             return _core.Abort.FAILED
 
     return await _core.yield_indefinitely(abort)
-
-
-run_in_worker_thread = deprecated_alias(
-    "run_in_worker_thread", run_sync_in_worker_thread, "0.2.0", issue=68
-)

--- a/trio/socket.py
+++ b/trio/socket.py
@@ -6,3 +6,14 @@
 # here.
 from ._socket import *
 from ._socket import __all__
+
+from . import _deprecate
+from ._socket import _SocketType
+_deprecate.enable_attribute_deprecations(__name__)
+__deprecated_attributes__ = {
+    "SocketType":
+        _deprecate.DeprecatedAttribute(
+            _SocketType, "0.2.0", issue=170, instead="is_trio_socket"
+        )
+}
+del _deprecate, _SocketType

--- a/trio/testing/_check_streams.py
+++ b/trio/testing/_check_streams.py
@@ -82,8 +82,8 @@ async def check_one_way_stream(stream_maker, clogged_stream_maker):
 
         # Simple sending/receiving
         async with _core.open_nursery() as nursery:
-            nursery.spawn(do_send_all, b"x")
-            nursery.spawn(checked_receive_1, b"x")
+            nursery.start_soon(do_send_all, b"x")
+            nursery.start_soon(checked_receive_1, b"x")
 
         async def send_empty_then_y():
             # Streams should tolerate sending b"" without giving it any
@@ -92,19 +92,19 @@ async def check_one_way_stream(stream_maker, clogged_stream_maker):
             await do_send_all(b"y")
 
         async with _core.open_nursery() as nursery:
-            nursery.spawn(send_empty_then_y)
-            nursery.spawn(checked_receive_1, b"y")
+            nursery.start_soon(send_empty_then_y)
+            nursery.start_soon(checked_receive_1, b"y")
 
         ### Checking various argument types
 
         # send_all accepts bytearray and memoryview
         async with _core.open_nursery() as nursery:
-            nursery.spawn(do_send_all, bytearray(b"1"))
-            nursery.spawn(checked_receive_1, b"1")
+            nursery.start_soon(do_send_all, bytearray(b"1"))
+            nursery.start_soon(checked_receive_1, b"1")
 
         async with _core.open_nursery() as nursery:
-            nursery.spawn(do_send_all, memoryview(b"2"))
-            nursery.spawn(checked_receive_1, b"2")
+            nursery.start_soon(do_send_all, memoryview(b"2"))
+            nursery.start_soon(checked_receive_1, b"2")
 
         # max_bytes must be a positive integer
         with _assert_raises(ValueError):
@@ -116,8 +116,8 @@ async def check_one_way_stream(stream_maker, clogged_stream_maker):
 
         with _assert_raises(_core.ResourceBusyError):
             async with _core.open_nursery() as nursery:
-                nursery.spawn(do_receive_some, 1)
-                nursery.spawn(do_receive_some, 1)
+                nursery.start_soon(do_receive_some, 1)
+                nursery.start_soon(do_receive_some, 1)
 
         # Method always has to exist, and an empty stream with a blocked
         # receive_some should *always* allow send_all. (Technically it's legal
@@ -130,11 +130,11 @@ async def check_one_way_stream(stream_maker, clogged_stream_maker):
             scope.cancel()
 
         async with _core.open_nursery() as nursery:
-            nursery.spawn(
+            nursery.start_soon(
                 simple_check_wait_send_all_might_not_block,
                 nursery.cancel_scope
             )
-            nursery.spawn(do_receive_some, 1)
+            nursery.start_soon(do_receive_some, 1)
 
         # closing the r side leads to BrokenStreamError on the s side
         # (eventually)
@@ -144,8 +144,8 @@ async def check_one_way_stream(stream_maker, clogged_stream_maker):
                     await do_send_all(b"x" * 100)
 
         async with _core.open_nursery() as nursery:
-            nursery.spawn(expect_broken_stream_on_send)
-            nursery.spawn(do_aclose, r)
+            nursery.start_soon(expect_broken_stream_on_send)
+            nursery.start_soon(do_aclose, r)
 
         # once detected, the stream stays broken
         with _assert_raises(BrokenStreamError):
@@ -192,8 +192,8 @@ async def check_one_way_stream(stream_maker, clogged_stream_maker):
             await do_aclose(r)
 
         async with _core.open_nursery() as nursery:
-            nursery.spawn(send_then_close)
-            nursery.spawn(receive_send_then_close)
+            nursery.start_soon(send_then_close)
+            nursery.start_soon(receive_send_then_close)
 
     async with _ForceCloseBoth(await stream_maker()) as (s, r):
         await aclose_forcefully(r)
@@ -252,12 +252,12 @@ async def check_one_way_stream(stream_maker, clogged_stream_maker):
         with _core.open_cancel_scope() as scope:
             scope.cancel()
             async with _core.open_nursery() as nursery:
-                nursery.spawn(expect_cancelled, do_send_all, b"x")
-                nursery.spawn(expect_cancelled, do_receive_some, 1)
+                nursery.start_soon(expect_cancelled, do_send_all, b"x")
+                nursery.start_soon(expect_cancelled, do_receive_some, 1)
 
         async with _core.open_nursery() as nursery:
-            nursery.spawn(do_aclose, s)
-            nursery.spawn(do_aclose, r)
+            nursery.start_soon(do_aclose, s)
+            nursery.start_soon(do_aclose, r)
 
     # check wait_send_all_might_not_block, if we can
     if clogged_stream_maker is not None:
@@ -279,9 +279,9 @@ async def check_one_way_stream(stream_maker, clogged_stream_maker):
                     await r.receive_some(16834)
 
             async with _core.open_nursery() as nursery:
-                nursery.spawn(waiter, nursery.cancel_scope)
+                nursery.start_soon(waiter, nursery.cancel_scope)
                 await _core.wait_all_tasks_blocked()
-                nursery.spawn(receiver)
+                nursery.start_soon(receiver)
 
             assert record == [
                 "waiter sleeping",
@@ -293,8 +293,8 @@ async def check_one_way_stream(stream_maker, clogged_stream_maker):
             # simultaneous wait_send_all_might_not_block fails
             with _assert_raises(_core.ResourceBusyError):
                 async with _core.open_nursery() as nursery:
-                    nursery.spawn(s.wait_send_all_might_not_block)
-                    nursery.spawn(s.wait_send_all_might_not_block)
+                    nursery.start_soon(s.wait_send_all_might_not_block)
+                    nursery.start_soon(s.wait_send_all_might_not_block)
 
             # and simultaneous send_all and wait_send_all_might_not_block (NB
             # this test might destroy the stream b/c we end up cancelling
@@ -302,16 +302,16 @@ async def check_one_way_stream(stream_maker, clogged_stream_maker):
             # recreate afterwards)
             with _assert_raises(_core.ResourceBusyError):
                 async with _core.open_nursery() as nursery:
-                    nursery.spawn(s.wait_send_all_might_not_block)
-                    nursery.spawn(s.send_all, b"123")
+                    nursery.start_soon(s.wait_send_all_might_not_block)
+                    nursery.start_soon(s.send_all, b"123")
 
         async with _ForceCloseBoth(await clogged_stream_maker()) as (s, r):
             # send_all and send_all blocked simultaneously should also raise
             # (but again this might destroy the stream)
             with _assert_raises(_core.ResourceBusyError):
                 async with _core.open_nursery() as nursery:
-                    nursery.spawn(s.send_all, b"123")
-                    nursery.spawn(s.send_all, b"123")
+                    nursery.start_soon(s.send_all, b"123")
+                    nursery.start_soon(s.send_all, b"123")
 
         # closing the receiver causes wait_send_all_might_not_block to return
         async with _ForceCloseBoth(await clogged_stream_maker()) as (s, r):
@@ -327,8 +327,8 @@ async def check_one_way_stream(stream_maker, clogged_stream_maker):
                 await aclose_forcefully(r)
 
             async with _core.open_nursery() as nursery:
-                nursery.spawn(sender)
-                nursery.spawn(receiver)
+                nursery.start_soon(sender)
+                nursery.start_soon(receiver)
 
         # and again with the call starting after the close
         async with _ForceCloseBoth(await clogged_stream_maker()) as (s, r):
@@ -398,18 +398,18 @@ async def check_two_way_stream(stream_maker, clogged_stream_maker):
             assert got == data
 
         async with _core.open_nursery() as nursery:
-            nursery.spawn(sender, s1, test_data, 0)
-            nursery.spawn(sender, s2, test_data[::-1], 1)
-            nursery.spawn(receiver, s1, test_data[::-1], 2)
-            nursery.spawn(receiver, s2, test_data, 3)
+            nursery.start_soon(sender, s1, test_data, 0)
+            nursery.start_soon(sender, s2, test_data[::-1], 1)
+            nursery.start_soon(receiver, s1, test_data[::-1], 2)
+            nursery.start_soon(receiver, s2, test_data, 3)
 
         async def expect_receive_some_empty():
             assert await s2.receive_some(10) == b""
             await s2.aclose()
 
         async with _core.open_nursery() as nursery:
-            nursery.spawn(expect_receive_some_empty)
-            nursery.spawn(s1.aclose)
+            nursery.start_soon(expect_receive_some_empty)
+            nursery.start_soon(s1.aclose)
 
 
 async def check_half_closeable_stream(stream_maker, clogged_stream_maker):
@@ -442,8 +442,8 @@ async def check_half_closeable_stream(stream_maker, clogged_stream_maker):
             assert await r.receive_some(10) == b""
 
         async with _core.open_nursery() as nursery:
-            nursery.spawn(send_x_then_eof, s1)
-            nursery.spawn(expect_x_then_eof, s2)
+            nursery.start_soon(send_x_then_eof, s1)
+            nursery.start_soon(expect_x_then_eof, s2)
 
         # now sending is disallowed
         with _assert_raises(ClosedStreamError):
@@ -455,8 +455,8 @@ async def check_half_closeable_stream(stream_maker, clogged_stream_maker):
 
         # and we can still send stuff back the other way
         async with _core.open_nursery() as nursery:
-            nursery.spawn(send_x_then_eof, s2)
-            nursery.spawn(expect_x_then_eof, s1)
+            nursery.start_soon(send_x_then_eof, s2)
+            nursery.start_soon(expect_x_then_eof, s1)
 
     if clogged_stream_maker is not None:
         async with _ForceCloseBoth(await clogged_stream_maker()) as (s1, s2):
@@ -466,7 +466,7 @@ async def check_half_closeable_stream(stream_maker, clogged_stream_maker):
                     t = nursery.spawn(s1.send_all, b"x")
                     await _core.wait_all_tasks_blocked()
                     assert t.result is None
-                    nursery.spawn(s1.send_eof)
+                    nursery.start_soon(s1.send_eof)
 
         async with _ForceCloseBoth(await clogged_stream_maker()) as (s1, s2):
             # wait_send_all_might_not_block and send_eof simultaneously is not
@@ -476,4 +476,4 @@ async def check_half_closeable_stream(stream_maker, clogged_stream_maker):
                     t = nursery.spawn(s1.wait_send_all_might_not_block)
                     await _core.wait_all_tasks_blocked()
                     assert t.result is None
-                    nursery.spawn(s1.send_eof)
+                    nursery.start_soon(s1.send_eof)

--- a/trio/testing/_memory_streams.py
+++ b/trio/testing/_memory_streams.py
@@ -400,8 +400,8 @@ def memory_stream_pair():
                 print(data)
 
         async with trio.open_nursery() as nursery:
-            nursery.spawn(sender)
-            nursery.spawn(receiver)
+            nursery.start_soon(sender)
+            nursery.start_soon(receiver)
 
     By default, this will print ``b"12345"`` and then immediately exit; with
     our trickle stream it instead sleeps 1 second, then prints ``b"1"``, then

--- a/trio/testing/_sequencer.py
+++ b/trio/testing/_sequencer.py
@@ -45,9 +45,9 @@ class Sequencer:
          async def main():
             seq = trio.testing.Sequencer()
             async with trio.open_nursery() as nursery:
-                nursery.spawn(worker1, seq)
-                nursery.spawn(worker2, seq)
-                nursery.spawn(worker3, seq)
+                nursery.start_soon(worker1, seq)
+                nursery.start_soon(worker2, seq)
+                nursery.start_soon(worker3, seq)
 
     """
 

--- a/trio/tests/module_with_deprecations.py
+++ b/trio/tests/module_with_deprecations.py
@@ -1,0 +1,21 @@
+regular = "hi"
+
+from .. import _deprecate
+
+_deprecate.enable_attribute_deprecations(__name__)
+
+__deprecated_attributes__ = {
+    "dep1":
+        _deprecate.DeprecatedAttribute(
+            "value1",
+            "1.1",
+            issue=1,
+        ),
+    "dep2":
+        _deprecate.DeprecatedAttribute(
+            "value2",
+            "1.2",
+            issue=1,
+            instead="instead-string",
+        ),
+}

--- a/trio/tests/test_highlevel_serve_listeners.py
+++ b/trio/tests/test_highlevel_serve_listeners.py
@@ -128,7 +128,7 @@ async def test_serve_listeners_connection_nursery(autojump_clock):
         async with trio.open_nursery() as nursery:
             task_status.started(nursery)
             await wait_all_tasks_blocked()
-            assert len(nursery.children) == 10
+            assert len(nursery.child_tasks) == 10
             raise Done
 
     with pytest.raises(Done):

--- a/trio/tests/test_highlevel_socket.py
+++ b/trio/tests/test_highlevel_socket.py
@@ -66,8 +66,8 @@ async def fill_stream(s):
         nursery.cancel_scope.cancel()
 
     async with _core.open_nursery() as nursery:
-        nursery.spawn(sender)
-        nursery.spawn(waiter, nursery)
+        nursery.start_soon(sender)
+        nursery.start_soon(waiter, nursery)
 
 
 async def test_SocketStream_generic():

--- a/trio/tests/test_socket.py
+++ b/trio/tests/test_socket.py
@@ -368,8 +368,7 @@ async def test_SocketType_simple_server(address, socket_type):
         addr = listener.getsockname()[:2]
         async with _core.open_nursery() as nursery:
             nursery.start_soon(client.connect, addr)
-            accept_task = nursery.spawn(listener.accept)
-        server, client_addr = accept_task.result.unwrap()
+            server, client_addr = await listener.accept()
         with server:
             assert client_addr == server.getpeername() == client.getsockname()
             await server.send(b"x")

--- a/trio/tests/test_socket.py
+++ b/trio/tests/test_socket.py
@@ -229,8 +229,8 @@ async def test_socketpair_simple():
     a, b = tsocket.socketpair()
     with a, b:
         async with _core.open_nursery() as nursery:
-            nursery.spawn(child, a)
-            nursery.spawn(child, b)
+            nursery.start_soon(child, a)
+            nursery.start_soon(child, b)
 
 
 @pytest.mark.skipif(not hasattr(tsocket, "fromshare"), reason="windows only")
@@ -367,7 +367,7 @@ async def test_SocketType_simple_server(address, socket_type):
         listener.listen(20)
         addr = listener.getsockname()[:2]
         async with _core.open_nursery() as nursery:
-            nursery.spawn(client.connect, addr)
+            nursery.start_soon(client.connect, addr)
             accept_task = nursery.spawn(listener.accept)
         server, client_addr = accept_task.result.unwrap()
         with server:
@@ -498,7 +498,7 @@ async def test_SocketType_non_blocking_paths():
                 assert await ta.recv(10) == b"2"
 
         async with _core.open_nursery() as nursery:
-            nursery.spawn(do_successful_blocking_recv)
+            nursery.start_soon(do_successful_blocking_recv)
             await wait_all_tasks_blocked()
             b.send(b"2")
         # block then cancelled
@@ -508,7 +508,7 @@ async def test_SocketType_non_blocking_paths():
                     await ta.recv(10)
 
         async with _core.open_nursery() as nursery:
-            nursery.spawn(do_cancelled_blocking_recv)
+            nursery.start_soon(do_cancelled_blocking_recv)
             await wait_all_tasks_blocked()
             nursery.cancel_scope.cancel()
         # Okay, here's the trickiest one: we want to exercise the path where
@@ -533,8 +533,8 @@ async def test_SocketType_non_blocking_paths():
                 assert await ta.recv(1) == b"a"
 
         async with _core.open_nursery() as nursery:
-            nursery.spawn(t1)
-            nursery.spawn(t2)
+            nursery.start_soon(t1)
+            nursery.start_soon(t2)
             await wait_all_tasks_blocked()
             a.send(b"b")
             b.send(b"a")
@@ -736,8 +736,8 @@ async def test_SocketType_sendall(recwarn):
             assert nbytes == BIG
 
         async with _core.open_nursery() as nursery:
-            nursery.spawn(sender)
-            nursery.spawn(receiver)
+            nursery.start_soon(sender)
+            nursery.start_soon(receiver)
 
         # We know that we received BIG bytes of NULs so far. Make sure that
         # was all the data in there.

--- a/trio/tests/test_socket.py
+++ b/trio/tests/test_socket.py
@@ -6,7 +6,7 @@ import inspect
 
 from .. import _core
 from .. import socket as tsocket
-from .._socket import _NUMERIC_ONLY, _try_sync
+from .._socket import _NUMERIC_ONLY, _try_sync, _SocketType
 from ..testing import assert_yields, wait_all_tasks_blocked
 
 ################################################################
@@ -248,12 +248,12 @@ async def test_fromshare():
 
 async def test_socket():
     with tsocket.socket() as s:
-        assert isinstance(s, tsocket._SocketType)
+        assert isinstance(s, _SocketType)
         assert tsocket.is_trio_socket(s)
         assert s.family == tsocket.AF_INET
 
     with tsocket.socket(tsocket.AF_INET6, tsocket.SOCK_DGRAM) as s:
-        assert isinstance(s, tsocket._SocketType)
+        assert isinstance(s, _SocketType)
         assert tsocket.is_trio_socket(s)
         assert s.family == tsocket.AF_INET6
 
@@ -319,7 +319,8 @@ async def test_SocketType_dup():
     with a, b:
         a2 = a.dup()
         with a2:
-            assert isinstance(a2, tsocket._SocketType)
+            assert isinstance(a2, _SocketType)
+            assert tsocket.is_trio_socket(a2)
             assert a2.fileno() != a.fileno()
             a.close()
             await a2.send(b"x")

--- a/trio/tests/test_sync.py
+++ b/trio/tests/test_sync.py
@@ -173,6 +173,7 @@ async def test_Semaphore():
     s.acquire_nowait()
 
     record = []
+
     async def do_acquire(s):
         record.append("started")
         await s.acquire()
@@ -242,6 +243,7 @@ async def test_Lock_and_StrictFIFOLock(lockcls):
         l.release()
 
     holder_task = None
+
     async def holder():
         nonlocal holder_task
         holder_task = _core.current_task()
@@ -313,6 +315,7 @@ async def test_Condition():
         c.notify_all()
 
     finished_waiters = set()
+
     async def waiter(i):
         async with c:
             await c.wait()
@@ -406,6 +409,7 @@ async def test_Queue_join():
         await q.join()
 
     record = []
+
     async def do_join(q):
         record.append("started")
         await q.join()
@@ -426,6 +430,7 @@ async def test_Queue_join():
         q.task_done()
 
     assert record == ["started", "started", "finished", "finished"]
+
 
 async def test_Queue_iter():
     q = Queue(1)
@@ -503,6 +508,7 @@ async def test_Queue_fairness():
     q = Queue(1)
 
     result = None
+
     async def do_get(q):
         nonlocal result
         result = await q.get()

--- a/trio/tests/test_sync.py
+++ b/trio/tests/test_sync.py
@@ -126,7 +126,7 @@ async def test_CapacityLimiter_change_total_tokens():
 
     async with _core.open_nursery() as nursery:
         for i in range(5):
-            nursery.spawn(c.acquire_on_behalf_of, i)
+            nursery.start_soon(c.acquire_on_behalf_of, i)
             await wait_all_tasks_blocked()
         assert set(c.statistics().borrowers) == {0, 1}
         assert c.statistics().tasks_waiting == 3
@@ -259,7 +259,7 @@ async def test_Lock_and_StrictFIFOLock(lockcls):
         assert statistics.owner is t
         assert statistics.tasks_waiting == 0
 
-        nursery.spawn(holder)
+        nursery.start_soon(holder)
         await wait_all_tasks_blocked()
         statistics = l.statistics()
         print(statistics)
@@ -432,8 +432,8 @@ async def test_Queue_iter():
             assert item == next(expected)
 
     async with _core.open_nursery() as nursery:
-        nursery.spawn(producer)
-        nursery.spawn(consumer)
+        nursery.start_soon(producer)
+        nursery.start_soon(consumer)
 
 
 async def test_Queue_statistics():
@@ -450,9 +450,9 @@ async def test_Queue_statistics():
         q.put_nowait(2)
         q.put_nowait(3)
         assert q.full()
-        nursery.spawn(q.put, 4)
-        nursery.spawn(q.put, 5)
-        nursery.spawn(q.join)
+        nursery.start_soon(q.put, 4)
+        nursery.start_soon(q.put, 5)
+        nursery.start_soon(q.join)
         await wait_all_tasks_blocked()
         statistics = q.statistics()
         assert statistics.qsize == 3
@@ -464,9 +464,9 @@ async def test_Queue_statistics():
 
     q = Queue(4)
     async with _core.open_nursery() as nursery:
-        nursery.spawn(q.get)
-        nursery.spawn(q.get)
-        nursery.spawn(q.get)
+        nursery.start_soon(q.get)
+        nursery.start_soon(q.get)
+        nursery.start_soon(q.get)
         await wait_all_tasks_blocked()
         statistics = q.statistics()
         assert statistics.qsize == 0
@@ -602,7 +602,7 @@ async def test_generic_lock_exclusion(lock_factory):
     async with _core.open_nursery() as nursery:
         lock_like = lock_factory()
         for _ in range(WORKERS):
-            nursery.spawn(worker, lock_like)
+            nursery.start_soon(worker, lock_like)
     assert not in_critical_section
     assert acquires == LOOPS * WORKERS
 
@@ -624,9 +624,9 @@ async def test_generic_lock_fifo_fairness(lock_factory):
 
     lock_like = lock_factory()
     async with _core.open_nursery() as nursery:
-        nursery.spawn(loopy, 1, lock_like)
-        nursery.spawn(loopy, 2, lock_like)
-        nursery.spawn(loopy, 3, lock_like)
+        nursery.start_soon(loopy, 1, lock_like)
+        nursery.start_soon(loopy, 2, lock_like)
+        nursery.start_soon(loopy, 3, lock_like)
     # The first three could be in any order due to scheduling randomness,
     # but after that they should repeat in the same order
     for i in range(LOOPS):

--- a/trio/tests/test_sync.py
+++ b/trio/tests/test_sync.py
@@ -28,8 +28,8 @@ async def test_Event():
         record.append("woken")
 
     async with _core.open_nursery() as nursery:
-        t1 = nursery.spawn(child)
-        t2 = nursery.spawn(child)
+        nursery.start_soon(child)
+        nursery.start_soon(child)
         await wait_all_tasks_blocked()
         assert record == ["sleeping", "sleeping"]
         assert e.statistics().tasks_waiting == 2
@@ -94,9 +94,8 @@ async def test_CapacityLimiter():
     async with _core.open_nursery() as nursery:
         await c.acquire_on_behalf_of("value 1")
         await c.acquire_on_behalf_of("value 2")
-        t = nursery.spawn(c.acquire_on_behalf_of, "value 3")
+        nursery.start_soon(c.acquire_on_behalf_of, "value 3")
         await wait_all_tasks_blocked()
-        assert t.result is None
         assert c.borrowed_tokens == 2
         assert c.statistics().tasks_waiting == 1
         c.release_on_behalf_of("value 2")
@@ -104,7 +103,6 @@ async def test_CapacityLimiter():
         assert c.borrowed_tokens == 2
         with pytest.raises(_core.WouldBlock):
             c.acquire_nowait()
-        await t.wait()
 
     c.release_on_behalf_of("value 3")
     c.release_on_behalf_of("value 1")
@@ -174,17 +172,23 @@ async def test_Semaphore():
     assert s.value == 1
     s.acquire_nowait()
 
+    record = []
+    async def do_acquire(s):
+        record.append("started")
+        await s.acquire()
+        record.append("finished")
+
     async with _core.open_nursery() as nursery:
-        t = nursery.spawn(s.acquire)
+        nursery.start_soon(do_acquire, s)
         await wait_all_tasks_blocked()
-        assert t.result is None
+        assert record == ["started"]
         assert s.value == 0
         s.release()
         # Fairness:
         assert s.value == 0
         with pytest.raises(_core.WouldBlock):
             s.acquire_nowait()
-        await t.wait()
+    assert record == ["started", "finished"]
 
 
 async def test_Semaphore_bounded():
@@ -237,13 +241,16 @@ async def test_Lock_and_StrictFIFOLock(lockcls):
         # Error out if we don't own the lock
         l.release()
 
+    holder_task = None
     async def holder():
+        nonlocal holder_task
+        holder_task = _core.current_task()
         async with l:
             await sleep_forever()
 
     async with _core.open_nursery() as nursery:
         assert not l.locked()
-        t = nursery.spawn(holder)
+        nursery.start_soon(holder)
         await wait_all_tasks_blocked()
         assert l.locked()
         # WouldBlock if someone else holds the lock
@@ -256,7 +263,7 @@ async def test_Lock_and_StrictFIFOLock(lockcls):
         statistics = l.statistics()
         print(statistics)
         assert statistics.locked
-        assert statistics.owner is t
+        assert statistics.owner is holder_task
         assert statistics.tasks_waiting == 0
 
         nursery.start_soon(holder)
@@ -305,31 +312,30 @@ async def test_Condition():
         # Can't notify without holding the lock
         c.notify_all()
 
-    async def waiter():
+    finished_waiters = set()
+    async def waiter(i):
         async with c:
             await c.wait()
+        finished_waiters.add(i)
 
     async with _core.open_nursery() as nursery:
-        w = []
-        for _ in range(3):
-            w.append(nursery.spawn(waiter))
+        for i in range(3):
+            nursery.start_soon(waiter, i)
             await wait_all_tasks_blocked()
         async with c:
             c.notify()
         assert c.locked()
         await wait_all_tasks_blocked()
-        assert w[0].result is not None
-        assert w[1].result is w[2].result is None
+        assert finished_waiters == {0}
         async with c:
             c.notify_all()
         await wait_all_tasks_blocked()
-        assert w[1].result is not None
-        assert w[2].result is not None
+        assert finished_waiters == {0, 1, 2}
 
+    finished_waiters = set()
     async with _core.open_nursery() as nursery:
-        w = []
-        for _ in range(3):
-            w.append(nursery.spawn(waiter))
+        for i in range(3):
+            nursery.start_soon(waiter, i)
             await wait_all_tasks_blocked()
         async with c:
             c.notify(2)
@@ -341,9 +347,7 @@ async def test_Condition():
         assert c.statistics().lock_statistics.tasks_waiting == 1
 
         await wait_all_tasks_blocked()
-        assert w[0].result is not None
-        assert w[1].result is not None
-        assert w[2].result is None
+        assert finished_waiters == {0, 1}
 
         async with c:
             c.notify_all()
@@ -401,20 +405,27 @@ async def test_Queue_join():
     with assert_yields():
         await q.join()
 
+    record = []
+    async def do_join(q):
+        record.append("started")
+        await q.join()
+        record.append("finished")
+
     async with _core.open_nursery() as nursery:
         await q.put(None)
-        t1 = nursery.spawn(q.join)
-        t2 = nursery.spawn(q.join)
+        nursery.start_soon(do_join, q)
+        nursery.start_soon(do_join, q)
         await wait_all_tasks_blocked()
-        assert t1.result is t2.result is None
+        assert record == ["started", "started"]
         q.put_nowait(None)
         q.get_nowait()
         q.get_nowait()
         q.task_done()
         await wait_all_tasks_blocked()
-        assert t1.result is t2.result is None
+        assert record == ["started", "started"]
         q.task_done()
 
+    assert record == ["started", "started", "finished", "finished"]
 
 async def test_Queue_iter():
     q = Queue(1)
@@ -490,13 +501,19 @@ async def test_Queue_fairness():
     # But if someone else is waiting to get, then they "own" the item we put,
     # so we can't get it (even though we run first):
     q = Queue(1)
+
+    result = None
+    async def do_get(q):
+        nonlocal result
+        result = await q.get()
+
     async with _core.open_nursery() as nursery:
-        t = nursery.spawn(q.get)
+        nursery.start_soon(do_get, q)
         await wait_all_tasks_blocked()
         q.put_nowait(2)
         with pytest.raises(_core.WouldBlock):
             q.get_nowait()
-    assert t.result.unwrap() == 2
+    assert result == 2
 
     # And the analogous situation for put: if we free up a space, we can't
     # immediately put something in it if someone is already waiting to do that
@@ -506,7 +523,7 @@ async def test_Queue_fairness():
         q.put_nowait(None)
     assert q.qsize() == 1
     async with _core.open_nursery() as nursery:
-        t = nursery.spawn(q.put, 2)
+        nursery.start_soon(q.put, 2)
         await wait_all_tasks_blocked()
         assert q.qsize() == 1
         assert q.get_nowait() == 1
@@ -637,13 +654,17 @@ async def test_generic_lock_fifo_fairness(lock_factory):
 async def test_generic_lock_acquire_nowait_blocks_acquire(lock_factory):
     lock_like = lock_factory()
 
+    record = []
+
     async def lock_taker():
+        record.append("started")
         async with lock_like:
             pass
+        record.append("finished")
 
     async with _core.open_nursery() as nursery:
         lock_like.acquire_nowait()
-        t = nursery.spawn(lock_taker)
+        nursery.start_soon(lock_taker)
         await wait_all_tasks_blocked()
-        assert t.result is None
+        assert record == ["started"]
         lock_like.release()

--- a/trio/tests/test_testing.py
+++ b/trio/tests/test_testing.py
@@ -35,6 +35,7 @@ async def test_wait_all_tasks_blocked():
 
     # check cancellation
     record = []
+
     async def cancelled_while_waiting():
         try:
             await wait_all_tasks_blocked()

--- a/trio/tests/test_threads.py
+++ b/trio/tests/test_threads.py
@@ -197,7 +197,9 @@ async def test_run_in_worker_thread_cancellation():
     async def child(q, cancellable):
         record.append("start")
         try:
-            return await run_sync_in_worker_thread(f, q, cancellable=cancellable)
+            return await run_sync_in_worker_thread(
+                f, q, cancellable=cancellable
+            )
         finally:
             record.append("exit")
 

--- a/trio/tests/test_threads.py
+++ b/trio/tests/test_threads.py
@@ -195,15 +195,21 @@ async def test_run_in_worker_thread_cancellation():
         register[0] = "finished"
 
     async def child(q, cancellable):
-        return await run_sync_in_worker_thread(f, q, cancellable=cancellable)
+        record.append("start")
+        try:
+            return await run_sync_in_worker_thread(f, q, cancellable=cancellable)
+        finally:
+            record.append("exit")
 
+    record = []
     q = stdlib_queue.Queue()
     async with _core.open_nursery() as nursery:
-        task1 = nursery.spawn(child, q, True)
+        nursery.start_soon(child, q, True)
         # Give it a chance to get started. (This is important because
         # run_sync_in_worker_thread does a yield_if_cancelled before blocking
         # on the thread, and we don't want to trigger this.)
         await wait_all_tasks_blocked()
+        assert record == ["start"]
         # Then cancel it.
         nursery.cancel_scope.cancel()
     # The task exited, but the thread didn't:
@@ -214,16 +220,17 @@ async def test_run_in_worker_thread_cancellation():
         time.sleep(0.01)
 
     # This one can't be cancelled
+    record = []
     register[0] = None
     async with _core.open_nursery() as nursery:
-        task2 = nursery.spawn(child, q, False)
+        nursery.start_soon(child, q, False)
         await wait_all_tasks_blocked()
         nursery.cancel_scope.cancel()
         with _core.open_cancel_scope(shield=True):
             for _ in range(10):
                 await _core.yield_briefly()
         # It's still running
-        assert task2.result is None
+        assert record == ["start"]
         q.put(None)
         # Now it exits
 
@@ -251,7 +258,7 @@ def test_run_in_worker_thread_abandoned(capfd):
             await run_sync_in_worker_thread(thread_fn, cancellable=True)
 
         async with _core.open_nursery() as nursery:
-            t = nursery.spawn(child)
+            nursery.start_soon(child)
             await wait_all_tasks_blocked()
             nursery.cancel_scope.cancel()
 
@@ -328,7 +335,7 @@ async def test_run_in_worker_thread_limiter(MAX, cancel, use_default_limiter):
                 state.running -= 1
             print("thread_fn exiting")
 
-        async def run_thread():
+        async def run_thread(event):
             with _core.open_cancel_scope() as cancel_scope:
                 await run_sync_in_worker_thread(
                     thread_fn,
@@ -340,12 +347,14 @@ async def test_run_in_worker_thread_limiter(MAX, cancel, use_default_limiter):
                 "run_thread finished, cancelled:",
                 cancel_scope.cancelled_caught
             )
+            event.set()
 
         async with _core.open_nursery() as nursery:
             print("spawning")
-            tasks = []
+            events = []
             for i in range(COUNT):
-                tasks.append(nursery.spawn(run_thread))
+                events.append(Event())
+                nursery.start_soon(run_thread, events[-1])
                 await wait_all_tasks_blocked()
             # In the cancel case, we in particular want to make sure that the
             # cancelled tasks don't release the semaphore. So let's wait until
@@ -354,7 +363,7 @@ async def test_run_in_worker_thread_limiter(MAX, cancel, use_default_limiter):
             # who's supposed to be waiting is waiting:
             if cancel:
                 print("waiting for first cancellation to clear")
-                await tasks[0].wait()
+                await events[0].wait()
                 await wait_all_tasks_blocked()
             # Then wait until the first MAX threads are parked in gate.wait(),
             # and the next MAX threads are parked on the semaphore, to make

--- a/trio/tests/test_util.py
+++ b/trio/tests/test_util.py
@@ -47,8 +47,8 @@ async def test_ConflictDetector():
 
     with pytest.raises(_core.ResourceBusyError) as excinfo:
         async with _core.open_nursery() as nursery:
-            nursery.spawn(wait_with_ul1)
-            nursery.spawn(wait_with_ul1)
+            nursery.start_soon(wait_with_ul1)
+            nursery.start_soon(wait_with_ul1)
     assert "ul1" in str(excinfo.value)
 
     # mixing sync and async entry


### PR DESCRIPTION
Deprecates nursery.spawn and most of the nursery and task APIs.

Todo:

* [x] do a pass through the docs to get rid of now-irrelevant prose
* [x] Move now-less-central stuff into hazmat (Task, UnboundedQueue, Result?)