### PR TITLE
Test Python 3.7 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,31 @@
 language: python
-python:
-  # The pypy tests are slow, so we list them first
-  - pypy3.5-5.10.1
-  - 3.5.0
-  - 3.5.2
-  - 3.6
-  - 3.5-dev
-  - 3.6-dev
-  - 3.7-dev
 sudo: false
 dist: trusty
 
 matrix:
   include:
-    - os: linux
-      language: generic
-      env: USE_PYPY_NIGHTLY=1
-    - os: linux
-      language: python
-      python: 3.6
+    - python: 3.6
       env: CHECK_DOCS=1
-    - os: linux
-      language: python
-      python: 3.6
+    - python: 3.6
       env: CHECK_FORMATTING=1
+    # The pypy tests are slow, so we list them first
+    - python: pypy3.5
+    - language: generic
+      env: USE_PYPY_NIGHTLY=1
+    - python: 3.5.0
+    - python: 3.5.2
+    - python: 3.6
+    - python: 3.7
+      dist: xenial
+      sudo: required
+    - python: 3.5-dev
+    - python: 3.6-dev
+    - python: 3.7-dev
+      dist: xenial
+      sudo: required
+    - python: 3.8-dev
+      dist: xenial
+      sudo: required
 
 script:
   - ci/travis.sh


### PR DESCRIPTION
- Use xenial on GCE for 3.7+
- Add 3.7 and 3.8-dev

I changed `pypy3.5-5.10.1` to `pypy3.5` (which happens to be 5.10.1 just now). Is there a reason it was pinned? The Travis PyPy documentation isn't clear on this.