### PR TITLE
Enable MacOS testing on Travis, disable 3.6 testing on Jenkins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,15 @@ matrix:
     - python: 3.8-dev
       dist: xenial
       sudo: required
+    - os: osx
+      language: generic
+      env: MACPYTHON=3.5.4
+    - os: osx
+      language: generic
+      env: MACPYTHON=3.6.6
+    - os: osx
+      language: generic
+      env: MACPYTHON=3.7.0
 
 script:
   - ci/travis.sh

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,8 @@
 def configs = [
     [
         label: 'sierra',
-        pyversions: ['python3.5', 'python3.6'],
+        // pyversions: ['python3.5', 'python3.6'],
+        pyversions: ['python3.5'],
     ],
 ]
 

--- a/ci/travis.sh
+++ b/ci/travis.sh
@@ -6,6 +6,18 @@ YAPF_VERSION=0.20.1
 
 git rev-parse HEAD
 
+if [ "$TRAVIS_OS_NAME" = "osx" ]; then
+    curl -Lo macpython.pkg https://www.python.org/ftp/python/${MACPYTHON}/python-${MACPYTHON}-macosx10.6.pkg
+    sudo installer -pkg macpython.pkg -target /
+    ls /Library/Frameworks/Python.framework/Versions/*/bin/
+    PYTHON_EXE=/Library/Frameworks/Python.framework/Versions/*/bin/python3
+    # The pip in older MacPython releases doesn't support a new enough TLS
+    curl https://bootstrap.pypa.io/get-pip.py | sudo $PYTHON_EXE
+    sudo $PYTHON_EXE -m pip install virtualenv
+    $PYTHON_EXE -m virtualenv testenv
+    source testenv/bin/activate
+fi
+
 if [ "$USE_PYPY_NIGHTLY" = "1" ]; then
     curl -fLo pypy.tar.bz2 http://buildbot.pypy.org/nightly/py3.5/pypy-c-jit-latest-linux64.tar.bz2
     if [ ! -s pypy.tar.bz2 ]; then


### PR DESCRIPTION
Travis MacOS is much more functional than it used to be, and on
ci.cryptography.org we're hitting:
  https://github.com/MagicStack/immutables/issues/7

So let's try turning on Travis's MacOS and see how it goes, while
scaling back our Jenkins testing so that bug doesn't block everything.