### PR TITLE
monitoring arbitrary kevents

### DIFF
--- a/trio/_core/tests/test_kqueue.py
+++ b/trio/_core/tests/test_kqueue.py
@@ -1,0 +1,20 @@
+import select
+import subprocess
+
+from ... import _core
+
+
+async def test_kqueue_monitor_proc_event():
+    p = subprocess.Popen(['sleep', '0.1'])
+    ident = p.pid
+    filter = select.KQ_FILTER_PROC
+    fflags = select.KQ_NOTE_EXIT
+    with _core.monitor_kevent(ident, filter, fflags) as q:
+        async for batch in q:
+            for evt in batch:
+                assert evt.ident == ident
+                assert evt.filter == filter
+                assert evt.fflags == fflags
+                assert evt.data == 0  # exit code
+                # we only expect one event for KQ_NOTE_EXIT
+                return

--- a/trio/_core/tests/test_kqueue.py
+++ b/trio/_core/tests/test_kqueue.py
@@ -1,7 +1,12 @@
 import select
 import subprocess
 
+import pytest
+
 from ... import _core
+
+use_kqueue = hasattr(select, 'kqueue')
+pytestmark = pytest.mark.skipif(not use_kqueue, reason="kqueue platforms only")
 
 
 async def test_kqueue_monitor_proc_event():


### PR DESCRIPTION
So, this is just to start thinking how we can implement support for arbitrary kevent events (#578). I'm not a kqueue expert at all, I just happen to run macOS. @njsmith is this similar to what you had in mind?

I think there are weird interactions between flags that are not apparent from the documentation. For example it appears that waiting for process exit will get an event with EV_ONESHOT which makes sense (you can't wait for an event from a pid that doesn't exist anymore). So maybe making it actually *arbitrary* involves some more tricks that I haven't explored yet.

But it seems to work ok to wait for a child process to terminate. I'm afraid I might be missing something for that use case too, though, because there is a race condition between process creation and opening a monitor. If the process has already terminated we get an exception, or we might even monitor the wrong process. I'm not sure this is relevant to this issue. Maybe the API should be changed for the bigger picture but right now I cannot suggest how.