### PR TITLE
Renames and deprecations for #68

### DIFF
--- a/docs/source/history.rst
+++ b/docs/source/history.rst
@@ -137,6 +137,7 @@ will work but complain loudly, and won't work in 0.3.0):
 ``nursery.spawn`` → ``nursery.start_soon``
 
 ``current_call_soon_thread_and_signal_safe`` → :class:`trio.hazmat.TrioToken`
+``run_in_trio_thread``, ``await_in_trio_thread`` → :class:`trio.BlockingTrioPortal`
 
 deprecated big chunks of nursery and Task API
 

--- a/docs/source/history.rst
+++ b/docs/source/history.rst
@@ -136,6 +136,8 @@ will work but complain loudly, and won't work in 0.3.0):
 ``run_in_worker_thread`` → ``run_sync_in_worker_thread``
 ``nursery.spawn`` → ``nursery.start_soon``
 
+``current_call_soon_thread_and_signal_safe`` → :class:`trio.hazmat.TrioToken`
+
 deprecated big chunks of nursery and Task API
 
 

--- a/docs/source/reference-hazmat.rst
+++ b/docs/source/reference-hazmat.rst
@@ -197,10 +197,13 @@ Global state: system tasks and run-local storage
 .. autofunction:: spawn_system_task
 
 
-Entering trio from external threads or signal handlers
-======================================================
+Trio tokens
+===========
 
-.. autofunction:: current_call_soon_thread_and_signal_safe
+.. autoclass:: TrioToken()
+   :members:
+
+.. autofunction:: current_trio_token
 
 
 Safer KeyboardInterrupt handling

--- a/trio/__init__.py
+++ b/trio/__init__.py
@@ -111,6 +111,7 @@ hazmat.__deprecated_attributes__ = {
 # Having the public path in .__module__ attributes is important for:
 # - exception names in printed tracebacks
 # - sphinx :show-inheritance:
+# - deprecation warnings
 # - pickle
 # - probably other stuff
 from ._util import fixup_module_metadata

--- a/trio/_core/__init__.py
+++ b/trio/_core/__init__.py
@@ -27,6 +27,9 @@ __all__ += _ki.__all__
 from ._run import *
 __all__ += _run.__all__
 
+from ._entry_queue import *
+__all__ += _entry_queue.__all__
+
 from ._parking_lot import *
 __all__ += _parking_lot.__all__
 

--- a/trio/_core/_entry_queue.py
+++ b/trio/_core/_entry_queue.py
@@ -1,0 +1,178 @@
+from collections import deque
+import threading
+
+import attr
+
+from .. import _core
+from ._wakeup_socketpair import WakeupSocketpair
+
+__all__ = ["TrioToken"]
+
+
+@attr.s
+class EntryQueue:
+    # This used to use a queue.Queue. but that was broken, because Queues are
+    # implemented in Python, and not reentrant -- so it was thread-safe, but
+    # not signal-safe. deque is implemented in C, so each operation is atomic
+    # WRT threads (and this is guaranteed in the docs), AND each operation is
+    # atomic WRT signal delivery (signal handlers can run on either side, but
+    # not *during* a deque operation). dict makes similar guarantees - and on
+    # CPython 3.6 and PyPy, it's even ordered!
+    queue = attr.ib(default=attr.Factory(deque))
+    idempotent_queue = attr.ib(default=attr.Factory(dict))
+
+    wakeup = attr.ib(default=attr.Factory(WakeupSocketpair))
+    done = attr.ib(default=False)
+    # Must be a reentrant lock, because it's acquired from signal handlers.
+    # RLock is signal-safe as of cpython 3.2. NB that this does mean that the
+    # lock is effectively *disabled* when we enter from signal context. The
+    # way we use the lock this is OK though, because when
+    # run_sync_soon is called from a signal it's atomic WRT the
+    # main thread -- it just might happen at some inconvenient place. But if
+    # you look at the one place where the main thread holds the lock, it's
+    # just to make 1 assignment, so that's atomic WRT a signal anyway.
+    lock = attr.ib(default=attr.Factory(threading.RLock))
+
+    async def task(self):
+        assert _core.currently_ki_protected()
+        # RLock has two implementations: a signal-safe version in _thread, and
+        # and signal-UNsafe version in threading. We need the signal safe
+        # version. Python 3.2 and later should always use this anyway, but,
+        # since the symptoms if this goes wrong are just "weird rare
+        # deadlocks", then let's make a little check.
+        # See:
+        #     https://bugs.python.org/issue13697#msg237140
+        assert self.lock.__class__.__module__ == "_thread"
+
+        def run_cb(job):
+            # We run this with KI protection enabled; it's the callback's
+            # job to disable it if it wants it disabled. Exceptions are
+            # treated like system task exceptions (i.e., converted into
+            # TrioInternalError and cause everything to shut down).
+            sync_fn, args = job
+            try:
+                sync_fn(*args)
+            except BaseException as exc:
+
+                async def kill_everything(exc):
+                    raise exc
+
+                _core.spawn_system_task(kill_everything, exc)
+            return True
+
+        # This has to be carefully written to be safe in the face of new items
+        # being queued while we iterate, and to do a bounded amount of work on
+        # each pass:
+        def run_all_bounded():
+            for _ in range(len(self.queue)):
+                run_cb(self.queue.popleft())
+            for job in list(self.idempotent_queue):
+                del self.idempotent_queue[job]
+                run_cb(job)
+
+        try:
+            while True:
+                run_all_bounded()
+                if not self.queue and not self.idempotent_queue:
+                    await self.wakeup.wait_woken()
+                else:
+                    await _core.checkpoint()
+        except _core.Cancelled:
+            # Keep the work done with this lock held as minimal as possible,
+            # because it doesn't protect us against concurrent signal delivery
+            # (see the comment above). Notice that this code would still be
+            # correct if written like:
+            #   self.done = True
+            #   with self.lock:
+            #       pass
+            # because all we want is to force run_sync_soon
+            # to either be completely before or completely after the write to
+            # done. That's why we don't need the lock to protect
+            # against signal handlers.
+            with self.lock:
+                self.done = True
+            # No more jobs will be submitted, so just clear out any residual
+            # ones:
+            run_all_bounded()
+            assert not self.queue
+            assert not self.idempotent_queue
+
+    def close(self):
+        self.wakeup.close()
+
+    def size(self):
+        return len(self.queue) + len(self.idempotent_queue)
+
+    def spawn(self):
+        name = "<TrioToken.run_sync_soon task>"
+        _core.spawn_system_task(self.task, name=name)
+
+    def run_sync_soon(self, sync_fn, *args, idempotent=False):
+        with self.lock:
+            if self.done:
+                raise _core.RunFinishedError("run() has exited")
+            # We have to hold the lock all the way through here, because
+            # otherwise the main thread might exit *while* we're doing these
+            # calls, and then our queue item might not be processed, or the
+            # wakeup call might trigger an OSError b/c the IO manager has
+            # already been shut down.
+            if idempotent:
+                self.idempotent_queue[(sync_fn, args)] = None
+            else:
+                self.queue.append((sync_fn, args))
+            self.wakeup.wakeup_thread_and_signal_safe()
+
+
+class TrioToken:
+    def __init__(self, reentry_queue):
+        self._reentry_queue = reentry_queue
+
+    def run_sync_soon(self, sync_fn, *args, idempotent=False):
+        """Schedule a call to ``sync_fn(*args)`` to occur in the context of a
+        trio task.
+
+        This is safe to call from the main thread, from other threads, and
+        from signal handlers. This is the fundamental primitive used to
+        re-enter the Trio run loop from outside of it.
+
+        The call will happen "soon", but there's no guarantee about exactly
+        when, and no mechanism provided for finding out when it's happened.
+        If you need this, you'll have to build your own.
+
+        The call is effectively run as part of a system task (see
+        :func:`~trio.hazmat.spawn_system_task`). In particular this means
+        that:
+
+        * :exc:`KeyboardInterrupt` protection is *enabled* by default; if
+          you want ``sync_fn`` to be interruptible by control-C, then you
+          need to use :func:`~trio.hazmat.disable_ki_protection`
+          explicitly.
+
+        * If ``sync_fn`` raises an exception, then it's converted into a
+          :exc:`~trio.TrioInternalError` and *all* tasks are cancelled. You
+          should be careful that ``sync_fn`` doesn't crash.
+
+        All calls with ``idempotent=False`` are processed in strict
+        first-in first-out order.
+
+        If ``idempotent=True``, then ``sync_fn`` and ``args`` must be
+        hashable, and trio will make a best-effort attempt to discard any
+        call submission which is equal to an already-pending call. Trio
+        will make an attempt to process these in first-in first-out order,
+        but no guarantees. (Currently processing is FIFO on CPython 3.6 and
+        PyPy, but not CPython 3.5.)
+
+        Any ordering guarantees apply separately to ``idempotent=False``
+        and ``idempotent=True`` calls; there's no rule for how calls in the
+        different categories are ordered with respect to each other.
+
+        :raises trio.RunFinishedError:
+              if the associated call to :func:`trio.run`
+              has already exited. (Any call that *doesn't* raise this error
+              is guaranteed to be fully processed before :func:`trio.run`
+              exits.)
+
+        """
+        self._reentry_queue.run_sync_soon(
+            sync_fn, *args, idempotent=idempotent
+        )

--- a/trio/_core/_entry_queue.py
+++ b/trio/_core/_entry_queue.py
@@ -124,6 +124,24 @@ class EntryQueue:
 
 
 class TrioToken:
+    """An opaque object representing a single call to :func:`trio.run`.
+
+    It has no public constructor; instead, see :func:`current_trio_token`.
+
+    This object has two uses:
+
+    1. It lets you re-enter the Trio run loop from external threads or signal
+       handlers. This is the low-level primitive that
+       :func:`trio.run_sync_in_worker_thread` uses to receive results from
+       worker threads, that :func:`trio.catch_signals` uses to receive
+       notifications about signals, and so forth.
+
+    2. Each call to :func:`trio.run` has exactly one associated
+       :class:`TrioToken` object, so you can use it to identify a particular
+       call.
+
+    """
+
     def __init__(self, reentry_queue):
         self._reentry_queue = reentry_queue
 

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -1084,6 +1084,10 @@ class Runner:
 
     @_public
     def current_trio_token(self):
+        """Retrieve the :class:`TrioToken` for the current call to
+        :func:`trio.run`.
+
+        """
         if self.trio_token is None:
             self.trio_token = TrioToken(self.entry_queue)
         return self.trio_token

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -31,11 +31,11 @@ from ._traps import (
     CancelShieldedCheckpoint,
     WaitTaskRescheduled,
 )
+from ._entry_queue import EntryQueue, TrioToken
 from ._ki import (
     LOCALS_KEY_KI_PROTECTION_ENABLED, currently_ki_protected, ki_manager,
     enable_ki_protection
 )
-from ._wakeup_socketpair import WakeupSocketpair
 from . import _public
 
 # At the bottom of this file there's also some "clever" code that generates
@@ -44,8 +44,8 @@ from . import _public
 # namespaces.
 __all__ = [
     "Task", "run", "open_nursery", "open_cancel_scope", "checkpoint",
-    "current_task", "current_effective_deadline", "checkpoint_if_cancelled",
-    "STATUS_IGNORED"
+    "current_call_soon_thread_and_signal_safe", "current_task",
+    "current_effective_deadline", "checkpoint_if_cancelled", "STATUS_IGNORED"
 ]
 
 GLOBAL_RUN_CONTEXT = threading.local()
@@ -726,7 +726,12 @@ class _RunStatistics:
     tasks_runnable = attr.ib()
     seconds_to_next_deadline = attr.ib()
     io_statistics = attr.ib()
-    call_soon_queue_size = attr.ib()
+    run_sync_soon_queue_size = attr.ib()
+
+    @property
+    @deprecated("0.2.0", issue=68, instead="run_sync_soon_queue_size")
+    def call_soon_queue_size(self):
+        return self.run_sync_soon_queue_size
 
 
 @attr.s(cmp=False, hash=False)
@@ -751,9 +756,12 @@ class Runner:
     main_task = attr.ib(default=None)
     system_nursery = attr.ib(default=None)
 
+    entry_queue = attr.ib(default=attr.Factory(EntryQueue))
+    trio_token = attr.ib(default=None)
+
     def close(self):
         self.io_manager.close()
-        self.call_soon_wakeup.close()
+        self.entry_queue.close()
         self.instrument("after_run")
 
     # Methods marked with @_public get converted into functions exported by
@@ -773,9 +781,9 @@ class Runner:
           pending cancel scope deadline. May be negative if the deadline has
           expired but we haven't yet processed cancellations. May be
           :data:`~math.inf` if there are no pending deadlines.
-        * ``call_soon_queue_size`` (int): The number of unprocessed callbacks
-          queued via
-          :func:`trio.hazmat.current_call_soon_thread_and_signal_safe`.
+        * ``run_sync_soon_queue_size`` (int): The number of
+          unprocessed callbacks queued via
+          :meth:`trio.hazmat.TrioToken.run_sync_soon`.
         * ``io_statistics`` (object): Some statistics from trio's I/O
           backend. This always has an attribute ``backend`` which is a string
           naming which operating-system-specific I/O backend is in use; the
@@ -792,10 +800,7 @@ class Runner:
             tasks_runnable=len(self.runq),
             seconds_to_next_deadline=seconds_to_next_deadline,
             io_statistics=self.io_manager.statistics(),
-            call_soon_queue_size=(
-                len(self.call_soon_queue) +
-                len(self.call_soon_idempotent_queue)
-            ),
+            run_sync_soon_queue_size=self.entry_queue.size(),
         )
 
     @_public
@@ -1058,13 +1063,13 @@ class Runner:
     async def init(self, async_fn, args):
         async with open_nursery() as system_nursery:
             self.system_nursery = system_nursery
-            self.spawn_system_task(
-                self.call_soon_task, name="<call soon task>"
-            )
+
+            self.entry_queue.spawn()
 
             self.main_task = self.spawn_impl(
                 async_fn, args, self.system_nursery, name=None
             )
+
             async for task_batch in system_nursery._monitor:
                 for task in task_batch:
                     if task is self.main_task:
@@ -1074,165 +1079,14 @@ class Runner:
                         system_nursery._reap_and_unwrap(task)
 
     ################
-    # Outside Context Problems
+    # Outside context problems
     ################
 
-    # XX factor this chunk into another file
-
-    # This used to use a queue.Queue. but that was broken, because Queues are
-    # implemented in Python, and not reentrant -- so it was thread-safe, but
-    # not signal-safe. deque is implemented in C, so each operation is atomic
-    # WRT threads (and this is guaranteed in the docs), AND each operation is
-    # atomic WRT signal delivery (signal handlers can run on either side, but
-    # not *during* a deque operation). dict makes similar guarantees - and on
-    # CPython 3.6 and PyPy, it's even ordered!
-    call_soon_wakeup = attr.ib(default=attr.Factory(WakeupSocketpair))
-    call_soon_queue = attr.ib(default=attr.Factory(deque))
-    call_soon_idempotent_queue = attr.ib(default=attr.Factory(dict))
-    call_soon_done = attr.ib(default=False)
-    # Must be a reentrant lock, because it's acquired from signal
-    # handlers. RLock is signal-safe as of cpython 3.2.
-    # NB that this does mean that the lock is effectively *disabled* when we
-    # enter from signal context. The way we use the lock this is OK though,
-    # because when call_soon_thread_and_signal_safe is called from a signal
-    # it's atomic WRT the main thread -- it just might happen at some
-    # inconvenient place. But if you look at the one place where the main
-    # thread holds the lock, it's just to make 1 assignment, so that's atomic
-    # WRT a signal anyway.
-    call_soon_lock = attr.ib(default=attr.Factory(threading.RLock))
-
-    def call_soon_thread_and_signal_safe(
-            self, sync_fn, *args, idempotent=False
-    ):
-        with self.call_soon_lock:
-            if self.call_soon_done:
-                raise RunFinishedError("run() has exited")
-            # We have to hold the lock all the way through here, because
-            # otherwise the main thread might exit *while* we're doing these
-            # calls, and then our queue item might not be processed, or the
-            # wakeup call might trigger an OSError b/c the IO manager has
-            # already been shut down.
-            if idempotent:
-                self.call_soon_idempotent_queue[(sync_fn, args)] = None
-            else:
-                self.call_soon_queue.append((sync_fn, args))
-            self.call_soon_wakeup.wakeup_thread_and_signal_safe()
-
     @_public
-    def current_call_soon_thread_and_signal_safe(self):
-        """Returns a reference to the ``call_soon_thread_and_signal_safe``
-        function for the current trio run:
-
-        .. currentmodule:: None
-
-        .. function:: call_soon_thread_and_signal_safe(sync_fn, *args, idempotent=False)
-
-           Schedule a call to ``sync_fn(*args)`` to occur in the context of a
-           trio task. This is safe to call from the main thread, from other
-           threads, and from signal handlers.
-
-           The call is effectively run as part of a system task (see
-           :func:`~trio.hazmat.spawn_system_task`). In particular this means
-           that:
-
-           * :exc:`KeyboardInterrupt` protection is *enabled* by default; if
-             you want ``sync_fn`` to be interruptible by control-C, then you
-             need to use :func:`~trio.hazmat.disable_ki_protection`
-             explicitly.
-
-           * If ``sync_fn`` raises an exception, then it's converted into a
-             :exc:`~trio.TrioInternalError` and *all* tasks are cancelled. You
-             should be careful that ``sync_fn`` doesn't crash.
-
-           All calls with ``idempotent=False`` are processed in strict
-           first-in first-out order.
-
-           If ``idempotent=True``, then ``sync_fn`` and ``args`` must be
-           hashable, and trio will make a best-effort attempt to discard any
-           call submission which is equal to an already-pending call. Trio
-           will make an attempt to process these in first-in first-out order,
-           but no guarantees. (Currently processing is FIFO on CPython 3.6 and
-           PyPy, but not CPython 3.5.)
-
-           Any ordering guarantees apply separately to ``idempotent=False``
-           and ``idempotent=True`` calls; there's no rule for how calls in the
-           different categories are ordered with respect to each other.
-
-           :raises trio.RunFinishedError:
-                 if the associated call to :func:`trio.run`
-                 has already exited. (Any call that *doesn't* raise this error
-                 is guaranteed to be fully processed before :func:`trio.run`
-                 exits.)
-
-        .. currentmodule:: trio.hazmat
-
-        """
-        return self.call_soon_thread_and_signal_safe
-
-    async def call_soon_task(self):
-        assert currently_ki_protected()
-        # RLock has two implementations: a signal-safe version in _thread, and
-        # and signal-UNsafe version in threading. We need the signal safe
-        # version. Python 3.2 and later should always use this anyway, but,
-        # since the symptoms if this goes wrong are just "weird rare
-        # deadlocks", then let's make a little check.
-        # See:
-        #     https://bugs.python.org/issue13697#msg237140
-        assert self.call_soon_lock.__class__.__module__ == "_thread"
-
-        def run_cb(job):
-            # We run this with KI protection enabled; it's the callbacks
-            # job to disable it if it wants it disabled. Exceptions are
-            # treated like system task exceptions (i.e., converted into
-            # TrioInternalError and cause everything to shut down).
-            sync_fn, args = job
-            try:
-                sync_fn(*args)
-            except BaseException as exc:
-
-                async def kill_everything(exc):
-                    raise exc
-
-                self.spawn_system_task(kill_everything, exc)
-            return True
-
-        # This has to be carefully written to be safe in the face of new items
-        # being queued while we iterate, and to do a bounded amount of work on
-        # each pass:
-        def run_all_bounded():
-            for _ in range(len(self.call_soon_queue)):
-                run_cb(self.call_soon_queue.popleft())
-            for job in list(self.call_soon_idempotent_queue):
-                del self.call_soon_idempotent_queue[job]
-                run_cb(job)
-
-        try:
-            while True:
-                run_all_bounded()
-                if (not self.call_soon_queue
-                        and not self.call_soon_idempotent_queue):
-                    await self.call_soon_wakeup.wait_woken()
-                else:
-                    await checkpoint()
-        except Cancelled:
-            # Keep the work done with this lock held as minimal as possible,
-            # because it doesn't protect us against concurrent signal delivery
-            # (see the comment above). Notice that this could would still be
-            # correct if written like:
-            #   self.call_soon_done = True
-            #   with self.call_soon_lock:
-            #       pass
-            # because all we want is to force call_soon_thread_and_signal_safe
-            # to either be completely before or completely after the write to
-            # call_soon_done. That's why we don't need the lock to protect
-            # against signal handlers.
-            with self.call_soon_lock:
-                self.call_soon_done = True
-            # No more jobs will be submitted, so just clear out any residual
-            # ones:
-            run_all_bounded()
-            assert not self.call_soon_queue
-            assert not self.call_soon_idempotent_queue
+    def current_trio_token(self):
+        if self.trio_token is None:
+            self.trio_token = TrioToken(self.entry_queue)
+        return self.trio_token
 
     ################
     # KI handling
@@ -1240,20 +1094,26 @@ class Runner:
 
     ki_pending = attr.ib(default=False)
 
+    # deliver_ki is broke. Maybe move all the actual logic and state into
+    # RunToken, and we'll only have one instance per runner? But then we can't
+    # have a public constructor. Eh, but current_run_token() returning a
+    # unique object per run feels pretty nice. Maybe let's just go for it. And
+    # keep the class public so people can isinstance() it if they want.
+
     # This gets called from signal context
     def deliver_ki(self):
         self.ki_pending = True
         try:
-            self.call_soon_thread_and_signal_safe(self._deliver_ki_cb)
+            self.entry_queue.run_sync_soon(self._deliver_ki_cb)
         except RunFinishedError:
             pass
 
     def _deliver_ki_cb(self):
         if not self.ki_pending:
             return
-        # Can't happen because main_task and call_soon_task are created at the
-        # same time -- so even if KI arrives before main_task is created, we
-        # won't get here until afterwards.
+        # Can't happen because main_task and run_sync_soon_task are created at
+        # the same time -- so even if KI arrives before main_task is created,
+        # we won't get here until afterwards.
         assert self.main_task is not None
         if self.main_task._result is not None:
             # We're already in the process of exiting -- leave ki_pending set
@@ -1816,3 +1676,8 @@ def _generate_method_wrappers(cls, path_to_instance):
 
 _generate_method_wrappers(Runner, "runner")
 _generate_method_wrappers(TheIOManager, "runner.io_manager")
+
+
+@deprecated("0.2.0", issue=68, instead=TrioToken)
+def current_call_soon_thread_and_signal_safe():
+    return current_trio_token().run_sync_soon

--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -1225,6 +1225,20 @@ async def test_exception_chaining_after_yield_error():
     assert isinstance(excinfo.value.__context__, KeyError)
 
 
+def test_TrioToken_identity():
+    async def get_and_check_token():
+        token = _core.current_trio_token()
+        # Two calls in the same run give the same object
+        assert token is _core.current_trio_token()
+        return token
+
+    t1 = _core.run(get_and_check_token)
+    t2 = _core.run(get_and_check_token)
+    assert t1 is not t2
+    assert t1 != t2
+    assert hash(t1) != hash(t2)
+
+
 async def test_TrioToken_run_sync_soon_basic():
     record = []
 

--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -1936,7 +1936,9 @@ async def test_some_deprecated_but_uncovered_methods(recwarn):
         assert not nursery.zombies
 
     record = []
+    assert _core.current_statistics().call_soon_queue_size == 0
     call_soon = _core.current_call_soon_thread_and_signal_safe()
     call_soon(record.append, 1)
+    assert _core.current_statistics().call_soon_queue_size == 1
     await wait_all_tasks_blocked()
     assert record == [1]

--- a/trio/_signals.py
+++ b/trio/_signals.py
@@ -149,11 +149,11 @@ def catch_signals(signals):
             "Sorry, catch_signals is only possible when running in the "
             "Python interpreter's main thread"
         )
-    call_soon = _core.current_call_soon_thread_and_signal_safe()
+    token = _core.current_trio_token()
     queue = SignalQueue()
 
     def handler(signum, _):
-        call_soon(queue._add, signum, idempotent=True)
+        token.run_sync_soon(queue._add, signum, idempotent=True)
 
     try:
         with _signal_handler(signals, handler):

--- a/trio/_util.py
+++ b/trio/_util.py
@@ -242,7 +242,14 @@ def async_wraps(cls, wrapped_cls, attr_name):
 
 
 def fixup_module_metadata(module_name, namespace):
+    def fix_one(obj):
+        mod = getattr(obj, "__module__", None)
+        if mod is not None and mod.startswith("trio."):
+            obj.__module__ = module_name
+            if isinstance(obj, type):
+                for attr_value in obj.__dict__.values():
+                    fix_one(attr_value)
+
     for objname in namespace["__all__"]:
         obj = namespace[objname]
-        if hasattr(obj, "__module__") and obj.__module__.startswith("trio."):
-            obj.__module__ = module_name
+        fix_one(obj)

--- a/trio/hazmat.py
+++ b/trio/hazmat.py
@@ -26,6 +26,8 @@ __all__ = [
     "RunLocal",
     "wait_socket_readable",
     "wait_socket_writable",
+    "TrioToken",
+    "current_trio_token",
     # kqueue symbols
     "current_kqueue",
     "monitor_kevent",

--- a/trio/testing/_mock_clock.py
+++ b/trio/testing/_mock_clock.py
@@ -176,8 +176,8 @@ class MockClock(Clock):
         return self._virtual_base + virtual_offset
 
     def start_clock(self):
-        call_soon = _core.current_call_soon_thread_and_signal_safe()
-        call_soon(self._maybe_spawn_autojump_task)
+        token = _core.current_trio_token()
+        token.run_sync_soon(self._maybe_spawn_autojump_task)
 
     def current_time(self):
         return self._real_to_virtual(self._real_clock())

--- a/trio/tests/test_signals.py
+++ b/trio/tests/test_signals.py
@@ -62,8 +62,8 @@ async def test_catch_signals_race_condition_on_exit():
 
     async def wait_call_soon_idempotent_queue_barrier():
         ev = Event()
-        call_soon = _core.current_call_soon_thread_and_signal_safe()
-        call_soon(ev.set, idempotent=True)
+        token = _core.current_trio_token()
+        token.run_sync_soon(ev.set, idempotent=True)
         await ev.wait()
 
     print(1)

--- a/trio/tests/test_util.py
+++ b/trio/tests/test_util.py
@@ -172,3 +172,7 @@ def test_module_metadata_is_fixed_up():
     assert trio.hazmat.wait_task_rescheduled.__module__ == "trio.hazmat"
     import trio.testing
     assert trio.testing.trio_test.__module__ == "trio.testing"
+
+    # Also check methods
+    assert trio.ssl.SSLStream.__init__.__module__ == "trio.ssl"
+    assert trio.abc.Stream.send_all.__module__ == "trio.abc"


### PR DESCRIPTION
Adds:
- trio.hazmat.TrioToken
- trio.BlockingTrioToken

Deprecates:
- current_call_soon_thread_and_signal_safe
- run_in_trio_thread
- await_in_trio_thread

The new API has more consistent naming is generally less confusing due
to the use of actual objects instead of the unconventional returning
closures thing.