### PR TITLE
Switch back to Jenkins for MacOS builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,15 +26,15 @@ matrix:
     - python: 3.8-dev
       dist: xenial
       sudo: required
-    - os: osx
-      language: generic
-      env: MACPYTHON=3.5.4
-    - os: osx
-      language: generic
-      env: MACPYTHON=3.6.6
-    - os: osx
-      language: generic
-      env: MACPYTHON=3.7.0
+    # - os: osx
+    #   language: generic
+    #   env: MACPYTHON=3.5.4
+    # - os: osx
+    #   language: generic
+    #   env: MACPYTHON=3.6.6
+    # - os: osx
+    #   language: generic
+    #   env: MACPYTHON=3.7.0
 
 script:
   - ci/travis.sh

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,7 @@
 def configs = [
     [
         label: 'sierra',
-        // pyversions: ['python3.5', 'python3.6'],
-        pyversions: ['python3.5'],
+        pyversions: ['python3.5', 'python3.6', 'python3.7'],
     ],
 ]
 
@@ -53,6 +52,7 @@ def build(pyversion, label) {
                             export PATH="/usr/local/bin:\${PATH}"
                             export PATH="/Library/Frameworks/Python.framework/Versions/3.5/bin:\${PATH}"
                             export PATH="/Library/Frameworks/Python.framework/Versions/3.6/bin:\${PATH}"
+                            export PATH="/Library/Frameworks/Python.framework/Versions/3.7/bin:\${PATH}"
 
                             # Workaround for https://github.com/pypa/pip/issues/5345
                             # See also:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,3 +4,7 @@ ipython        # for the IPython traceback integration tests
 pyOpenSSL      # for the ssl tests
 trustme        # for the ssl tests
 pytest-faulthandler
+
+# Temporary hack to work around https://github.com/MagicStack/immutables/issues/7
+# until a new version of contextvars is released
+immutables == 0.6


### PR DESCRIPTION
While the Travis MacOS infrastructure is clearly *much* better than it
used to be, doing these tests on Jenkins is still faster overall, and
it avoids hitting gh-584.

This commit:

- adds a temporary workaround for
  https://github.com/MagicStack/immutables/issues/7
- re-enables all MacOS builds on Jenkins
  - including 3.7, which was previously not enabled
- re-disables Travis MacOS builds