### PR TITLE
Refactor open_unix_stream tests, and use more unique filename

### DIFF
--- a/trio/tests/test_highlevel_open_unix_stream.py
+++ b/trio/tests/test_highlevel_open_unix_stream.py
@@ -5,7 +5,6 @@ import tempfile
 import pytest
 
 from trio import open_unix_socket, Path
-from trio._util import fspath
 
 try:
     from socket import AF_UNIX
@@ -13,46 +12,34 @@ except ImportError:
     pytestmark = pytest.mark.skip("Needs unix socket support")
 
 
-async def get_server_socket():
-    name = Path() / tempfile.gettempdir() / "test.sock"
-    try:
-        await name.unlink()
-    except OSError:
-        pass
-
-    serv_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    serv_sock.bind(fspath(name))  # bpo-32562
-    serv_sock.listen(1)
-
-    return name, serv_sock
-
-
-async def _do_test_on_sock(serv_sock, unix_socket):
-    # shared code between some tests
-    client, _ = serv_sock.accept()
-    await unix_socket.send_all(b"test")
-    assert client.recv(2048) == b"test"
-
-    client.sendall(b"response")
-    received = await unix_socket.receive_some(2048)
-    assert received == b"response"
-
-
 async def test_open_bad_socket():
     # mktemp is marked as insecure, but that's okay, we don't want the file to
     # exist
-    name = os.path.join(tempfile.gettempdir(), tempfile.mktemp())
+    name = tempfile.mktemp()
     with pytest.raises(FileNotFoundError):
         await open_unix_socket(name)
 
 
 async def test_open_unix_socket():
-    name, serv_sock = await get_server_socket()
-    unix_socket = await open_unix_socket(fspath(name))
-    await _do_test_on_sock(serv_sock, unix_socket)
+    for name_type in [Path, str]:
+        name = tempfile.mktemp()
+        serv_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        with serv_sock:
+            serv_sock.bind(name)
+            try:
+                serv_sock.listen(1)
 
+                # The actual function we're testing
+                unix_socket = await open_unix_socket(name_type(name))
 
-async def test_open_unix_socket_with_path():
-    name, serv_sock = await get_server_socket()
-    unix_socket = await open_unix_socket(name)
-    await _do_test_on_sock(serv_sock, unix_socket)
+                async with unix_socket:
+                    client, _ = serv_sock.accept()
+                    with client:
+                        await unix_socket.send_all(b"test")
+                        assert client.recv(2048) == b"test"
+
+                        client.sendall(b"response")
+                        received = await unix_socket.receive_some(2048)
+                        assert received == b"response"
+            finally:
+                os.unlink(name)


### PR DESCRIPTION
The main substantive change here is switching to using mktemp() to
pick a server socket name, instead of using the fixed name
"/tmp/test.sock". This should fix gh-447.

While I was at it, I also refactored the main test, and made it clean
up after itself more carefully.

Finally, I replaced

   os.path.join(tempfile.gettempdir(), tempfile.mktemp())

with

   tempfile.mktemp()

Because it turns out they're equivalent: mktemp() already returns an
absolute filename inside an appropriate directory.