### PR TITLE
Avoid infinite recursion in ModuleWithDeprecations.__getattr__

### DIFF
--- a/trio/_deprecate.py
+++ b/trio/_deprecate.py
@@ -109,7 +109,7 @@ class DeprecatedAttribute:
     instead = attr.ib(default=_not_set)
 
 
-class ModuleWithDeprecations(ModuleType):
+class _ModuleWithDeprecations(ModuleType):
     def __getattr__(self, name):
         if name in self.__deprecated_attributes__:
             info = self.__deprecated_attributes__[name]
@@ -128,7 +128,11 @@ class ModuleWithDeprecations(ModuleType):
 def enable_attribute_deprecations(module_name):
     module = sys.modules[module_name]
     try:
-        module.__class__ = ModuleWithDeprecations
+        module.__class__ = _ModuleWithDeprecations
     except TypeError:
         # Need PyPy 5.9+ to support module __class__ assignment
         return
+    # Make sure that this is always defined so that
+    # _ModuleWithDeprecations.__getattr__ can access it without jumping
+    # through hoops or risking infinite recursion.
+    module.__deprecated_attributes__ = {}

--- a/trio/tests/module_with_deprecations.py
+++ b/trio/tests/module_with_deprecations.py
@@ -4,6 +4,14 @@ from .. import _deprecate
 
 _deprecate.enable_attribute_deprecations(__name__)
 
+# Make sure that we don't trigger infinite recursion when accessing module
+# attributes in between calling enable_attribute_deprecations and defining
+# __deprecated_attributes__:
+import sys
+this_mod = sys.modules[__name__]
+assert this_mod.regular == "hi"
+assert not hasattr(this_mod, "dep1")
+
 __deprecated_attributes__ = {
     "dep1":
         _deprecate.DeprecatedAttribute(


### PR DESCRIPTION
This isn't really needed currently (we'd know, the symptom is a
RecursionError at import time), but it's a genuine bug fix for a
problem I ran into while implementing gh-316. And since that PR seems
to be stalled at the moment, I want to get this in so it doesn't get
forgotten.