### PR TITLE
implement open_nursery with explicit context manager

### DIFF
--- a/newsfragments/612.bugfix.rst
+++ b/newsfragments/612.bugfix.rst
@@ -1,0 +1,4 @@
+The nursery context manager was rewritten to avoid use of
+`@asynccontextmanager` and `@async_generator`.  This reduces extraneous frames
+in exception traces and addresses bugs regarding `StopIteration` and
+`StopAsyncIteration` exceptions not propagating correctly.

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -294,6 +294,13 @@ class _TaskStatus:
 
 
 class NurseryManager:
+    """Nursery context manager.
+
+    Note we explicitly avoid @asynccontextmanager and @async_generator
+    since they add a lot of extraneous stack frames to exceptions, as
+    well as cause problematic behavior with handling of StopIteration.
+
+    """
     @enable_ki_protection
     async def __aenter__(self):
         assert currently_ki_protected()

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -308,15 +308,16 @@ class NurseryManager:
         try:
             await self._nursery._nested_child_finished(exc)
         except BaseException as new_exc:
-            if self._scope_manager.__exit__(
-                type(new_exc), new_exc, new_exc.__traceback__
-            ):
-                return True
-            else:
-                if new_exc is exc:
+            try:
+                if self._scope_manager.__exit__(
+                    type(new_exc), new_exc, new_exc.__traceback__
+                ):
+                    return True
+            except BaseException as scope_manager_exc:
+                if scope_manager_exc == exc:
                     return False
-                else:
-                    raise
+                raise  # scope_manager_exc
+            raise  # new_exc
         else:
             self._scope_manager.__exit__(None, None, None)
             return True

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -308,14 +308,14 @@ class NurseryManager:
         try:
             await self._nursery._nested_child_finished(exc)
         except BaseException as new_exc:
-            if not self._scope_manager.__exit__(
+            if self._scope_manager.__exit__(
                     type(new_exc), new_exc, new_exc.__traceback__):
+                return True
+            else:
                 if new_exc is exc:
                     return False
                 else:
                     raise
-            else:
-                return True
         else:
             self._scope_manager.__exit__(None, None, None)
             return True

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -309,7 +309,8 @@ class NurseryManager:
             await self._nursery._nested_child_finished(exc)
         except BaseException as new_exc:
             if self._scope_manager.__exit__(
-                    type(new_exc), new_exc, new_exc.__traceback__):
+                type(new_exc), new_exc, new_exc.__traceback__
+            ):
                 return True
             else:
                 if new_exc is exc:
@@ -322,7 +323,8 @@ class NurseryManager:
 
     def __enter__(self):
         raise RuntimeError(
-            "use 'async with open_nursery(...)', not 'with open_nursery(...)'")
+            "use 'async with open_nursery(...)', not 'with open_nursery(...)'"
+        )
 
     def __exit__(self):  # pragma: no cover
         assert False, """Never called, but should be defined"""

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -298,9 +298,11 @@ class NurseryManager:
 
     Note we explicitly avoid @asynccontextmanager and @async_generator
     since they add a lot of extraneous stack frames to exceptions, as
-    well as cause problematic behavior with handling of StopIteration.
+    well as cause problematic behavior with handling of StopIteration
+    and StopAsyncIteration.
 
     """
+
     @enable_ki_protection
     async def __aenter__(self):
         assert currently_ki_protected()

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -314,6 +314,8 @@ class NurseryManager:
                     return False
                 else:
                     raise
+            else:
+                return True
         else:
             self._scope_manager.__exit__(None, None, None)
             return True

--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -1823,6 +1823,12 @@ async def test_nursery_start_keeps_nursery_open(autojump_clock):
         assert _core.current_time() - t0 == 7
 
 
+async def test_nursery_explicit_exception():
+    with pytest.raises(KeyError):
+        async with _core.open_nursery():
+            raise KeyError()
+
+
 def test_contextvar_support():
     var = contextvars.ContextVar("test")
     var.set("before")

--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -1848,10 +1848,6 @@ async def test_nursery_stop_async_iteration():
             self.count = count
             self.val = 0
 
-        @aiter_compat
-        def __aiter__(self):
-            return self
-
         async def __anext__(self):
             await sleep(0)
             val = self.val
@@ -1883,7 +1879,7 @@ async def test_nursery_stop_async_iteration():
                 if isinstance(exc, StopAsyncIteration):
                     got_stop = True
                     return None
-                else:
+                else:  # pragma: no cover
                     return exc
 
             with _core.MultiError.catch(handle):

--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -1829,6 +1829,18 @@ async def test_nursery_explicit_exception():
             raise KeyError()
 
 
+async def test_nursery_stop_iteration():
+    async def fail():
+        raise ValueError
+
+    try:
+        async with _core.open_nursery() as nursery:
+            nursery.start_soon(fail)
+            raise StopIteration
+    except _core.MultiError as e:
+        assert tuple(map(type, e.exceptions)) == (StopIteration, ValueError)
+
+
 def test_contextvar_support():
     var = contextvars.ContextVar("test")
     var.set("before")

--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -17,6 +17,7 @@ from async_generator import async_generator
 from .tutil import check_sequence_matches, gc_collect_harder
 from ... import _core
 from ..._timeouts import sleep
+from ..._util import aiter_compat
 from ...testing import (
     wait_all_tasks_blocked,
     Sequencer,
@@ -1847,6 +1848,7 @@ async def test_nursery_stop_async_iteration():
             self.count = count
             self.val = 0
 
+        @aiter_compat
         def __aiter__(self):
             return self
 
@@ -1865,12 +1867,15 @@ async def test_nursery_stop_async_iteration():
         async def _accumulate(self, f, items, i):
             items[i] = await f()
 
+        @aiter_compat
         def __aiter__(self):
             return self
 
         async def __anext__(self):
             nexts = self.nexts
-            items = [None, ] * len(nexts)
+            items = [
+                None,
+            ] * len(nexts)
             got_stop = False
 
             def handle(exc):


### PR DESCRIPTION
avoid use of `@asynccontextmanager` and `@async_generator` since they cause bugs as well as extraneous exception stack frames

TODO:
  * [x] address 2 failing tests (need some assistance!)
  * [x] address missing code coverage (test `if new_exc is exc` case)
  * [x] confirm impact on exception frame count (#56)
  * [x] confirm fixes #229 and fixes #393 
  * [x] newsfragment