### PR TITLE
Unix client socket support. See: #279

### DIFF
--- a/docs/source/reference-io.rst
+++ b/docs/source/reference-io.rst
@@ -195,6 +195,8 @@ abstraction.
 
 .. autofunction:: serve_ssl_over_tcp
 
+.. autofunction:: open_unix_socket
+
 .. autoclass:: SocketStream
    :members:
    :undoc-members:

--- a/newsfragments/401.feature.rst
+++ b/newsfragments/401.feature.rst
@@ -1,0 +1,1 @@
+Add unix client socket support.

--- a/trio/__init__.py
+++ b/trio/__init__.py
@@ -50,6 +50,9 @@ __all__ += _highlevel_open_tcp_stream.__all__
 from ._highlevel_open_tcp_listeners import *
 __all__ += _highlevel_open_tcp_listeners.__all__
 
+from ._highlevel_open_unix_stream import *
+__all__ += _highlevel_open_unix_stream.__all__
+
 from ._highlevel_ssl_helpers import *
 __all__ += _highlevel_ssl_helpers.__all__
 

--- a/trio/_core/_ki.py
+++ b/trio/_core/_ki.py
@@ -176,8 +176,10 @@ disable_ki_protection.__name__ = "disable_ki_protection"
 
 @contextmanager
 def ki_manager(deliver_cb, restrict_keyboard_interrupt_to_checkpoints):
-    if (threading.current_thread() != threading.main_thread()
-            or signal.getsignal(signal.SIGINT) != signal.default_int_handler):
+    if (
+        threading.current_thread() != threading.main_thread()
+        or signal.getsignal(signal.SIGINT) != signal.default_int_handler
+    ):
         yield
         return
 

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -383,8 +383,10 @@ class Nursery:
         self.cancel_scope.cancel()
 
     def _check_nursery_closed(self):
-        if (not self._nested_child_running and not self._children
-                and not self._pending_starts):
+        if (
+            not self._nested_child_running and not self._children
+            and not self._pending_starts
+        ):
             self._closed = True
             if self._parent_waiting_in_aexit:
                 self._parent_waiting_in_aexit = False
@@ -1477,8 +1479,10 @@ async def checkpoint_if_cancelled():
 
     """
     task = current_task()
-    if (task._pending_cancel_scope() is not None or
-        (task is task._runner.main_task and task._runner.ki_pending)):
+    if (
+        task._pending_cancel_scope() is not None or
+        (task is task._runner.main_task and task._runner.ki_pending)
+    ):
         await _core.checkpoint()
         assert False  # pragma: no cover
     task._cancel_points += 1

--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -1203,8 +1203,10 @@ async def test_TrioToken_run_sync_soon_idempotent():
         for i in range(100):
             token.run_sync_soon(cb, i, idempotent=True)
     await wait_all_tasks_blocked()
-    if (sys.version_info < (3, 6)
-            and platform.python_implementation() == "CPython"):
+    if (
+        sys.version_info < (3, 6)
+        and platform.python_implementation() == "CPython"
+    ):
         # no order guarantees
         record.sort()
     # Otherwise, we guarantee FIFO

--- a/trio/_highlevel_open_unix_stream.py
+++ b/trio/_highlevel_open_unix_stream.py
@@ -1,0 +1,32 @@
+import trio
+from trio._highlevel_open_tcp_stream import close_on_error
+from trio.socket import socket, SOCK_STREAM, AF_UNIX
+
+__all__ = ["open_unix_socket"]
+
+
+async def open_unix_socket(filename,):
+    """Opens a connection to the specified
+    `Unix domain socket <https://en.wikipedia.org/wiki/Unix_domain_socket>`_.
+
+    You must have read/write permission on the specified file to connect.
+
+    Args:
+      filename (str or bytes): The filename to open the connection to.
+
+    Returns:
+      SocketStream: a :class:`~trio.abc.Stream` connected to the given file.
+
+    Raises:
+      OSError: If the socket file could not be connected to.
+    """
+    if filename is None:
+        raise ValueError("Filename cannot be None")
+
+    # much more simplified logic vs tcp sockets - one socket type and only one
+    # possible location to connect to
+    sock = socket(AF_UNIX, SOCK_STREAM)
+    with close_on_error(sock):
+        await sock.connect(filename)
+
+    return trio.SocketStream(sock)

--- a/trio/_highlevel_open_unix_stream.py
+++ b/trio/_highlevel_open_unix_stream.py
@@ -1,6 +1,12 @@
 import trio
 from trio._highlevel_open_tcp_stream import close_on_error
-from trio.socket import socket, SOCK_STREAM, AF_UNIX
+from trio.socket import socket, SOCK_STREAM
+
+try:
+    from trio.socket import AF_UNIX
+    has_unix = True
+except ImportError:
+    has_unix = False
 
 __all__ = ["open_unix_socket"]
 
@@ -19,7 +25,11 @@ async def open_unix_socket(filename,):
 
     Raises:
       OSError: If the socket file could not be connected to.
+      RuntimeError: If AF_UNIX sockets are not supported.
     """
+    if not has_unix:
+        raise RuntimeError("Unix sockets are not supported on this platform")
+
     if filename is None:
         raise ValueError("Filename cannot be None")
 

--- a/trio/_highlevel_open_unix_stream.py
+++ b/trio/_highlevel_open_unix_stream.py
@@ -13,7 +13,7 @@ __all__ = ["open_unix_socket"]
 
 async def open_unix_socket(filename,):
     """Opens a connection to the specified
-    `Unix domain socket <https://en.wikipedia.org/wiki/Unix_domain_socket>`_.
+    `Unix domain socket <https://en.wikipedia.org/wiki/Unix_domain_socket>`__.
 
     You must have read/write permission on the specified file to connect.
 

--- a/trio/_highlevel_socket.py
+++ b/trio/_highlevel_socket.py
@@ -43,9 +43,9 @@ class SocketStream(HalfCloseableStream):
       socket: The trio socket object to wrap. Must have type ``SOCK_STREAM``,
           and be connected.
 
-    By default, :class:`SocketStream` enables ``TCP_NODELAY``, and (on
-    platforms where it's supported) enables ``TCP_NOTSENT_LOWAT`` with a
-    reasonable buffer size (currently 16 KiB) – see `issue #72
+    By default for TCP sockets, :class:`SocketStream` enables ``TCP_NODELAY``,
+    and (on platforms where it's supported) enables ``TCP_NOTSENT_LOWAT`` with
+    a reasonable buffer size (currently 16 KiB) – see `issue #72
     <https://github.com/python-trio/trio/issues/72>`__ for discussion. You can
     of course override these defaults by calling :meth:`setsockopt`.
 

--- a/trio/_socket.py
+++ b/trio/_socket.py
@@ -1,15 +1,14 @@
-from functools import wraps as _wraps, partial as _partial
+import os as _os
 import socket as _stdlib_socket
 import sys as _sys
-import os as _os
-from contextlib import contextmanager as _contextmanager
-import errno as _errno
+from functools import wraps as _wraps
 
 import idna as _idna
 
 from . import _core
 from ._deprecate import deprecated
 from ._threads import run_sync_in_worker_thread
+from ._util import fspath
 
 __all__ = []
 
@@ -509,9 +508,7 @@ class _SocketType(SocketType):
         elif self._sock.family == AF_UNIX:
             await _core.checkpoint()
             # unwrap path-likes
-            if hasattr(address, "__fspath__"):
-                return address.__fspath__()
-            return address
+            return fspath(address)
 
         else:
             await _core.checkpoint()

--- a/trio/_socket.py
+++ b/trio/_socket.py
@@ -462,8 +462,10 @@ class _SocketType(SocketType):
     async def bind(self, address):
         await _core.checkpoint()
         address = await self._resolve_local_address(address)
-        if (hasattr(_stdlib_socket, "AF_UNIX") and self.family == AF_UNIX
-                and address[0]):
+        if (
+            hasattr(_stdlib_socket, "AF_UNIX") and self.family == AF_UNIX
+            and address[0]
+        ):
             # Use a thread for the filesystem traversal (unless it's an
             # abstract domain socket)
             return await run_sync_in_worker_thread(self._sock.bind, address)
@@ -504,6 +506,13 @@ class _SocketType(SocketType):
                     "address should be a (host, port, [flowinfo, [scopeid]]) "
                     "tuple"
                 )
+        elif self._sock.family == AF_UNIX:
+            await _core.checkpoint()
+            # unwrap path-likes
+            if hasattr(address, "__fspath__"):
+                return address.__fspath__()
+            return address
+
         else:
             await _core.checkpoint()
             return address

--- a/trio/_ssl.py
+++ b/trio/_ssl.py
@@ -630,9 +630,11 @@ class SSLStream(Stream):
                 # For some reason, EOF before handshake sometimes raises
                 # SSLSyscallError instead of SSLEOFError (e.g. on my linux
                 # laptop, but not on appveyor). Thanks openssl.
-                if (self._https_compatible
-                        and isinstance(exc.__cause__,
-                                       (SSLEOFError, SSLSyscallError))):
+                if (
+                    self._https_compatible and
+                    isinstance(exc.__cause__,
+                               (SSLEOFError, SSLSyscallError))
+                ):
                     return b""
                 else:
                     raise
@@ -647,8 +649,10 @@ class SSLStream(Stream):
                 # BROKEN. But that's actually fine, because after getting an
                 # EOF on TLS then the only thing you can do is close the
                 # stream, and closing doesn't care about the state.
-                if (self._https_compatible
-                        and isinstance(exc.__cause__, SSLEOFError)):
+                if (
+                    self._https_compatible
+                    and isinstance(exc.__cause__, SSLEOFError)
+                ):
                     return b""
                 else:
                     raise

--- a/trio/_util.py
+++ b/trio/_util.py
@@ -295,5 +295,5 @@ def fspath(path) -> t.Union[str, bytes]:
     )
 
 
-if hasattr(os, "fspath"):  # pragma: no cover
+if hasattr(os, "fspath"):
     fspath = os.fspath

--- a/trio/_util.py
+++ b/trio/_util.py
@@ -157,7 +157,7 @@ class _AsyncGeneratorContextManager:
     def __enter__(self):
         raise RuntimeError(
             "use 'async with {func_name}(...)', not 'with {func_name}(...)'".
-                format(func_name=self._func_name)
+            format(func_name=self._func_name)
         )
 
     def __exit__(self):  # pragma: no cover
@@ -264,6 +264,7 @@ def fixup_module_metadata(module_name, namespace):
 # Python 3.5. See: https://www.python.org/dev/peps/pep-0519/#os
 # The input typehint is removed as there is no os.PathLike on 3.5.
 
+
 def fspath(path) -> t.Union[str, bytes]:
     """Return the string representation of the path.
 
@@ -287,11 +288,14 @@ def fspath(path) -> t.Union[str, bytes]:
         if isinstance(path, (str, bytes)):
             return path
         else:
-            raise TypeError("expected __fspath__() to return str or bytes, "
-                            "not " + type(path).__name__)
+            raise TypeError(
+                "expected __fspath__() to return str or bytes, "
+                "not " + type(path).__name__
+            )
 
-    raise TypeError("expected str, bytes or os.PathLike object, not "
-                    + path_type.__name__)
+    raise TypeError(
+        "expected str, bytes or os.PathLike object, not " + path_type.__name__
+    )
 
 
 if sys.version_info[0:2] >= (3, 6):

--- a/trio/_util.py
+++ b/trio/_util.py
@@ -133,8 +133,11 @@ class _AsyncGeneratorContextManager:
                 # Likewise, avoid suppressing if a StopIteration exception
                 # was passed to throw() and later wrapped into a RuntimeError
                 # (see PEP 479).
-                if (isinstance(value, (StopIteration, StopAsyncIteration))
-                        and exc.__cause__ is value):
+                if (
+                    isinstance(value,
+                               (StopIteration, StopAsyncIteration))
+                    and exc.__cause__ is value
+                ):
                     return False
                 raise
             except:

--- a/trio/_util.py
+++ b/trio/_util.py
@@ -15,11 +15,8 @@ import async_generator
 from . import _core
 
 __all__ = [
-    "signal_raise",
-    "aiter_compat",
-    "acontextmanager",
-    "ConflictDetector",
-    "fixup_module_metadata",
+    "signal_raise", "aiter_compat", "acontextmanager", "ConflictDetector",
+    "fixup_module_metadata", "fspath"
 ]
 
 # Equivalent to the C function raise(), which Python doesn't wrap
@@ -298,5 +295,5 @@ def fspath(path) -> t.Union[str, bytes]:
     )
 
 
-if sys.version_info[0:2] >= (3, 6):
+if hasattr(os, "fspath"):  # pragma: no cover
     fspath = os.fspath

--- a/trio/testing/_checkpoints.py
+++ b/trio/testing/_checkpoints.py
@@ -15,11 +15,19 @@ def _assert_yields_or_not(expected):
     try:
         yield
     finally:
-        if (expected and (task._cancel_points == orig_cancel
-                          or task._schedule_points == orig_schedule)):
+        if (
+            expected and (
+                task._cancel_points == orig_cancel
+                or task._schedule_points == orig_schedule
+            )
+        ):
             raise AssertionError("assert_checkpoints block did not yield!")
-        elif (not expected and (task._cancel_points != orig_cancel
-                                or task._schedule_points != orig_schedule)):
+        elif (
+            not expected and (
+                task._cancel_points != orig_cancel
+                or task._schedule_points != orig_schedule
+            )
+        ):
             raise AssertionError("assert_no_yields block yielded!")
 
 

--- a/trio/tests/test_exports.py
+++ b/trio/tests/test_exports.py
@@ -11,8 +11,10 @@ def test_core_is_properly_reexported():
     for symbol in _core.__all__:
         found = 0
         for source in sources:
-            if (symbol in source.__all__
-                    and getattr(source, symbol) is getattr(_core, symbol)):
+            if (
+                symbol in source.__all__
+                and getattr(source, symbol) is getattr(_core, symbol)
+            ):
                 found += 1
         print(symbol, found)
         assert found == 1

--- a/trio/tests/test_highlevel_open_unix_stream.py
+++ b/trio/tests/test_highlevel_open_unix_stream.py
@@ -1,3 +1,4 @@
+import os
 import socket
 import tempfile
 
@@ -11,21 +12,22 @@ except ImportError:
     pytestmark = pytest.mark.skip("Needs unix socket support")
 
 
-async def test_open_unix_socket():
+async def get_server_socket():
     name = Path() / tempfile.gettempdir() / "test.sock"
     try:
         await name.unlink()
     except OSError:
         pass
 
-    # server socket
     serv_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    serv_sock.bind(name.__fspath__())
+    serv_sock.bind(name.__fspath__())  # bpo-32562
     serv_sock.listen(1)
 
-    # for some reason the server socket can accept the connection AFTER it has
-    # been opened, so use that to test here
-    unix_socket = await open_unix_socket(name.__fspath__())
+    return name, serv_sock
+
+
+async def _do_test_on_sock(serv_sock, unix_socket):
+    # shared code between some tests
     client, _ = serv_sock.accept()
     await unix_socket.send_all(b"test")
     assert client.recv(2048) == b"test"
@@ -33,3 +35,23 @@ async def test_open_unix_socket():
     client.sendall(b"response")
     received = await unix_socket.receive_some(2048)
     assert received == b"response"
+
+
+@pytest.mark.xfail
+async def test_open_bad_socket():
+    # mktemp is marked as insecure, but that's okay, we don't want the file to
+    # exist
+    name = os.path.join(tempfile.gettempdir(), tempfile.mktemp())
+    await open_unix_socket(name)
+
+
+async def test_open_unix_socket():
+    name, serv_sock = await get_server_socket()
+    unix_socket = await open_unix_socket(name.__fspath__())
+    await _do_test_on_sock(serv_sock, unix_socket)
+
+
+async def test_open_unix_socket_with_path():
+    name, serv_sock = await get_server_socket()
+    unix_socket = await open_unix_socket(name)
+    await _do_test_on_sock(serv_sock, unix_socket)

--- a/trio/tests/test_highlevel_open_unix_stream.py
+++ b/trio/tests/test_highlevel_open_unix_stream.py
@@ -1,7 +1,14 @@
 import socket
 import tempfile
 
+import pytest
+
 from trio import open_unix_socket, Path
+
+try:
+    from socket import AF_UNIX
+except ImportError:
+    pytestmark = pytest.mark.skip("Needs unix socket support")
 
 
 async def test_open_unix_socket():

--- a/trio/tests/test_highlevel_open_unix_stream.py
+++ b/trio/tests/test_highlevel_open_unix_stream.py
@@ -1,0 +1,28 @@
+import socket
+import tempfile
+
+from trio import open_unix_socket, Path
+
+
+async def test_open_unix_socket():
+    name = Path() / tempfile.gettempdir() / "test.sock"
+    try:
+        await name.unlink()
+    except OSError:
+        pass
+
+    # server socket
+    serv_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    serv_sock.bind(name.__fspath__())
+    serv_sock.listen(1)
+
+    # for some reason the server socket can accept the connection AFTER it has
+    # been opened, so use that to test here
+    unix_socket = await open_unix_socket(name.__fspath__())
+    client, _ = serv_sock.accept()
+    await unix_socket.send_all(b"test")
+    assert client.recv(2048) == b"test"
+
+    client.sendall(b"response")
+    received = await unix_socket.receive_some(2048)
+    assert received == b"response"

--- a/trio/tests/test_highlevel_open_unix_stream.py
+++ b/trio/tests/test_highlevel_open_unix_stream.py
@@ -37,12 +37,12 @@ async def _do_test_on_sock(serv_sock, unix_socket):
     assert received == b"response"
 
 
-@pytest.mark.xfail
 async def test_open_bad_socket():
     # mktemp is marked as insecure, but that's okay, we don't want the file to
     # exist
     name = os.path.join(tempfile.gettempdir(), tempfile.mktemp())
-    await open_unix_socket(name)
+    with pytest.raises(FileNotFoundError):
+        await open_unix_socket(name)
 
 
 async def test_open_unix_socket():

--- a/trio/tests/test_ssl.py
+++ b/trio/tests/test_ssl.py
@@ -66,9 +66,12 @@ TRIO_TEST_CA.configure_trust(CLIENT_CTX)
 # will hopefully be fixed soon
 import sys
 WORKAROUND_PYPY_BUG = False
-if (hasattr(sys, "pypy_version_info") and
-    ((sys.pypy_version_info < (5, 9)) or
-     (sys.pypy_version_info[:4] == (5, 9, 0, "alpha")))):
+if (
+    hasattr(sys, "pypy_version_info") and (
+        (sys.pypy_version_info < (5, 9)) or
+        (sys.pypy_version_info[:4] == (5, 9, 0, "alpha"))
+    )
+):
     WORKAROUND_PYPY_BUG = True
 
 


### PR DESCRIPTION
A month later, I finally found the motivation to implement this.

Implementation was relatively simple; I reused SocketStream and wrote a very basic connector function (for client connections, I don't think there's any more that could be done).

Note:

 - Some of the changes are apparently due to yapf reformatting, and were unintentional.
 - The new test uses raw `socket.socket` to emulate a UDS server - not sure if that's the right thing to do.