### PR TITLE
Add support for sniffio

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ setup(
         "async_generator >= 1.9",
         "idna",
         "outcome",
+        "sniffio",
         # PEP 508 style, but:
         # https://bitbucket.org/pypa/wheel/issues/181/bdist_wheel-silently-discards-pep-508
         #"cffi; os_name == 'nt'",  # "cffi is required on windows"

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -13,6 +13,8 @@ from contextvars import copy_context
 from math import inf
 from time import monotonic
 
+from sniffio import current_async_library_cvar
+
 import attr
 from async_generator import (
     async_generator, yield_, asynccontextmanager, isasyncgen
@@ -1235,11 +1237,13 @@ def run(
         clock = SystemClock()
     instruments = list(instruments)
     io_manager = TheIOManager()
+    system_context = copy_context()
+    system_context.run(current_async_library_cvar.set, "trio")
     runner = Runner(
         clock=clock,
         instruments=instruments,
         io_manager=io_manager,
-        system_context=copy_context(),
+        system_context=system_context,
     )
     GLOBAL_RUN_CONTEXT.runner = runner
     locals()[LOCALS_KEY_KI_PROTECTION_ENABLED] = True

--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -10,6 +10,7 @@ from math import inf
 
 import attr
 import outcome
+import sniffio
 import pytest
 from async_generator import async_generator
 
@@ -1894,3 +1895,16 @@ def test_Cancelled_init():
 
     # private constructor should not raise
     _core.Cancelled._init()
+
+
+def test_sniffio_integration():
+    with pytest.raises(sniffio.AsyncLibraryNotFoundError):
+        sniffio.current_async_library()
+
+    async def check_inside_trio():
+        assert sniffio.current_async_library() == "trio"
+
+    _core.run(check_inside_trio)
+
+    with pytest.raises(sniffio.AsyncLibraryNotFoundError):
+        sniffio.current_async_library()


### PR DESCRIPTION
See https://github.com/python-trio/sniffio

And also https://github.com/vxgmichel/aiostream/issues/17

This shouldn't be merged (and tests will fail) until sniffio is
released on PyPI. But it demonstrates how to do it (and the tests pass
locally with my current sniffio checkout).