### PR TITLE
Give cancel scopes a nicer opaque repr

### DIFF
--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -88,7 +88,7 @@ class SystemClock:
 ################################################################
 
 
-@attr.s(cmp=False, hash=False)
+@attr.s(cmp=False, hash=False, repr=False)
 class CancelScope:
     _tasks = attr.ib(default=attr.Factory(set))
     _effective_deadline = attr.ib(default=inf)
@@ -96,6 +96,9 @@ class CancelScope:
     _shield = attr.ib(default=False)
     cancel_called = attr.ib(default=False)
     cancelled_caught = attr.ib(default=False)
+
+    def __repr__(self):
+        return "<cancel scope object at {:#x}>".format(id(self))
 
     @contextmanager
     @enable_ki_protection

--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -637,6 +637,12 @@ def test_instruments_crash(caplog):
     assert "Instrument has been disabled" in caplog.records[0].message
 
 
+async def test_cancel_scope_repr():
+    # Trivial smoke test
+    with _core.open_cancel_scope() as scope:
+        assert repr(scope).startswith("<cancel scope object")
+
+
 def test_cancel_points():
     async def main1():
         with _core.open_cancel_scope() as scope:


### PR DESCRIPTION
Previously the cancel scope repr looked like:

```
CancelScope(_tasks={<Task '__main__.main' at 0x7f7f6af99a90>}, _effective_deadline=228508.69968805768, _deadline=228508.69968805768, _shield=False, cancel_called=False, cancelled_caught=False)
```

This reveals a bunch of internal details. Let's hide those.

Maybe an even nicer version would print some details about the public
attributes like deadline, shield, cancel_called? I hit this while
preparing a talk for Friday though so I want to get this in now :-)