### PR TITLE
[ci] Make pip less verbose again

### DIFF
--- a/ci/travis.sh
+++ b/ci/travis.sh
@@ -51,10 +51,6 @@ pip --version
 curl https://bootstrap.pypa.io/get-pip.py | python
 pip --version
 
-# Temporary hack to debug https://github.com/python-trio/trio/issues/508
-shopt -s expand_aliases
-alias pip="pip -vvv"
-
 pip install -U pip setuptools wheel
 
 if [ "$CHECK_FORMATTING" = "1" ]; then


### PR DESCRIPTION
Our workaround for gh-508 seems to be working reliably now, so no need
to keep spamming test logs with this.