### PR TITLE
Un-deprecate assert_no_yields and rename to assert_no_checkpoints

### DIFF
--- a/trio/testing/__init__.py
+++ b/trio/testing/__init__.py
@@ -34,6 +34,10 @@ _deprecate.enable_attribute_deprecations(__name__)
 __deprecated_attributes__ = {
     "assert_yields":
         _deprecate.DeprecatedAttribute(assert_checkpoints, "0.2.0", issue=157),
+    "assert_no_yields":
+        _deprecate.DeprecatedAttribute(
+            assert_no_checkpoints, "0.2.0", issue=157
+        ),
 }
 
 del _deprecate

--- a/trio/testing/_checkpoints.py
+++ b/trio/testing/_checkpoints.py
@@ -3,7 +3,7 @@ from contextlib import contextmanager
 from .. import _core
 from .._deprecate import deprecated
 
-__all__ = ["assert_checkpoints", "assert_no_yields"]
+__all__ = ["assert_checkpoints", "assert_no_checkpoints"]
 
 
 @contextmanager
@@ -42,8 +42,7 @@ def assert_checkpoints():
     return _assert_yields_or_not(True)
 
 
-@deprecated("0.2.0", issue=157, instead=None)
-def assert_no_yields():
+def assert_no_checkpoints():
     """Use as a context manager to check that the code inside the ``with``
     block does not execute any :ref:`check points <checkpoints>`.
 
@@ -51,10 +50,11 @@ def assert_no_yields():
       AssertionError: if a checkpoint was executed.
 
     Example:
-      Synchronous code never yields, but we can double-check that::
+      Synchronous code never contains any checkpoints, but we can double-check
+      that::
 
          queue = trio.Queue(10)
-         with trio.testing.assert_no_yields():
+         with trio.testing.assert_no_checkpoints():
              queue.put_nowait(None)
 
     """

--- a/trio/tests/test_testing.py
+++ b/trio/tests/test_testing.py
@@ -158,12 +158,12 @@ async def test_assert_checkpoints(recwarn):
         await _core.cancel_shielded_checkpoint()
 
 
-async def test_assert_no_yields(recwarn):
-    with assert_no_yields():
+async def test_assert_no_checkpoints(recwarn):
+    with assert_no_checkpoints():
         1 + 1
 
     with pytest.raises(AssertionError):
-        with assert_no_yields():
+        with assert_no_checkpoints():
             await _core.checkpoint()
 
     # partial yield cases
@@ -173,12 +173,12 @@ async def test_assert_no_yields(recwarn):
                           _core.cancel_shielded_checkpoint]:
         print(partial_yield)
         with pytest.raises(AssertionError):
-            with assert_no_yields():
+            with assert_no_checkpoints():
                 await partial_yield()
 
     # And both together also count as a checkpoint
     with pytest.raises(AssertionError):
-        with assert_no_yields():
+        with assert_no_checkpoints():
             await _core.checkpoint_if_cancelled()
             await _core.cancel_shielded_checkpoint()
 


### PR DESCRIPTION
This was deprecated as part of gh-157 due to lack of use cases, but
gh-329 reported a plausible use-case so let's put it back.