### PR TITLE
Add CapacityLimiter.UNLIMITED

### DIFF
--- a/newsfragments/587.feature.rst
+++ b/newsfragments/587.feature.rst
@@ -1,0 +1,2 @@
+New singleton object :data:`trio.CapacityLimiter.UNLIMITED`, for when
+you need a :class:`CapacityLimiter` with infinite capacity.

--- a/trio/_sync.py
+++ b/trio/_sync.py
@@ -153,6 +153,15 @@ class CapacityLimiter:
        tokens aren't automatically created or destroyed over time; they're
        just borrowed and then put back.
 
+    .. data:: UNLIMITED
+
+       Sometimes you might need an instance of :class:`CapacityLimiter` that
+       has infinite capacity. :data:`trio.CapacityLimiter.UNLIMITED` is just
+       such an object. (Since it has infinite capacity, you only need one of
+       them.) But note that it does track which tasks are holding its tokens,
+       so you do still want to release tokens when you're done with them to
+       avoid a memory leak.
+
     """
 
     def __init__(self, total_tokens):
@@ -352,6 +361,10 @@ class CapacityLimiter:
             borrowers=list(self._borrowers),
             tasks_waiting=len(self._lot),
         )
+
+
+CapacityLimiter.UNLIMITED = CapacityLimiter(1)
+CapacityLimiter.UNLIMITED._total_tokens = float("inf")
 
 
 @async_cm


### PR DESCRIPTION
Sometimes we have an API that wants a CapacityLimiter (like
run_sync_soon_in_worker_thread), and we want to have unlimited
capacity (for example, when putting a long-running blocking call into
a background thread, like WaitForMultipleObjects or waitpid). This can
be done by writing a little stub class that implements the
CapacityLimiter interface, but doing this all the time is annoying.
Here's a full-fledged version, available whenever you need it.