### PR TITLE
Give more details when the init task crashes

### DIFF
--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -874,8 +874,14 @@ class Runner:
             task._cancel_stack[-1]._remove_task(task)
         self.tasks.remove(task)
         if task._parent_nursery is None:
-            # the init task should be the last task to exit
-            assert not self.tasks
+            # the init task should be the last task to exit. If not, then
+            # something is very wrong. Probably it hit some unexpected error,
+            # in which case we re-raise the error (which will later get
+            # converted to a TrioInternalError, but at least we'll get a
+            # traceback). Otherwise, raise a new error.
+            if self.tasks:  # pragma: no cover
+                result.unwrap()
+                raise TrioInternalError
         else:
             task._parent_nursery._child_finished(task, result)
         if task is self.main_task:


### PR DESCRIPTION
This should never happen in normal use, but sometimes there are bugs
that can cause the init task to crash. (For example, I hit this while
trying to debug gh-550.) Previously, this would trigger an assertion
failure, and the original exception would be lost. Let's preserve the
original exception to make debugging easier.