### PR TITLE
Add ability to wait for POLLPRI

### DIFF
--- a/docs/source/reference-hazmat.rst
+++ b/docs/source/reference-hazmat.rst
@@ -194,6 +194,30 @@ Unix-like systems provide the following functions:
        become writable.
 
 
+.. function:: wait_priority(fd)
+   :async:
+
+   Block until there is an "exceptional condition" on the given file
+   descriptor.
+
+   .. warning::
+
+      This method uses the ``POLLPRI`` flag to the ``epoll`` system call.
+      Its semantics are highly specific to the type of file descriptor
+      you're passing to it.
+
+   This test may be used to
+   * wait for changes to hardware inputs (Linux GPIO)
+   * notice changed state of a PTY slave by the master
+   * …
+
+   :arg fd:
+       integer file descriptor, or else an object with a ``fileno()`` method
+   :raises trio.ResourceBusyError:
+       if another task is already waiting for an exceptional condition on
+       the given fd.
+
+
 Kqueue-specific API
 -------------------
 

--- a/trio/_core/_io_epoll.py
+++ b/trio/_core/_io_epoll.py
@@ -78,12 +78,16 @@ class EpollIOManager:
             # Clever hack stolen from selectors.EpollSelector: an event
             # with EPOLLHUP or EPOLLERR flags wakes both readers and
             # writers.
-            if flags & ~select.EPOLLIN and waiters.write_task is not None:
-                _core.reschedule(waiters.write_task)
-                waiters.write_task = None
-            if flags & ~select.EPOLLOUT and waiters.read_task is not None:
+            if flags & ~(
+                select.EPOLLOUT | select.EPOLLPRI
+            ) and waiters.read_task is not None:
                 _core.reschedule(waiters.read_task)
                 waiters.read_task = None
+            if flags & ~(
+                select.EPOLLIN | select.EPOLLPRI
+            ) and waiters.write_task is not None:
+                _core.reschedule(waiters.write_task)
+                waiters.write_task = None
             if flags & select.EPOLLPRI and waiters.prio_task is not None:
                 _core.reschedule(waiters.prio_task)
                 waiters.prio_task = None

--- a/trio/hazmat.py
+++ b/trio/hazmat.py
@@ -22,6 +22,7 @@ __all__ = [
     "add_instrument",
     "current_clock",
     "current_statistics",
+    "wait_priority",
     "wait_writable",
     "wait_readable",
     "ParkingLot",


### PR DESCRIPTION
This extension is required for some interesting things. Personally I need it for accessing GPIO pins (specifically, epoll()ing for changing inputs).

I still have to figure out how to reliably test this, given that the TCP URGent flag is less than well supported these days, Travis is unlikely to run on a machine with two connected GPIO pins, and I haven't done anything with PTYs in a decade.