### PR TITLE
Be more careful about using time.monotonic instead of time.time

### DIFF
--- a/docs/source/reference-testing/across-realtime.py
+++ b/docs/source/reference-testing/across-realtime.py
@@ -45,9 +45,9 @@ async def main():
         nursery.start_soon(task2)
 
 def run_example(clock):
-    real_start = time.time()
+    real_start = time.monotonic()
     trio.run(main, clock=clock)
-    real_duration = time.time() - real_start
+    real_duration = time.monotonic() - real_start
     print("Total real time elapsed: {} seconds".format(real_duration))
 
 print("Clock where time passes at 100 years per second:\n")

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -267,12 +267,12 @@ this, that tries to call an async function but leaves out the
 
    async def broken_double_sleep(x):
        print("*yawn* Going to sleep")
-       start_time = time.time()
+       start_time = time.monotonic()
 
        # Whoops, we forgot the 'await'!
        trio.sleep(2 * x)
 
-       sleep_time = time.time() - start_time
+       sleep_time = time.monotonic() - start_time
        print("Woke up after {:.2f} seconds, feeling well rested!".format(sleep_time))
 
    trio.run(broken_double_sleep, 3)

--- a/notes-to-self/proxy-benchmarks.py
+++ b/notes-to-self/proxy-benchmarks.py
@@ -145,11 +145,11 @@ else:
 while True:
     print("-------")
     for obj in objs:
-        start = time.time()
+        start = time.monotonic()
         for _ in range(COUNT):
             obj.fileno()
             #obj.fileno
-        end = time.time()
+        end = time.monotonic()
         per_usec = COUNT / (end - start) / 1e6
         print("{:7.2f} / us: {} ({})"
               .format(per_usec, obj.strategy, obj.works_for))

--- a/notes-to-self/schedule-timing.py
+++ b/notes-to-self/schedule-timing.py
@@ -19,9 +19,9 @@ async def report_loop():
     try:
         while True:
             start_count = LOOPS
-            start_time = time.time()
+            start_time = time.monotonic()
             await trio.sleep(1)
-            end_time = time.time()
+            end_time = time.monotonic()
             end_count = LOOPS
             loops = end_count - start_count
             duration = end_time - start_time

--- a/trio/_core/tests/test_ki.py
+++ b/trio/_core/tests/test_ki.py
@@ -555,11 +555,11 @@ def test_ki_wakes_us_up():
             print("joining thread", sys.exc_info())
             thread.join()
 
-    start = time.time()
+    start = time.monotonic()
     try:
         _core.run(main)
     finally:
-        end = time.time()
+        end = time.monotonic()
         print("duration", end - start)
         print("sys.exc_info", sys.exc_info())
     assert 1.0 <= (end - start) < 2


### PR DESCRIPTION
The in test_ki.py actually managed to cause a spurious test failure:

  https://ci.cryptography.io/blue/organizations/jenkins/python-trio%2Ftrio/detail/PR-389/1/pipeline

so might as well get better habits.