### PR TITLE
Skip tests that need IPv6 if it is not available

### DIFF
--- a/trio/_core/tests/tutil.py
+++ b/trio/_core/tests/tutil.py
@@ -1,4 +1,5 @@
 # Utilities for testing
+import socket as stdlib_socket
 
 import pytest
 
@@ -9,6 +10,16 @@ slow = pytest.mark.skipif(
     not pytest.config.getoption("--run-slow", True),
     reason="use --run-slow to run slow tests",
 )
+
+try:
+    with stdlib_socket.socket(stdlib_socket.AF_INET6,
+                              stdlib_socket.SOCK_STREAM, 0) as s:
+        s.bind(('::1', 0))
+    have_ipv6 = True
+except OSError:
+    have_ipv6 = False
+
+need_ipv6 = pytest.mark.skipif(not have_ipv6, reason="need IPv6")
 
 
 def gc_collect_harder():

--- a/trio/tests/test_highlevel_open_tcp_listeners.py
+++ b/trio/tests/test_highlevel_open_tcp_listeners.py
@@ -10,7 +10,7 @@ from trio import (
 )
 from trio.testing import open_stream_to_socket_listener
 from .. import socket as tsocket
-from .._core.tests.tutil import slow
+from .._core.tests.tutil import slow, need_ipv6
 
 
 async def test_open_tcp_listeners_basic():
@@ -90,6 +90,7 @@ async def test_open_tcp_listeners_backlog():
     await check_backlog(nominal=10, required_min=10, required_max=20)
 
 
+@need_ipv6
 async def test_open_tcp_listeners_ipv6_v6only():
     # Check IPV6_V6ONLY is working properly
     (ipv6_listener,) = await open_tcp_listeners(0, host="::1")

--- a/trio/tests/test_socket.py
+++ b/trio/tests/test_socket.py
@@ -4,6 +4,7 @@ import os
 import socket as stdlib_socket
 import inspect
 
+from .._core.tests.tutil import need_ipv6
 from .. import _core
 from .. import socket as tsocket
 from .._socket import _NUMERIC_ONLY, _try_sync
@@ -352,9 +353,10 @@ async def test_SocketType_shutdown():
 
 
 @pytest.mark.parametrize(
-    "address, socket_type",
-    [('127.0.0.1', tsocket.AF_INET),
-     ('::1', tsocket.AF_INET6)]
+    "address, socket_type", [
+        ('127.0.0.1', tsocket.AF_INET),
+        pytest.param('::1', tsocket.AF_INET6, marks=need_ipv6)
+    ]
 )
 async def test_SocketType_simple_server(address, socket_type):
     # listen, bind, accept, connect, getpeername, getsockname

--- a/trio/tests/test_testing.py
+++ b/trio/tests/test_testing.py
@@ -6,6 +6,7 @@ import tempfile
 
 import pytest
 
+from .._core.tests.tutil import have_ipv6
 from .. import sleep
 from .. import _core
 from .._highlevel_generic import ClosedStreamError, aclose_forcefully
@@ -813,11 +814,12 @@ async def test_open_stream_to_socket_listener():
     sock.listen(10)
     await check(SocketListener(sock))
 
-    # Listener bound to IPv6 wildcard (needs special handling)
-    sock = tsocket.socket(family=tsocket.AF_INET6)
-    sock.bind(("::", 0))
-    sock.listen(10)
-    await check(SocketListener(sock))
+    if have_ipv6:
+        # Listener bound to IPv6 wildcard (needs special handling)
+        sock = tsocket.socket(family=tsocket.AF_INET6)
+        sock.bind(("::", 0))
+        sock.listen(10)
+        await check(SocketListener(sock))
 
     if hasattr(tsocket, "AF_UNIX"):
         # Listener bound to Unix-domain socket


### PR DESCRIPTION
IPv6 is not available on all travis images. This will skip IPv6 tests when IPv6 is not available.