### PR TITLE
Drop pytest-catchlog from test-requirements.txt

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,5 @@
-pytest >= 3.1   # fixes a bug in handling async def test_* and turn warnings into errors.
+pytest >= 3.3  # for catchlog fixture
 pytest-cov
-ipython   # for the IPython traceback integration tests
-pyOpenSSL # for the ssl tests
-trustme   # for the ssl tests
-pytest-catchlog
+ipython        # for the IPython traceback integration tests
+pyOpenSSL      # for the ssl tests
+trustme        # for the ssl tests


### PR DESCRIPTION
pytest says:

  pytest-catchlog plugin has been merged into the core, please remove it from your requirements.

I hear and obey.