### PR TITLE
Use immutable default for argument

### DIFF
--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -1140,7 +1140,7 @@ def run(
     async_fn,
     *args,
     clock=None,
-    instruments=[],
+    instruments=(),
     restrict_keyboard_interrupt_to_checkpoints=False
 ):
     """Run a trio-flavored async function, and return the result.


### PR DESCRIPTION
This is not currently a problem, but fixing it makes it *obviously* safe and avoids future bugs.  Closes #514.