### PR TITLE
Remove workaround for now-fixed 'immutables' bug

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,7 +4,3 @@ ipython        # for the IPython traceback integration tests
 pyOpenSSL      # for the ssl tests
 trustme        # for the ssl tests
 pytest-faulthandler
-
-# Temporary hack to work around https://github.com/MagicStack/immutables/issues/7
-# until a new version of contextvars is released
-immutables == 0.6


### PR DESCRIPTION
The latest release of contextvars (v2.3) fixed this bug, so we don't
need a workaround anymore:
    https://github.com/MagicStack/immutables/issues/7