### PR TITLE
Monkey patch traceback.TracebackException to support MultiError

### DIFF
--- a/docs/source/reference-core.rst
+++ b/docs/source/reference-core.rst
@@ -982,8 +982,6 @@ Nursery objects provide the following interface:
 Working with :exc:`MultiError`\s
 ++++++++++++++++++++++++++++++++
 
-.. autofunction:: format_exception
-
 .. autoexception:: MultiError
 
    .. attribute:: exceptions
@@ -1045,6 +1043,38 @@ context chaining. :meth:`MultiError.filter` and
 you return a new exception object, then the new object's
 ``__context__`` attribute will automatically be set to the original
 exception.
+
+We also monkey patch :class:`traceback.TracebackException` to be able
+to handle formatting :exc:`MultiError`\s. This means that anything that
+formats exception messages like :mod:`logging` will work out of the
+box::
+
+    import logging
+
+    logging.basicConfig()
+
+    try:
+        raise MultiError([ValueError("foo"), KeyError("bar")])
+    except:
+        logging.exception("Oh no!")
+        raise
+
+Will properly log the inner exceptions:
+
+.. code-block:: none
+
+    ERROR:root:Oh no!
+    Traceback (most recent call last):
+      File "<stdin>", line 2, in <module>
+    trio.MultiError: ValueError('foo',), KeyError('bar',)
+
+    Details of embedded exception 1:
+
+      ValueError: foo
+
+    Details of embedded exception 2:
+
+      KeyError: 'bar'
 
 
 Task-local storage

--- a/trio/_toplevel_core_reexports.py
+++ b/trio/_toplevel_core_reexports.py
@@ -14,10 +14,21 @@
 # a test to make sure that every _core export does get re-exported in one of
 # these places or another.
 __all__ = [
-    "TrioInternalError", "RunFinishedError", "WouldBlock", "Cancelled",
-    "ResourceBusyError", "MultiError", "format_exception", "run",
-    "open_nursery", "open_cancel_scope", "current_effective_deadline",
-    "STATUS_IGNORED", "current_time", "current_instruments", "TaskLocal"
+    "TrioInternalError",
+    "RunFinishedError",
+    "WouldBlock",
+    "Cancelled",
+    "ResourceBusyError",
+    "MultiError",
+    "run",
+    "format_exception",
+    "open_nursery",
+    "open_cancel_scope",
+    "current_effective_deadline",
+    "STATUS_IGNORED",
+    "current_time",
+    "current_instruments",
+    "TaskLocal",
 ]
 
 from . import _core


### PR DESCRIPTION
This monkey patches `traceback.TracebackException` on import. It overrides `TracebackException.__init__()` to extract any inner exceptions from `MultiError`s and overrides `TracebackException.format()` to include the details of the embedded exceptions.

This deprecates `trio.format_exception` as it is no longer needed and is now an alias for `traceback.format_exception`.

Documentation is included detailing some examples where this would be useful e.g. logging.

See gh-305.