### PR TITLE
[travis] Fix pypy skipping logic

### DIFF
--- a/ci/travis.sh
+++ b/ci/travis.sh
@@ -24,10 +24,13 @@ if [ "$USE_PYPY_NIGHTLY" = "1" ]; then
     # something like "pypy-c-jit-89963-748aa3022295-linux64"
     PYPY_DIR=$(echo pypy-c-jit-*)
     PYTHON_EXE=$PYPY_DIR/bin/pypy3
-    ($PYTHON_EXE -m ensurepip \
-     && $PYTHON_EXE -m pip install virtualenv \
-     && $PYTHON_EXE -m virtualenv testenv) \
-        || (echo "pypy nightly is broken; skipping tests"; exit 0)
+
+    if ! ($PYTHON_EXE -m ensurepip \
+              && $PYTHON_EXE -m pip install virtualenv \
+              && $PYTHON_EXE -m virtualenv testenv); then
+        echo "pypy nightly is broken; skipping tests"
+        exit 0
+    fi
     source testenv/bin/activate
 fi
 


### PR DESCRIPTION
We were calling 'exit 0' to skip the tests... inside subshell
parentheses (), so it was only exiting the subshell, not the overall
script. Whoops. Fix that.