### PR TITLE
Fix typo in `CapacityLimiter.acquire_on_behalf_of_nowait` docstring

### DIFF
--- a/trio/_sync.py
+++ b/trio/_sync.py
@@ -261,7 +261,7 @@ class CapacityLimiter:
         """Borrow a token from the sack, blocking if necessary.
 
         Raises:
-          RuntimeError: if the current task already holds a one of this sack's
+          RuntimeError: if the current task already holds one of this sack's
               tokens.
 
         """


### PR DESCRIPTION
Hello!
I found a typo as I was reading the docs. Here is a fix.