### PR TITLE
Asyncio compatibility

### DIFF
--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -929,7 +929,14 @@ class Runner:
         # for things like functools.partial objects wrapping an async
         # function. So we have to just call it and then check whether the
         # result is a coroutine object.
-        if not inspect.iscoroutine(coro):
+        if coro.__class__.__name__ == "CoroWrapper":
+            # CoroWrapper is an asyncio class used during debugging.
+            # They are not recognized as coroutines by the Python core,
+            # but they duck-type as such, so silently accept them.
+            # Testing by name because importing asyncio just for that test
+            # is overkill.
+            pass
+        elif not inspect.iscoroutine(coro):
             # Give good error for: nursery.start_soon(asyncio.sleep, 1)
             if _return_value_looks_like_wrong_library(coro):
                 raise TypeError(


### PR DESCRIPTION
I decided to do something about bug #171 so here is a first attempt at asyncio compatibility.

Asyncio's mainloop does not lend itself to being called from
Trio because its call to select() is too deeply embedded in it. Thus, this patch
supersedes all reasons why you'd need the "mainloop" part of asyncio's "loop" classes in the first place:
timeouts, file descriptors, and call-soon handling is delegated to trio. Everything else is left alone.
    
This code is incomplete and definitely not yet ready for merging, but the basic approach should work: about half of `aiotest`'s test cases succeed. Comments are welcome (and the reason I'm posting this hacky code in the first place).
    
TODO:
* support for asyncio threads, esp . `call_soon_threadsafe`.
* use asyncio.Handle/TimerHandle (or possibly subclasses of these) for code reuse and compatibility
* ditto for file descriptors.
* the timer implementation is too heavy-weight:
  use a separate task to manage them
* file descriptor retention across loop restarts is a hack, we can do better
* last but not least: add tests, e.g. from aiotest
  (but without the <3.5 and trollius stuff); add some trio/asyncio interoperability tests
* What about Windows?
