### PR TITLE
Update tag name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,7 +101,7 @@ asking for help in our `chat room
 <https://gitter.im/python-trio/general>`__, `filing a bug
 <https://github.com/python-trio/trio/issues/new>`__, or `posting a
 question on StackOverflow
-<https://stackoverflow.com/questions/ask?tags=python+trio>`__, and
+<https://stackoverflow.com/questions/ask?tags=python+python-trio>`__, and
 we'll do our best to help you out.
 
 **Trio is awesome and I want to help make it more awesome!** You're

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -20,5 +20,5 @@ https://stackoverflow.com/questions/25243482/how-to-add-sphinx-generated-index-t
 
 <p class="trio-help-hint">Need help? Try <a
 href="https://gitter.im/python-trio/general">chat</a> or <a
-href="https://stackoverflow.com/questions/ask?tags=python+trio">StackOverflow</a>.</p>
+href="https://stackoverflow.com/questions/ask?tags=python+python-trio">StackOverflow</a>.</p>
 {% endblock %}

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -108,8 +108,8 @@ If you get lost or confused...
 
 ...then we want to know! We have a friendly `chat channel
 <https://gitter.im/python-trio/general>`__, you can ask questions
-`using the "trio" tag on StackOverflow
-<https://stackoverflow.com/questions/ask?tags=python+trio>`__, or just
+`using the "python-trio" tag on StackOverflow
+<https://stackoverflow.com/questions/ask?tags=python+python-trio>`__, or just
 `file a bug <https://github.com/python-trio/trio/issues/new>`__ (if
 our documentation is confusing, that's our fault, and we want to fix
 it!).


### PR DESCRIPTION
See #402; `trio` is too generic a name to be a suitable tag on Stack Overflow.