### PR TITLE
Add different implementation of a task monitor. [WIP]

### DIFF
--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -503,7 +503,7 @@ class Task:
     _schedule_points = attr.ib(default=0)
 
     def __repr__(self):
-        return ("<Task {!r} at {:#x}>".format(self.name, id(self)))
+        return "<Task {!r} at {:#x}>".format(self.name, id(self))
 
     @property
     def parent_nursery(self):

--- a/trio/monitor.py
+++ b/trio/monitor.py
@@ -10,12 +10,12 @@ from ._version import __version__
 from .abc import Instrument
 from .hazmat import current_task, Task
 
-
 # inspiration: https://github.com/python-trio/trio/blob/master/notes-to-self/print-task-tree.py
 
 # example usage:
 # monitor = Monitor()
 # trio.
+
 
 class Monitor(Instrument):
     """Represents a monitor; a simple way of monitoring the health of your
@@ -34,8 +34,9 @@ class Monitor(Instrument):
 
         # authentication for running code in a frame
         rand = random.SystemRandom()
-        self.auth_pin = ''.join(rand.choice(string.ascii_letters) for x in
-                                range(0, 8))
+        self.auth_pin = ''.join(
+            rand.choice(string.ascii_letters) for x in range(0, 8)
+        )
 
     @staticmethod
     def get_root_task() -> Task:
@@ -77,9 +78,10 @@ class Monitor(Instrument):
         """
         # send the banner
         version = __version__
-        await stream.send_all(b"Connected to the Trio monitor, using "
-                              b"trio " + version.encode(encoding="ascii") +
-                              b"\n")
+        await stream.send_all(
+            b"Connected to the Trio monitor, using "
+            b"trio " + version.encode(encoding="ascii") + b"\n"
+        )
 
         while True:
             await stream.send_all(b"trio> ")
@@ -97,8 +99,9 @@ class Monitor(Instrument):
             try:
                 fn = getattr(self, "command_{}".format(name))
             except AttributeError:
-                await stream.send_all(b"No such command: " + name.encode() +
-                                      b"\n")
+                await stream.send_all(
+                    b"No such command: " + name.encode() + b"\n"
+                )
                 continue
 
             try:
@@ -114,14 +117,16 @@ class Monitor(Instrument):
                 await stream.send_all(b"Error: " + errormessage.encode())
                 raise
 
-            await stream.send_all("\n".join(lines).encode(encoding="ascii") +
-                                  b"\n")
+            await stream.send_all(
+                "\n".join(lines).encode(encoding="ascii") + b"\n"
+            )
 
     # command definitions
     async def command_help(self):
         """Sends help.
         """
         name_rpad = 12
+
         def pred(i):
             return hasattr(i, "__name__") \
                    and i.__name__.startswith("command_")
@@ -178,7 +183,6 @@ class Monitor(Instrument):
         return lines
 
 
-
 def main():
     import argparse
     import telnetlib
@@ -188,10 +192,15 @@ def main():
         pass
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-a", "--address", default="127.0.0.1",
-                        help="The address to connect to")
-    parser.add_argument("-p", "--port", default=14761,
-                        help="The port to connect to")
+    parser.add_argument(
+        "-a",
+        "--address",
+        default="127.0.0.1",
+        help="The address to connect to"
+    )
+    parser.add_argument(
+        "-p", "--port", default=14761, help="The port to connect to"
+    )
 
     args = parser.parse_args()
     # TODO: Potentially wrap sys.stdin
@@ -199,6 +208,7 @@ def main():
     client.interact()
 
     return 0
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/trio/monitor.py
+++ b/trio/monitor.py
@@ -254,8 +254,8 @@ class Monitor(Instrument):
     async def command_ps(self):
         """Gets the current list of tasks."""
         lines = []
-        headers = ('ID', 'Name')
-        widths = (15, 50)
+        headers = ('ID', 'Name', 'Parent')
+        widths = (15, 50, 15)
         header_line = []
 
         for name, width in zip(headers, widths):
@@ -270,10 +270,14 @@ class Monitor(Instrument):
             else:
                 name = task.name
 
-            lines.append(' '.join([
-                str(id(task)).ljust(widths[0]),
-                name,
-            ]))
+            if task.parent_nursery is None:
+                parent = "N/A"
+            else:
+                parent = str(id(task.parent_nursery.parent_task))
+
+            result = [str(id(task)).ljust(widths[0]), name.ljust(49), parent]
+
+            lines.append(' '.join(result))
 
         return lines
 

--- a/trio/monitor.py
+++ b/trio/monitor.py
@@ -1,0 +1,139 @@
+import random
+import string
+import sys
+
+import inspect
+
+from ._version import __version__
+from .abc import Instrument
+from .hazmat import current_task, Task
+
+
+# inspiration: https://github.com/python-trio/trio/blob/master/notes-to-self/print-task-tree.py
+
+# example usage:
+# monitor = Monitor()
+# trio.
+
+class Monitor(Instrument):
+    """Represents a monitor; a simple way of monitoring the health of your
+    Trio application using the Trio instrumentation API.
+
+    The monitor protocol is a simple text-based protocol, accessible from a
+    telnet client, for example.
+    """
+    MID_PREFIX = "|─ "
+    MID_CONTINUE = "|  "
+    END_PREFIX = "\─ "
+    END_CONTINUE = " " * len(END_PREFIX)
+
+    def __init__(self):
+        self.authenticated = False
+
+        # authentication for running code in a frame
+        rand = random.SystemRandom()
+        self.auth_pin = ''.join(rand.choice(string.ascii_letters) for x in
+                                range(0, 8))
+
+    @staticmethod
+    def get_root_task() -> Task:
+        """Gets the current root task."""
+        task = current_task()
+        while task.parent_nursery is not None:
+            task = task.parent_nursery.parent_task
+        return task
+
+    async def listen_on_stream(self, stream):
+        """Makes the monitor server listen on a stream.
+        Use this as a callback from a listener.
+        """
+        return await self.main_loop(stream)
+
+    async def main_loop(self, stream):
+        """Runs the main loop of the monitor.
+        """
+        # send the banner
+        version = __version__
+        await stream.send_all(b"Connected to the Trio monitor, using "
+                              b"trio " + version.encode(encoding="ascii") +
+                              b"\n")
+
+        while True:
+            await stream.send_all(b"trio> ")
+            command = await stream.receive_some(2048)
+            if command == b"":
+                return
+
+            command = command.decode("ascii").rstrip("\n").rstrip("\r")
+            name, *args = command.split(" ")
+
+            # special handling for closing
+            if name in ["exit", "ex", "quit", "q", ":q"]:
+                return await stream.aclose()
+
+            try:
+                fn = getattr(self, "command_{}".format(name))
+            except AttributeError:
+                await stream.send_all(b"No such command: " + name.encode() +
+                                      b"\n")
+                continue
+
+            try:
+                lines = await fn(*args)
+            except Exception as e:
+                if isinstance(e, TypeError) and \
+                        "takes at most" in ' '.join(e.args):
+                    # hacky, but idk what else to do
+                    await stream.send_all(' '.join(e.args).encode("ascii"))
+                    continue
+
+                errormessage = type(e).__name__ + ": " + ' '.join(e.args)
+                await stream.send_all(b"Error: " + errormessage.encode())
+                raise
+
+            await stream.send_all("\n".join(lines).encode(encoding="ascii") +
+                                  b"\n")
+
+    # command definitions
+    async def command_help(self):
+        """
+        Sends help.
+        """
+        name_rpad = 12
+        def pred(i):
+            return hasattr(i, "__name__") \
+                   and i.__name__.startswith("command_")
+
+        commands = inspect.getmembers(self, predicate=pred)
+        lines = ["Commands:"]
+        for name, command in commands:
+            doc = inspect.getdoc(command).splitlines(keepends=False)[0]
+            name = name.split("_", 1)[1]
+            lines.append(name.ljust(name_rpad) + doc)
+
+        return lines
+
+
+def main():
+    import argparse
+    import telnetlib
+    try:
+        import readline
+    except ImportError:
+        pass
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-a", "--address", default="127.0.0.1",
+                        help="The address to connect to")
+    parser.add_argument("-p", "--port", default=14761,
+                        help="The port to connect to")
+
+    args = parser.parse_args()
+    # TODO: Potentially wrap sys.stdin
+    client = telnetlib.Telnet(host=args.address, port=args.port)
+    client.interact()
+
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This is WIP, don't merge yet.

This is a basic implementation of a task monitor as in #413. It is inspired by curio and the other PR open for this (#429) but takes a different approach, requiring the user to spawn a handler for the Monitor server.

Current plans:

 - [x] Use the instrument API to provide a command ala `redis-cli monitor` showing the live status of your application
 - [ ] Add a task tree displayer
 - [ ] Add the ability to execute code in a task's frame (maybe?)