### PR TITLE
Error for user-created Cancelled()

### DIFF
--- a/newsfragments/342.removal.rst
+++ b/newsfragments/342.removal.rst
@@ -1,0 +1,3 @@
+Attempting to raise :exc:`trio.Cancelled` will cause a :exc:`RuntimeError`.
+:meth:`cancel_scope.cancel() <trio.The cancel scope interface.cancel>` should be
+used instead.

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -168,7 +168,7 @@ class CancelScope:
         self._tasks.update(tasks)
 
     def _make_exc(self):
-        exc = Cancelled()
+        exc = Cancelled._init()
         exc._scope = self
         return exc
 

--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -1848,3 +1848,18 @@ async def test_contextvar_multitask():
         var.set("hmmmm")
         n.start_soon(t2)
         await wait_all_tasks_blocked()
+
+
+def test_Cancelled_init():
+    check_Cancelled_error = pytest.raises(
+        RuntimeError, match='should not be raised directly'
+    )
+
+    with check_Cancelled_error:
+        raise _core.Cancelled
+
+    with check_Cancelled_error:
+        _core.Cancelled()
+
+    # private constructor should not raise
+    _core.Cancelled._init()


### PR DESCRIPTION
Resolves #342.

- Is `RuntimeError` the correct type?
- Should the error message be more helpful? We probably want to point people to `CancelScope.cancel()`

## Todo
- [x] Add tests
- [x] Add note in `Cancelled`'s documentation that users should not raise it themselves.