### PR TITLE
Add `current_root_task` to get the root task without having to walk the tree.

### DIFF
--- a/docs/source/reference-hazmat.rst
+++ b/docs/source/reference-hazmat.rst
@@ -510,6 +510,8 @@ this does serve to illustrate the basic structure of the
 Task API
 --------
 
+.. autofunction:: current_root_task()
+
 .. autofunction:: current_task()
 
 .. class:: Task()

--- a/newsfragments/452.feature.rst
+++ b/newsfragments/452.feature.rst
@@ -1,1 +1,1 @@
-Add ``current_root_task`` to get the root task.
+Add :func:`trio.hazmat.current_root_task` to get the root task.

--- a/newsfragments/452.feature.rst
+++ b/newsfragments/452.feature.rst
@@ -1,0 +1,1 @@
+Add ``current_root_task`` to get the root task.

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -678,6 +678,13 @@ class Runner:
         """
         return self.clock
 
+    @_public
+    def current_root_task(self):
+        """Returns the current root :class:`Task`.
+
+        """
+        return self.init_task
+
     ################
     # Core task handling primitives
     ################

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -681,6 +681,8 @@ class Runner:
     @_public
     def current_root_task(self):
         """Returns the current root :class:`Task`.
+        
+        This is the task that is the ultimate parent of all other tasks.
 
         """
         return self.init_task

--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -1475,7 +1475,6 @@ async def test_task_tree_introspection():
 
 
 async def test_nursery_closure():
-
     async def child1(nursery):
         # We can add new tasks to the nursery even after entering __aexit__,
         # so long as there are still tasks running

--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -1,25 +1,23 @@
-import threading
-import sys
-import time
-from math import inf
-import platform
 import functools
+import platform
+import sys
+import threading
+import time
 import warnings
 from contextlib import contextmanager
-import gc
+from math import inf
 
-import pytest
 import attr
+import pytest
 
 from .tutil import check_sequence_matches, gc_collect_harder
+from ... import _core
+from ..._timeouts import sleep
 from ...testing import (
     wait_all_tasks_blocked,
     Sequencer,
     assert_checkpoints,
 )
-from ..._timeouts import sleep
-
-from ... import _core
 
 
 # slightly different from _timeouts.sleep_forever because it returns the value
@@ -275,6 +273,11 @@ async def test_current_task():
 
     async with _core.open_nursery() as nursery:
         nursery.start_soon(child)
+
+
+async def test_root_task():
+    root = _core.current_root_task()
+    assert root.parent_nursery is None
 
 
 def test_out_of_context():
@@ -1472,6 +1475,7 @@ async def test_task_tree_introspection():
 
 
 async def test_nursery_closure():
+
     async def child1(nursery):
         # We can add new tasks to the nursery even after entering __aexit__,
         # so long as there are still tasks running

--- a/trio/hazmat.py
+++ b/trio/hazmat.py
@@ -15,6 +15,7 @@ __all__ = [
     "Task",
     "checkpoint",
     "current_task",
+    "current_root_task",
     "checkpoint_if_cancelled",
     "spawn_system_task",
     "reschedule",


### PR DESCRIPTION
Re-opened because I broke my fork whilst rebasing.