### PR TITLE
Skip a test on systems with buggy AI_V4MAPPED handling

### DIFF
--- a/newsfragments/580.bugfix.rst
+++ b/newsfragments/580.bugfix.rst
@@ -1,0 +1,3 @@
+Some version of MacOS have a buggy ``getaddrinfo`` that was causing
+spurious test failures; we now detect those systems and skip the
+relevant test when found.

--- a/trio/_socket.py
+++ b/trio/_socket.py
@@ -523,7 +523,7 @@ class _SocketType(SocketType):
         # Special cases to match the stdlib, see gh-277
         if host == "":
             host = None
-        if host == "<broadcast>" and self._sock.family == AF_INET:
+        if host == "<broadcast>":
             host = "255.255.255.255"
         # Since we always pass in an explicit family here, AI_ADDRCONFIG
         # doesn't add any value -- if we have no ipv6 connectivity and are

--- a/trio/_socket.py
+++ b/trio/_socket.py
@@ -523,7 +523,7 @@ class _SocketType(SocketType):
         # Special cases to match the stdlib, see gh-277
         if host == "":
             host = None
-        if host == "<broadcast>":
+        if host == "<broadcast>" and self._sock.family == AF_INET:
             host = "255.255.255.255"
         # Since we always pass in an explicit family here, AI_ADDRCONFIG
         # doesn't add any value -- if we have no ipv6 connectivity and are

--- a/trio/tests/test_socket.py
+++ b/trio/tests/test_socket.py
@@ -377,6 +377,18 @@ async def test_SocketType_simple_server(address, socket_type):
             assert await client.recv(1) == b"x"
 
 
+# On some MacOS systems, getaddrinfo likes to return V4-mapped addresses even
+# when we *don't* pass AI_V4MAPPED.
+# https://github.com/python-trio/trio/issues/580
+def gai_without_v4mapped_is_buggy():  # pragma: no cover
+    try:
+        stdlib_socket.getaddrinfo("1.2.3.4", 0, family=stdlib_socket.AF_INET6)
+    except stdlib_socket.gaierror:
+        return False
+    else:
+        return True
+
+
 # Direct thorough tests of the implicit resolver helpers
 async def test_SocketType_resolve():
     # For some reason the stdlib special-cases "" to pass NULL to getaddrinfo
@@ -416,16 +428,18 @@ async def test_SocketType_resolve():
         sock6.setsockopt(tsocket.IPPROTO_IPV6, tsocket.IPV6_V6ONLY, False)
         assert await s6res(("1.2.3.4", "http")) == ("::ffff:1.2.3.4", 80, 0, 0)
 
-        # But not if it's true
-        sock6.setsockopt(tsocket.IPPROTO_IPV6, tsocket.IPV6_V6ONLY, True)
-        with pytest.raises(tsocket.gaierror) as excinfo:
-            await s6res(("1.2.3.4", 80))
-        # Windows, MacOS
-        expected_errnos = {tsocket.EAI_NONAME}
-        # Linux
-        if hasattr(tsocket, "EAI_ADDRFAMILY"):
-            expected_errnos.add(tsocket.EAI_ADDRFAMILY)
-        assert excinfo.value.errno in expected_errnos
+        # But not if it's true (at least on systems where getaddrinfo works
+        # correctly)
+        if not gai_without_v4mapped_is_buggy():  # pragma: no branch
+            sock6.setsockopt(tsocket.IPPROTO_IPV6, tsocket.IPV6_V6ONLY, True)
+            with pytest.raises(tsocket.gaierror) as excinfo:
+                await s6res(("1.2.3.4", 80))
+            # Windows, MacOS
+            expected_errnos = {tsocket.EAI_NONAME}
+            # Linux
+            if hasattr(tsocket, "EAI_ADDRFAMILY"):
+                expected_errnos.add(tsocket.EAI_ADDRFAMILY)
+            assert excinfo.value.errno in expected_errnos
 
         # A family where we know nothing about the addresses, so should just
         # pass them through. This should work on Linux, which is enough to


### PR DESCRIPTION
Closes gh-580

@sorcio: This is an unusual bug in that we actually do not know which
systems are affected or why, and we don't have any of the affected
systems in our CI setup. So even if the tests pass here I have no idea
if it's actually working :-). Can you test this branch and confirm it
fixes the failure you were seeing?