### PR TITLE
Raise a more explicit async generator error

### DIFF
--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -14,7 +14,9 @@ from math import inf
 from time import monotonic
 
 import attr
-from async_generator import async_generator, yield_, asynccontextmanager
+from async_generator import (
+    async_generator, yield_, asynccontextmanager, isasyncgen
+)
 from sortedcontainers import SortedDict
 from outcome import Error, Value
 
@@ -804,6 +806,13 @@ class Runner:
                     "That won't work without some sort of compatibility shim."
                     .format(coro)
                 )
+
+            if isasyncgen(coro):
+                raise TypeError(
+                    "start_soon expected an async function but got an async "
+                    "generator {!r}".format(coro)
+                )
+
             # Give good error for: nursery.start_soon(some_sync_fn)
             raise TypeError(
                 "trio expected an async function, but {!r} appears to be "

--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -11,6 +11,7 @@ from math import inf
 import attr
 import outcome
 import pytest
+from async_generator import async_generator
 
 from .tutil import check_sequence_matches, gc_collect_harder
 from ... import _core
@@ -1589,6 +1590,15 @@ def test_nice_error_on_bad_calls_to_run_or_spawn():
             with pytest.raises(TypeError) as excinfo:
                 bad_call(len, [1, 2, 3])
             assert "appears to be synchronous" in str(excinfo.value)
+
+            @async_generator
+            async def async_gen(arg):  # pragma: no cover
+                pass
+
+            with pytest.raises(TypeError) as excinfo:
+                bad_call(async_gen, 0)
+            msg = "expected an async function but got an async generator"
+            assert msg in str(excinfo.value)
 
             # Make sure no references are kept around to keep anything alive
             del excinfo


### PR DESCRIPTION
Alert the user that that passing an async generator to a task spawning method is not allowed.

Fixes #546

I wasn't sure where to add a test for this as it doesn't seem the slew of `TypeError`s and corresponding messages are verified anywhere?