### PR TITLE
Add task blocked watchdog.

### DIFF
--- a/newsfragments/591.feature.rst
+++ b/newsfragments/591.feature.rst
@@ -1,0 +1,3 @@
+Add a watchdog for blocked tasks to Trio. This will automatically print a
+warning (and a full traceback of all threads) if a function is blocked without
+yielding for 5 seconds.

--- a/newsfragments/591.feature.rst
+++ b/newsfragments/591.feature.rst
@@ -1,3 +1,3 @@
 Add a watchdog for blocked tasks to Trio. This will automatically print a
 warning (and a full traceback of all threads) if a function is blocked without
-yielding for 5 seconds.
+yielding for 5 seconds (by default).

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -1158,7 +1158,8 @@ def run(
     clock=None,
     instruments=(),
     restrict_keyboard_interrupt_to_checkpoints=False,
-    use_watchdog=True
+    use_watchdog=True,
+    watchdog_timeout=5
 ):
     """Run a trio-flavored async function, and return the result.
 
@@ -1220,6 +1221,9 @@ def run(
           and if so will notify you and print the stack traces of all
           threads to show exactly where the program is blocked.
 
+      watchdog_timeout (int): The number of seconds the watchdog will wait
+          before notifying that the main thread is blocked.
+
     Returns:
       Whatever ``async_fn`` returns.
 
@@ -1260,7 +1264,7 @@ def run(
     locals()[LOCALS_KEY_KI_PROTECTION_ENABLED] = True
 
     if use_watchdog:
-        watchdog = TrioWatchdog()
+        watchdog = TrioWatchdog(watchdog_timeout)
     else:
         watchdog = None
 

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -1264,6 +1264,8 @@ def run(
     else:
         watchdog = None
 
+    GLOBAL_RUN_CONTEXT.watchdog = watchdog
+
     # KI handling goes outside the core try/except/finally to avoid a window
     # where KeyboardInterrupt would be allowed and converted into an
     # TrioInternalError:

--- a/trio/_core/_watchdog.py
+++ b/trio/_core/_watchdog.py
@@ -1,0 +1,81 @@
+import sys
+
+import threading
+import traceback
+
+
+class TrioWatchdog(object):
+    def __init__(self):
+        self._stopped = False
+        self._thread = None
+        self._notify_event = threading.Event()
+
+        self._before_counter = 0
+        self._after_counter = 0
+
+    def notify_alive_before(self):
+        """
+        Notifies the watchdog that the Trio thread is alive before running
+        a task.
+        """
+        self._before_counter += 1
+        self._notify_event.set()
+
+    def notify_alive_after(self):
+        """
+        Notifies the watchdog that the Trio thread is alive after running a
+        task.
+        """
+        self._after_counter += 1
+
+    def _main_loop(self):
+        while True:
+            if self._stopped:
+                return
+
+            self._notify_event.clear()
+            orig_starts = self._before_counter
+            orig_stops = self._after_counter
+            if orig_starts == orig_stops:
+                # main thread asleep; nothing to do until it wakes up
+                self._notify_event.wait()
+                if self._stopped:
+                    return
+            else:
+                self._notify_event.wait(timeout=5)
+                if self._stopped:
+                    return
+
+                if orig_starts == self._before_counter \
+                        and orig_stops == self._after_counter:
+                    print(
+                        "Trio Watchdog has not received any notifications in "
+                        "5 seconds, main thread is blocked!",
+                        file=sys.stderr
+                    )
+                    # faulthandler is not very useful to us, honestly
+                    # faulthandler.dump_traceback(all_threads=True)
+                    print(
+                        "Printing the traceback of all threads:",
+                        file=sys.stderr
+                    )
+                    self._print_all_threads()
+
+    def _print_all_threads(self):
+        # separated for indent reasons, damned 80 char limit
+        for thread in threading.enumerate():
+            print(
+                "Thread {} (most recent call last):".format(thread.name),
+                file=sys.stderr
+            )
+            # scary internal function!
+            traceback.print_stack(sys._current_frames()[thread.ident])
+
+    def start(self):
+        self._thread = threading.Thread(
+            target=self._main_loop, name="<trio watchdog>", daemon=True
+        )
+        self._thread.start()
+
+    def stop(self):
+        self._stopped = True

--- a/trio/_core/_watchdog.py
+++ b/trio/_core/_watchdog.py
@@ -5,10 +5,11 @@ import traceback
 
 
 class TrioWatchdog(object):
-    def __init__(self):
+    def __init__(self, timeout=5):
         self._stopped = False
         self._thread = None
         self._notify_event = threading.Event()
+        self._timeout = timeout
 
         self._before_counter = 0
         self._after_counter = 0
@@ -42,7 +43,7 @@ class TrioWatchdog(object):
                 if self._stopped:
                     return
             else:
-                self._notify_event.wait(timeout=5)
+                self._notify_event.wait(timeout=self._timeout)
                 if self._stopped:
                     return
 
@@ -79,3 +80,5 @@ class TrioWatchdog(object):
 
     def stop(self):
         self._stopped = True
+        self._notify_event.set()
+        self._thread.join()

--- a/trio/_core/tests/test_watchdog.py
+++ b/trio/_core/tests/test_watchdog.py
@@ -1,0 +1,30 @@
+import threading
+import time
+from io import StringIO
+
+import contextlib
+
+from ..tests.tutil import slow
+from .. import _run
+
+
+@slow
+async def test_watchdog():
+    watchdog = _run.GLOBAL_RUN_CONTEXT.watchdog
+    target = StringIO()
+    with contextlib.redirect_stderr(target):
+        time.sleep(7)
+
+    assert target.getvalue().startswith(
+        "Trio Watchdog has not received any "
+        "notifications in 5 seconds, main "
+        "thread is blocked!"
+    )
+
+    # checkpoint to ensure the watchdog gets a notification, sees that its
+    # dead, and winds down its thread
+    watchdog.stop()
+    await _run.checkpoint()
+    time.sleep(6)  # ensure if the watchdog is waiting for 5s, it wakes
+    await _run.checkpoint()
+    assert not watchdog._thread.is_alive()


### PR DESCRIPTION
Closes #591.

TODO:
  * [ ] rebase to master
  * [ ] fix deadlock (see https://github.com/python-trio/trio/pull/596#issuecomment-415270221 and https://github.com/python-trio/trio/pull/596#issuecomment-415339649)
  * [ ] improve tests: code coverage, reduce time scale
  * API review
    * [ ] `watchdog_timeout=None` instead of additional `use_watchdog` option?
    * [ ] best default?  Perhaps "max block time of a healthy Trio program x 10".
  * [ ] documentation
  * [ ] newsfragment
  * [ ] future work: include e.g. 99.9 percentile observed block time in Trio stats, to help users decide appropriate watchdog_timeout for their app