### PR TITLE
Python 3.7 fixups

### DIFF
--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -768,7 +768,7 @@ class Runner:
                     .format(async_fn=async_fn)
                 ) from None
 
-            # Give good error for: nursery.start_soon(asyncio.sleep(1))
+            # Give good error for: nursery.start_soon(future)
             if _return_value_looks_like_wrong_library(async_fn):
                 raise TypeError(
                     "trio was expecting an async function, but instead it got "
@@ -785,7 +785,7 @@ class Runner:
         # function. So we have to just call it and then check whether the
         # result is a coroutine object.
         if not inspect.iscoroutine(coro):
-            # Give good error for: nursery.start_soon(asyncio.sleep, 1)
+            # Give good error for: nursery.start_soon(func_returning_future)
             if _return_value_looks_like_wrong_library(coro):
                 raise TypeError(
                     "start_soon got unexpected {!r} – are you trying to use a "

--- a/trio/_core/tests/test_result.py
+++ b/trio/_core/tests/test_result.py
@@ -17,7 +17,7 @@ def test_Result():
     assert e.error is exc
     with pytest.raises(RuntimeError):
         e.unwrap()
-    assert repr(e) == "Error(RuntimeError('oops',))"
+    assert repr(e) == "Error({!r})".format(exc)
 
     with pytest.raises(TypeError):
         Error("hello")

--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -1553,8 +1553,12 @@ def test_nice_error_on_bad_calls_to_run_or_spawn():
 
             import asyncio
 
+            @asyncio.coroutine
+            def generator_based_coro():
+                yield from asyncio.sleep(1)
+
             with pytest.raises(TypeError) as excinfo:
-                bad_call(asyncio.sleep(1))
+                bad_call(generator_based_coro())
             assert "asyncio" in str(excinfo.value)
 
             with pytest.raises(TypeError) as excinfo:
@@ -1562,7 +1566,7 @@ def test_nice_error_on_bad_calls_to_run_or_spawn():
             assert "asyncio" in str(excinfo.value)
 
             with pytest.raises(TypeError) as excinfo:
-                bad_call(asyncio.sleep, 1)
+                bad_call(generator_based_coro)
             assert "asyncio" in str(excinfo.value)
 
             with pytest.raises(TypeError) as excinfo:


### PR DESCRIPTION
Travis tests are currently failing because they finally updated their
Python 3.7-dev to something recent, and this created some mild test
breakage. This PR fixes it to get our CI working again.