### PR TITLE
Always force tasks off the queue

### DIFF
--- a/trio/_sync.py
+++ b/trio/_sync.py
@@ -968,7 +968,10 @@ class Queue:
             return _core.Abort.SUCCEEDED
 
         self._get_wait[task] = None
-        value = await _core.wait_task_rescheduled(abort_fn)
+        try:
+            value = await _core.wait_task_rescheduled(abort_fn)
+        finally:
+            self._get_wait.pop(task, None)
         return value
 
     @aiter_compat

--- a/trio/tests/test_sync.py
+++ b/trio/tests/test_sync.py
@@ -5,6 +5,7 @@ import weakref
 from ..testing import wait_all_tasks_blocked, assert_checkpoints
 
 from .. import _core
+from .. import _timeouts
 from .._timeouts import sleep_forever
 from .._sync import *
 
@@ -406,6 +407,11 @@ async def test_Queue():
     with pytest.raises(_core.WouldBlock):
         q.get_nowait()
     assert q.empty()
+
+    with _timeouts.move_on_after(0.01) as timeout_scope:
+        await q.get()
+    assert timeout_scope.cancelled_caught
+    await q.put("Test for https://github.com/python-trio/trio/pull/553")
 
 
 async def test_Queue_iter():


### PR DESCRIPTION
When queue.get() is cancelled, the task must not be left on the queue.
Otherwise an interesting crash will result when the next item is pushed.

Best demonstrated by:
```
    with trio.move_on_after(0.01) as timeout_scope:
        await q.get()
    assert timeout_scope.cancelled_caught
    await q.put("Test for PR #553")
```
