### PR TITLE
Fix --run-slow test option

### DIFF
--- a/trio/_core/tests/test_ki.py
+++ b/trio/_core/tests/test_ki.py
@@ -12,7 +12,6 @@ from ... import _core
 from ...testing import wait_all_tasks_blocked
 from ..._util import acontextmanager, signal_raise
 from ..._timeouts import sleep
-from .tutil import slow
 
 
 def ki_self():
@@ -446,7 +445,7 @@ def test_ki_is_good_neighbor():
 #   pthread_kill(pthread_self, SIGINT)
 # in the child thread, to make sure signals in non-main threads also wake up
 # the main loop... but currently that test would fail (see gh-109 again).
-@slow
+@pytest.mark.slow
 def test_ki_wakes_us_up():
     assert threading.current_thread() == threading.main_thread()
 

--- a/trio/_core/tests/test_multierror.py
+++ b/trio/_core/tests/test_multierror.py
@@ -7,8 +7,6 @@ import re
 from pathlib import Path
 import subprocess
 
-from .tutil import slow
-
 from .._multierror import (
     MultiError,
     format_exception,
@@ -509,21 +507,21 @@ else:
 need_ipython = pytest.mark.skipif(not have_ipython, reason="need IPython")
 
 
-@slow
+@pytest.mark.slow
 @need_ipython
 def test_ipython_exc_handler():
     completed = run_script("simple_excepthook.py", use_ipython=True)
     check_simple_excepthook(completed)
 
 
-@slow
+@pytest.mark.slow
 @need_ipython
 def test_ipython_imported_but_unused():
     completed = run_script("simple_excepthook_IPython.py")
     check_simple_excepthook(completed)
 
 
-@slow
+@pytest.mark.slow
 @need_ipython
 def test_ipython_custom_exc_handler():
     # Check we get a nice warning (but only one!) if the user is using IPython

--- a/trio/_core/tests/tutil.py
+++ b/trio/_core/tests/tutil.py
@@ -4,13 +4,6 @@ import pytest
 
 import gc
 
-# See trio/tests/conftest.py for the other half of this
-slow = pytest.mark.skipif(
-    not pytest.config.getoption("--run-slow", True),
-    reason="use --run-slow to run slow tests",
-)
-
-
 def gc_collect_harder():
     # In the test suite we sometimes want to call gc.collect() to make sure
     # that any objects with noisy __del__ methods (e.g. unawaited coroutines)

--- a/trio/tests/conftest.py
+++ b/trio/tests/conftest.py
@@ -13,6 +13,14 @@ from ..testing import trio_test, MockClock
 def pytest_addoption(parser):
     parser.addoption("--run-slow", action="store_true", help="run slow tests")
 
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--run-slow"):
+        # --runslow given in cli: do not skip slow tests
+        return
+    skip_slow = pytest.mark.skip(reason="need --run-slow option to run")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)
 
 @pytest.fixture
 def mock_clock():

--- a/trio/tests/test_highlevel_open_tcp_listeners.py
+++ b/trio/tests/test_highlevel_open_tcp_listeners.py
@@ -10,7 +10,6 @@ from trio import (
 )
 from trio.testing import open_stream_to_socket_listener
 from .. import socket as tsocket
-from .._core.tests.tutil import slow
 
 
 async def test_open_tcp_listeners_basic():
@@ -75,7 +74,7 @@ async def measure_backlog(listener):
     return len(client_streams)
 
 
-@slow
+@pytest.mark.slow
 async def test_open_tcp_listeners_backlog():
     # Operating systems don't necessarily use the exact backlog you pass
     async def check_backlog(nominal, required_min, required_max):

--- a/trio/tests/test_ssl.py
+++ b/trio/tests/test_ssl.py
@@ -22,8 +22,6 @@ from .. import ssl as tssl
 from .. import socket as tsocket
 from .._util import ConflictDetector, acontextmanager
 
-from .._core.tests.tutil import slow
-
 from ..testing import (
     assert_checkpoints,
     Sequencer,
@@ -551,7 +549,7 @@ async def test_renegotiation_simple():
         await s.aclose()
 
 
-@slow
+@pytest.mark.slow
 async def test_renegotiation_randomized(mock_clock):
     # The only blocking things in this function are our random sleeps, so 0 is
     # a good threshold.

--- a/trio/tests/test_threads.py
+++ b/trio/tests/test_threads.py
@@ -13,7 +13,6 @@ from ..testing import wait_all_tasks_blocked
 from .._threads import *
 
 from .._core.tests.test_ki import ki_self
-from .._core.tests.tutil import slow
 
 
 async def test_do_in_trio_thread():


### PR DESCRIPTION
Symptom:
```======================================================================
ERROR: trio._core.tests.test_ki (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: trio._core.tests.test_ki
Traceback (most recent call last):
  File "/usr/lib/python3.6/unittest/loader.py", line 428, in _find_test_path
    module = self._get_module_from_name(name)
  File "/usr/lib/python3.6/unittest/loader.py", line 369, in _get_module_from_name
    __import__(name)
  File "/home/smurf/src/trio/.pybuild/pythonX.Y_3.6/build/trio/_core/tests/test_ki.py", line 15, in <module>
    from .tutil import slow
  File "/home/smurf/src/trio/.pybuild/pythonX.Y_3.6/build/trio/_core/tests/tutil.py", line 9, in <module>
    not pytest.config.getoption("--run-slow", True),
AttributeError: module 'pytest' has no attribute 'config'
```
Fix:
Use the pattern described in
https://docs.pytest.org/en/latest/example/simple.html