### PR TITLE
make SocketType.type match what it will be in python 3.7+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
+.pytest_cache/
 nosetests.xml
 coverage.xml
 

--- a/trio/_highlevel_socket.py
+++ b/trio/_highlevel_socket.py
@@ -5,7 +5,6 @@ from contextlib import contextmanager
 
 from . import _core
 from . import socket as tsocket
-from ._socket import real_socket_type
 from ._util import ConflictDetector
 from .abc import HalfCloseableStream, Listener
 from ._highlevel_generic import (
@@ -62,7 +61,7 @@ class SocketStream(HalfCloseableStream):
     def __init__(self, socket):
         if not isinstance(socket, tsocket.SocketType):
             raise TypeError("SocketStream requires trio socket object")
-        if real_socket_type(socket.type) != tsocket.SOCK_STREAM:
+        if socket.type != tsocket.SOCK_STREAM:
             raise ValueError("SocketStream requires a SOCK_STREAM socket")
         try:
             socket.getpeername()
@@ -339,7 +338,7 @@ class SocketListener(Listener):
     def __init__(self, socket):
         if not isinstance(socket, tsocket.SocketType):
             raise TypeError("SocketListener requires trio socket object")
-        if real_socket_type(socket.type) != tsocket.SOCK_STREAM:
+        if socket.type != tsocket.SOCK_STREAM:
             raise ValueError("SocketListener requires a SOCK_STREAM socket")
         try:
             listening = socket.getsockopt(

--- a/trio/_socket.py
+++ b/trio/_socket.py
@@ -362,10 +362,9 @@ _SOCK_TYPE_MASK = ~(
 
 # Note that this is *not* in __all__.
 #
-# Hopefully Python will eventually make something like this public
-# (see bpo-21327) but I don't want to make it public myself and then
-# find out they picked a different name... this is used internally in
-# this file and also elsewhere in trio.
+# This function will modify the given socket to match the behavior in python
+# 3.7. This will become unecessary and can be removed when support for versions
+# older than 3.7 is dropped.
 def real_socket_type(type_num):
     return type_num & _SOCK_TYPE_MASK
 
@@ -440,6 +439,9 @@ class _SocketType(SocketType):
 
     @property
     def type(self):
+        # Modify the socket type do match what is done on python 3.7. When
+        # support for versions older than 3.7 is dropped, this can be updated
+        # to just return self._sock.type
         return real_socket_type(self._sock.type)
 
     @property

--- a/trio/_socket.py
+++ b/trio/_socket.py
@@ -144,7 +144,7 @@ def set_custom_hostname_resolver(hostname_resolver):
       hostname_resolver (trio.abc.HostnameResolver or None): The new custom
           hostname resolver, or None to restore the default behavior.
 
-    Returns: 
+    Returns:
       The previous hostname resolver (which may be None).
 
     """
@@ -172,7 +172,7 @@ def set_custom_socket_factory(socket_factory):
       socket_factory (trio.abc.SocketFactory or None): The new custom
           socket factory, or None to restore the default behavior.
 
-    Returns: 
+    Returns:
       The previous socket factory (which may be None).
 
     """
@@ -440,7 +440,7 @@ class _SocketType(SocketType):
 
     @property
     def type(self):
-        return self._sock.type
+        return real_socket_type(self._sock.type)
 
     @property
     def proto(self):
@@ -531,8 +531,7 @@ class _SocketType(SocketType):
             if not self._sock.getsockopt(IPPROTO_IPV6, IPV6_V6ONLY):
                 flags |= AI_V4MAPPED
         gai_res = await getaddrinfo(
-            host, port, self._sock.family, real_socket_type(self._sock.type),
-            self._sock.proto, flags
+            host, port, self._sock.family, self.type, self._sock.proto, flags
         )
         # AFAICT from the spec it's not possible for getaddrinfo to return an
         # empty list.

--- a/trio/tests/test_socket.py
+++ b/trio/tests/test_socket.py
@@ -7,6 +7,7 @@ import tempfile
 
 from .._core.tests.tutil import need_ipv6
 from .. import _core
+from .. import _socket as _tsocket
 from .. import socket as tsocket
 from .._socket import _NUMERIC_ONLY, _try_sync
 from ..testing import assert_checkpoints, wait_all_tasks_blocked
@@ -308,7 +309,7 @@ async def test_SocketType_basics():
     # type family proto
     stdlib_sock = stdlib_socket.socket()
     sock = tsocket.from_stdlib_socket(stdlib_sock)
-    assert sock.type == stdlib_sock.type
+    assert sock.type == _tsocket.real_socket_type(stdlib_sock.type)
     assert sock.family == stdlib_sock.family
     assert sock.proto == stdlib_sock.proto
     sock.close()


### PR DESCRIPTION
Resolves https://github.com/python-trio/trio/issues/422

I'm not sure if the test is correct so please let me know if that (or anything else) needs to be modified.