### PR TITLE
Add a custom stdlib logging.Formatter for MultiErrors

### DIFF
--- a/docs/source/reference-core.rst
+++ b/docs/source/reference-core.rst
@@ -1046,6 +1046,82 @@ you return a new exception object, then the new object's
 ``__context__`` attribute will automatically be set to the original
 exception.
 
+.. autoclass:: Formatter
+
+Example:
+
+To setup a logger that will properly format :exc:`MultiError`
+tracebacks::
+
+    import logging
+
+    # Create logger
+    logger = logging.getLogger('simple_example')
+
+    # Create console handler
+    ch = logging.StreamHandler()
+
+    # Create formatter
+    formatter = trio.Formatter()
+
+    # add formatter to ch
+    ch.setFormatter(formatter)
+
+    # add ch to logger
+    logger.addHandler(ch)
+
+If you use a ``logging.conf`` file with :func:`logging.config.fileConfig`
+
+.. code-block:: ini
+
+    [loggers]
+    keys=root,trioExample
+
+    [handlers]
+    keys=consoleHandler
+
+    [formatters]
+    keys=trioFormatter
+
+    [logger_root]
+    handlers=consoleHandler
+
+    [logger_trioExample]
+    handlers=consoleHandler
+    qualname=trioExample
+    propagate=0
+
+    [handler_consoleHandler]
+    class=StreamHandler
+    formatter=trioFormatter
+    args=(sys.stdout,)
+
+    [formatter_trioFormatter]
+    class=trio.Formatter
+
+If you use a YAML file with :func:`logging.config.dictConfig`
+
+.. code-block:: yaml
+
+    version: 1
+    formatters:
+      trio:
+        class: trio.Formatter
+    handlers:
+      console:
+        class: logging.StreamHandler
+        formatter: trio
+        stream: ext://sys.stdout
+    loggers:
+      trioExample:
+        handlers: [console]
+        propagate: no
+    root:
+      handlers: [console]
+
+For more details see the :ref:`Standard Library Logging Configuration
+functions<logging-config-api>`.
+
 
 Task-local storage
 ------------------

--- a/trio/_core/_multierror.py
+++ b/trio/_core/_multierror.py
@@ -6,8 +6,9 @@ import types
 from contextlib import contextmanager
 
 import attr
+import logging
 
-__all__ = ["MultiError", "format_exception"]
+__all__ = ["MultiError", "format_exception", "Formatter"]
 
 ################################################################
 # MultiError
@@ -405,6 +406,28 @@ def _format_exception_multi(seen, etype, value, tb, limit, chain):
                 chunks.append(textwrap.indent(chunk, " " * 2))
 
     return chunks
+
+
+################################################################
+# MultiError logging Formatter
+################################################################
+
+
+class Formatter(logging.Formatter):
+    """
+    A :class:`logging.Formatter` but with special support for printing tracebacks for :class:`trio.MultiError`.
+    """
+
+    def formatException(self, ei):
+        """
+        Format and return the specified exception information as a string.
+
+        This implementation uses :func:`trio.format_exception`.
+        """
+        s = "".join(format_exception(ei[0], ei[1], ei[2]))
+        if s[-1:] == "\n":
+            s = s[:-1]
+        return s
 
 
 def trio_excepthook(etype, value, tb):

--- a/trio/_toplevel_core_reexports.py
+++ b/trio/_toplevel_core_reexports.py
@@ -17,7 +17,8 @@ __all__ = [
     "TrioInternalError", "RunFinishedError", "WouldBlock", "Cancelled",
     "ResourceBusyError", "MultiError", "format_exception", "run",
     "open_nursery", "open_cancel_scope", "current_effective_deadline",
-    "STATUS_IGNORED", "current_time", "current_instruments", "TaskLocal"
+    "STATUS_IGNORED", "current_time", "current_instruments", "TaskLocal",
+    "Formatter"
 ]
 
 from . import _core


### PR DESCRIPTION
This formatter will use `format_exception` to format all exceptions so that `MultiError` instances are logged properly.

Documentation is included showing how to register the formatter.

See gh-305.