### PR TITLE
Remove is_trio_socket

### DIFF
--- a/docs/source/history.rst
+++ b/docs/source/history.rst
@@ -86,10 +86,11 @@ the :mod:`trio` and :mod:`trio.hazmat` modules
 https://github.com/python-trio/trio/issues/314
 
 
-* ``trio.socket.SocketType`` will no longer be exposed publically in
-  0.3.0. Since it had no public constructor, the only thing you could
-  do with it was ``isinstance(obj, SocketType)``. Instead, use
-  :func:`trio.socket.is_trio_socket`. (https://github.com/python-trio/trio/issues/170)
+* ``trio.socket.SocketType`` is now an empty abstract base class, with
+  the actual socket class made private. This shouldn't effect anyone,
+  since the only thing you could directly use it for in the first
+  place was ``isinstance`` checks, and those still work
+  (https://github.com/python-trio/trio/issues/170)
 
 * The following classes and functions have moved from :mod:`trio` to
   :mod:`trio.hazmat`:

--- a/docs/source/reference-io.rst
+++ b/docs/source/reference-io.rst
@@ -248,9 +248,7 @@ library socket into a trio socket:
 
 Unlike :func:`socket.socket`, :func:`trio.socket.socket` is a
 function, not a class; if you want to check whether an object is a
-trio socket, use:
-
-.. autofunction:: is_trio_socket
+trio socket, use ``isinstance(obj, trio.socket.SocketType)``.
 
 For name lookup, Trio provides the standard functions, but with some
 changes:
@@ -297,7 +295,13 @@ broken features:
 Socket objects
 ~~~~~~~~~~~~~~
 
-.. interface:: The trio socket object interface
+.. class:: SocketType
+
+   .. note:: :class:`trio.socket.SocketType` is an abstract class and
+      cannot be instantiated directly; you get concrete socket objects
+      by calling constructors like :func:`trio.socket.socket`.
+      However, you can use it to check if an object is a Trio socket
+      via ``isinstance(obj, trio.socket.SocketType)``.
 
    Trio socket objects are overall very similar to the :ref:`standard
    library socket objects <python:socket-objects>`, with a few

--- a/trio/_abc.py
+++ b/trio/_abc.py
@@ -198,22 +198,16 @@ class SocketFactory(metaclass=ABCMeta):
     def socket(self, family=None, type=None, proto=None):
         """Create and return a socket object.
 
+        Your socket object must inherit from :class:`trio.socket.SocketType`,
+        which is an empty class whose only purpose is to "mark" which classes
+        should be considered valid trio sockets.
+
         Called by :func:`trio.socket.socket`.
 
         Note that unlike :func:`trio.socket.socket`, this does not take a
         ``fileno=`` argument. If a ``fileno=`` is specified, then
         :func:`trio.socket.socket` returns a regular trio socket object
         instead of calling this method.
-
-        """
-
-    @abstractmethod
-    def is_trio_socket(self, obj):
-        """Check if the given object is a socket instance.
-
-        Called by :func:`trio.socket.is_trio_socket`, which returns True if
-        the given object is a builtin trio socket object *or* if this method
-        returns True.
 
         """
 

--- a/trio/_highlevel_socket.py
+++ b/trio/_highlevel_socket.py
@@ -60,7 +60,7 @@ class SocketStream(HalfCloseableStream):
     """
 
     def __init__(self, socket):
-        if not tsocket.is_trio_socket(socket):
+        if not isinstance(socket, tsocket.SocketType):
             raise TypeError("SocketStream requires trio socket object")
         if real_socket_type(socket.type) != tsocket.SOCK_STREAM:
             raise ValueError("SocketStream requires a SOCK_STREAM socket")
@@ -329,7 +329,7 @@ class SocketListener(Listener):
     """
 
     def __init__(self, socket):
-        if not tsocket.is_trio_socket(socket):
+        if not isinstance(socket, tsocket.SocketType):
             raise TypeError("SocketListener requires trio socket object")
         if real_socket_type(socket.type) != tsocket.SOCK_STREAM:
             raise ValueError("SocketListener requires a SOCK_STREAM socket")

--- a/trio/socket.py
+++ b/trio/socket.py
@@ -6,14 +6,3 @@
 # here.
 from ._socket import *
 from ._socket import __all__
-
-from . import _deprecate
-from ._socket import _SocketType
-_deprecate.enable_attribute_deprecations(__name__)
-__deprecated_attributes__ = {
-    "SocketType":
-        _deprecate.DeprecatedAttribute(
-            _SocketType, "0.2.0", issue=170, instead="is_trio_socket"
-        )
-}
-del _deprecate, _SocketType

--- a/trio/tests/test_highlevel_open_tcp_listeners.py
+++ b/trio/tests/test_highlevel_open_tcp_listeners.py
@@ -145,7 +145,7 @@ class FakeOSError(OSError):
 
 
 @attr.s
-class FakeSocket:
+class FakeSocket(tsocket.SocketType):
     family = attr.ib()
     type = attr.ib()
     proto = attr.ib()
@@ -176,9 +176,6 @@ class FakeSocket:
 class FakeSocketFactory:
     poison_after = attr.ib()
     sockets = attr.ib(default=attr.Factory(list))
-
-    def is_trio_socket(self, obj):
-        return isinstance(obj, FakeSocket)
 
     def socket(self, family, type, proto):
         sock = FakeSocket(family, type, proto)

--- a/trio/tests/test_highlevel_open_tcp_stream.py
+++ b/trio/tests/test_highlevel_open_tcp_stream.py
@@ -95,7 +95,7 @@ async def test_open_tcp_stream_input_validation():
 
 
 @attr.s
-class FakeSocket:
+class FakeSocket(trio.socket.SocketType):
     scenario = attr.ib()
     family = attr.ib()
     type = attr.ib()
@@ -153,9 +153,6 @@ class Scenario(trio.abc.SocketFactory, trio.abc.HostnameResolver):
             raise OSError("pretending not to support ipv6")
         self.socket_count += 1
         return FakeSocket(self, family, type, proto)
-
-    def is_trio_socket(self, obj):
-        return isinstance(obj, FakeSocket)
 
     def _ip_to_gai_entry(self, ip):
         if ":" in ip:

--- a/trio/tests/test_highlevel_socket.py
+++ b/trio/tests/test_highlevel_socket.py
@@ -153,7 +153,7 @@ async def test_SocketListener_socket_closed_underfoot():
 
 
 async def test_SocketListener_accept_errors():
-    class FakeSocket:
+    class FakeSocket(tsocket.SocketType):
         def __init__(self, events):
             self._events = iter(events)
 
@@ -177,12 +177,6 @@ async def test_SocketListener_accept_errors():
                 raise event
             else:
                 return event, None
-
-    class FakeSocketFactory:
-        def is_trio_socket(self, obj):
-            return isinstance(obj, FakeSocket)
-
-    tsocket.set_custom_socket_factory(FakeSocketFactory())
 
     fake_server_sock = FakeSocket([])
 


### PR DESCRIPTION
As pointed out in:

  https://github.com/python-trio/trio/issues/170#issuecomment-327025129

there are advantages to having the "is this a trio socket" check be
spelled using 'isinstance'. This commit un-deprecates the
trio.socket.SocketType name and makes it an abstract class that
concrete socket implementations should inherit from, and then gets rid
of is_trio_socket since it's now unnecessary.