### PR TITLE
Rename MacOS to macOS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@
 
 .. image:: https://travis-ci.org/python-trio/trio.svg?branch=master
    :target: https://travis-ci.org/python-trio/trio
-   :alt: Automated test status (Linux and MacOS)
+   :alt: Automated test status (Linux and macOS)
 
 .. image:: https://ci.appveyor.com/api/projects/status/af4eyed8o8tc3t0r/branch/master?svg=true
    :target: https://ci.appveyor.com/project/njsmith/trio/history
@@ -98,7 +98,7 @@ and an `echo server
 
 **Cool, but will it work on my system?** Probably! As long as you have
 some kind of Python 3.5-or-better (CPython or the latest PyPy3 are
-both fine), and are using Linux, MacOS, or Windows, then trio should
+both fine), and are using Linux, macOS, or Windows, then trio should
 absolutely work. *BSD and illumos likely work too, but we don't have
 testing infrastructure for them. All of our dependencies are pure
 Python, except for CFFI on Windows, and that has wheels available, so

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -198,7 +198,7 @@ locally can be useful
 (``pytest --cov=PACKAGENAME --cov-report=html``), but don't be
 surprised if you get lower coverage than when looking at Codecov
 reports, because there are some lines that are only executed on
-Windows, or MacOS, or PyPy, or CPython, or... you get the idea. After
+Windows, or macOS, or PyPy, or CPython, or... you get the idea. After
 you create a PR, Codecov will automatically report back with the
 coverage, so you can check how you're really doing. (But note that the
 results can be inaccurate until all the tests are passing. If the

--- a/docs/source/design.rst
+++ b/docs/source/design.rst
@@ -482,7 +482,7 @@ three implementations:
 
 * ``EpollIOManager`` in ``_io_epoll.py`` (used on Linux, illumos)
 
-* ``KqueueIOManager`` in ``_io_kqueue.py`` (used on MacOS, \*BSD)
+* ``KqueueIOManager`` in ``_io_kqueue.py`` (used on macOS, \*BSD)
 
 * ``WindowsIOManager`` in ``_io_windows.py`` (used on Windows)
 

--- a/docs/source/history.rst
+++ b/docs/source/history.rst
@@ -26,7 +26,7 @@ Bugfixes
 - Fix a memory leak in :class:`trio.CapacityLimiter`, that could occurr when
   ``acquire`` or ``acquire_on_behalf_of`` was cancelled. (`#548
   <https://github.com/python-trio/trio/issues/548>`__)
-- Some version of MacOS have a buggy ``getaddrinfo`` that was causing spurious
+- Some version of macOS have a buggy ``getaddrinfo`` that was causing spurious
   test failures; we now detect those systems and skip the relevant test when
   found. (`#580 <https://github.com/python-trio/trio/issues/580>`__)
 - Prevent crashes when used with Sentry (raven-python). (`#599

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -45,7 +45,7 @@ chance to give feedback about any compatibility-breaking changes.
 
 Vital statistics:
 
-* Supported environments: Linux, MacOS, or Windows running some kind of Python
+* Supported environments: Linux, macOS, or Windows running some kind of Python
   3.5-or-better (either CPython or PyPy3 is fine). \*BSD and
   illumos likely work too, but are untested.
 

--- a/notes-to-self/socketpair-buffering.py
+++ b/notes-to-self/socketpair-buffering.py
@@ -11,7 +11,7 @@ import socket
 #   with both set to 1, buffers 525347
 #   except sometimes it's less intermittently (?!?)
 #
-# MacOS:
+# macOS:
 #   if bufsize = 1, can queue up 1 one-byte send
 #   with default bufsize, can queue up 8192 one-byte sends
 #   and bufsize = 0 is invalid (setsockopt errors out)

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ chance to give feedback about any compatibility-breaking changes.
 
 Vital statistics:
 
-* Supported environments: Linux, MacOS, or Windows running some kind of Python
+* Supported environments: Linux, macOS, or Windows running some kind of Python
   3.5-or-better (either CPython or PyPy3 is fine). \\*BSD and illumos likely
   work too, but are not tested.
 

--- a/trio/_core/_wakeup_socketpair.py
+++ b/trio/_core/_wakeup_socketpair.py
@@ -12,7 +12,7 @@ class WakeupSocketpair:
         # for wakeups. With these settings, maximum number of 1-byte sends
         # before getting BlockingIOError:
         #   Linux 4.8: 6
-        #   MacOS (darwin 15.5): 1
+        #   macOS (darwin 15.5): 1
         #   Windows 10: 525347
         # Windows you're weird. (And on Windows setting SNDBUF to 0 makes send
         # blocking, even on non-blocking sockets, so don't do that.)

--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -1353,7 +1353,7 @@ async def test_TrioToken_run_sync_soon_massive_queue():
     # There are edge cases in the wakeup fd code when the wakeup fd overflows,
     # so let's try to make that happen. This is also just a good stress test
     # in general. (With the current-as-of-2017-02-14 code using a socketpair
-    # with minimal buffer, Linux takes 6 wakeups to fill the buffer and MacOS
+    # with minimal buffer, Linux takes 6 wakeups to fill the buffer and macOS
     # takes 1 wakeup. So 1000 is overkill if anything. Windows OTOH takes
     # ~600,000 wakeups, but has the same code paths...)
     COUNT = 1000

--- a/trio/_highlevel_open_tcp_listeners.py
+++ b/trio/_highlevel_open_tcp_listeners.py
@@ -32,7 +32,7 @@ __all__ = ["open_tcp_listeners", "serve_tcp"]
 # different operating systems. But on every system, passing in a too-large
 # backlog just causes it to be silently truncated to the configured maximum,
 # so this is unnecessary -- we can just pass in "infinity" and get the maximum
-# that way. (Verified on Windows, Linux, MacOS using
+# that way. (Verified on Windows, Linux, macOS using
 # notes-to-self/measure-listen-backlog.py)
 def _compute_backlog(backlog):
     if backlog is None:

--- a/trio/_highlevel_socket.py
+++ b/trio/_highlevel_socket.py
@@ -126,7 +126,7 @@ class SocketStream(HalfCloseableStream):
 
     async def send_eof(self):
         async with self._send_conflict_detector:
-            # On MacOS, calling shutdown a second time raises ENOTCONN, but
+            # On macOS, calling shutdown a second time raises ENOTCONN, but
             # send_eof needs to be idempotent.
             if self.socket.did_shutdown_SHUT_WR:
                 return
@@ -180,7 +180,7 @@ class SocketStream(HalfCloseableStream):
 # -----------------
 #
 # Here's a list of all the possible errors that accept() can return, according
-# to the POSIX spec or the Linux, FreeBSD, MacOS, and Windows docs:
+# to the POSIX spec or the Linux, FreeBSD, macOS, and Windows docs:
 #
 # Can't happen with a trio socket:
 # - EAGAIN/(WSA)EWOULDBLOCK
@@ -226,7 +226,7 @@ class SocketStream(HalfCloseableStream):
 # - ignores EPERM, with comment about Linux firewalls
 # - logs and ignores EMFILE, ENOBUFS, ENFILE, ENOMEM, ECONNABORTED
 #   Comment notes that ECONNABORTED is a BSDism and that Linux returns the
-#   socket before having it fail, and MacOS just silently discards it.
+#   socket before having it fail, and macOS just silently discards it.
 # - other errors are raised, which is logged + kills the socket
 # ref: src/twisted/internet/tcp.py, Port.doRead
 #
@@ -347,7 +347,7 @@ class SocketListener(Listener):
                 tsocket.SOL_SOCKET, tsocket.SO_ACCEPTCONN
             )
         except OSError:
-            # SO_ACCEPTCONN fails on MacOS; we just have to trust the user.
+            # SO_ACCEPTCONN fails on macOS; we just have to trust the user.
             pass
         else:
             if not listening:

--- a/trio/_signals.py
+++ b/trio/_signals.py
@@ -23,7 +23,7 @@ __all__ = ["catch_signals"]
 #   impose that, and the failure mode is annoying (signals get delivered via
 #   signal handlers whether we want them to or not).
 #
-# - on MacOS/*BSD, kqueue is the natural way. Semantics: kqueue acts as an
+# - on macOS/*BSD, kqueue is the natural way. Semantics: kqueue acts as an
 #   *extra* signal delivery mechanism. Signals are delivered the normal
 #   way, *and* are delivered to kqueue. So you want to set them to SIG_IGN so
 #   that they don't end up pending forever (I guess?). I can't find any actual

--- a/trio/_socket.py
+++ b/trio/_socket.py
@@ -587,13 +587,13 @@ class _SocketType(SocketType):
         # - But, we also want to provide the correct semantics, and part
         #   of that means giving correct errors. So, for example, if you
         #   haven't called .listen(), then .accept() raises an error
-        #   immediately. But in this same circumstance, then on MacOS, the
+        #   immediately. But in this same circumstance, then on macOS, the
         #   socket does not register as readable. So if we block waiting
         #   for read *before* we call accept, then we'll be waiting
         #   forever instead of properly raising an error. (On Linux,
         #   interestingly, AFAICT a socket that can't possible read/write
         #   *does* count as readable/writable for select() purposes. But
-        #   not on MacOS.)
+        #   not on macOS.)
         #
         # So, we have to call the function once, with the appropriate
         # cancellation/yielding sandwich if it succeeds, and if it gives
@@ -688,7 +688,7 @@ class _SocketType(SocketType):
                 #
                 # In practice, the resolution is probably that non-blocking
                 # connect simply never returns EINTR, so the question of how to
-                # handle it is moot.  Someone spelunked MacOS/FreeBSD and
+                # handle it is moot.  Someone spelunked macOS/FreeBSD and
                 # confirmed this is true there:
                 #
                 #   https://stackoverflow.com/questions/14134440/eintr-and-non-blocking-calls

--- a/trio/tests/test_highlevel_socket.py
+++ b/trio/tests/test_highlevel_socket.py
@@ -154,7 +154,7 @@ async def test_SocketListener():
         excinfo.match(r".*SOCK_STREAM")
 
     # Didn't call .listen()
-    # MacOS has no way to check for this, so skip testing it there.
+    # macOS has no way to check for this, so skip testing it there.
     if sys.platform != "darwin":
         with tsocket.socket() as s:
             await s.bind(("127.0.0.1", 0))

--- a/trio/tests/test_socket.py
+++ b/trio/tests/test_socket.py
@@ -144,7 +144,7 @@ async def test_getaddrinfo(monkeygai):
             await tsocket.getaddrinfo("::1", "12345", type=-1)
     # Linux, Windows
     expected_errnos = {tsocket.EAI_SOCKTYPE}
-    # MacOS
+    # macOS
     if hasattr(tsocket, "EAI_BADHINTS"):
         expected_errnos.add(tsocket.EAI_BADHINTS)
     assert excinfo.value.errno in expected_errnos
@@ -377,7 +377,7 @@ async def test_SocketType_simple_server(address, socket_type):
             assert await client.recv(1) == b"x"
 
 
-# On some MacOS systems, getaddrinfo likes to return V4-mapped addresses even
+# On some macOS systems, getaddrinfo likes to return V4-mapped addresses even
 # when we *don't* pass AI_V4MAPPED.
 # https://github.com/python-trio/trio/issues/580
 def gai_without_v4mapped_is_buggy():  # pragma: no cover
@@ -438,7 +438,7 @@ async def test_SocketType_resolve():
             sock6.setsockopt(tsocket.IPPROTO_IPV6, tsocket.IPV6_V6ONLY, True)
             with pytest.raises(tsocket.gaierror) as excinfo:
                 await s6res(("1.2.3.4", 80))
-            # Windows, MacOS
+            # Windows, macOS
             expected_errnos = {tsocket.EAI_NONAME}
             # Linux
             if hasattr(tsocket, "EAI_ADDRFAMILY"):
@@ -620,7 +620,7 @@ async def test_SocketType_connect_paths():
                 # TCP port 2 is not assigned. Pretty sure nothing will be
                 # listening there. (We used to bind a port and then *not* call
                 # listen() to ensure nothing was listening there, but it turns
-                # out on MacOS if you do this it takes 30 seconds for the
+                # out on macOS if you do this it takes 30 seconds for the
                 # connect to fail. Really. Also if you use a non-routable
                 # address. This way fails instantly though. As long as nothing
                 # is listening on port 2.)
@@ -682,7 +682,7 @@ async def test_send_recv_variants():
         # passing MSG_MORE to send_some on a connected UDP socket seems to
         # just be ignored.
         #
-        # But there's no MSG_MORE on Windows or MacOS. I guess send_some flags
+        # But there's no MSG_MORE on Windows or macOS. I guess send_some flags
         # are really not very useful, but at least this tests them a bit.
         if hasattr(tsocket, "MSG_MORE"):
             await a.sendto(b"xxx", tsocket.MSG_MORE, b.getsockname())
@@ -856,7 +856,7 @@ async def test_unix_domain_socket():
                 assert await ssock.recv(1) == b"x"
 
     # Can't use tmpdir fixture, because we can exceed the maximum AF_UNIX path
-    # length on MacOS.
+    # length on macOS.
     with tempfile.TemporaryDirectory() as tmpdir:
         path = "{}/sock".format(tmpdir)
         await check_AF_UNIX(path)
@@ -865,7 +865,7 @@ async def test_unix_domain_socket():
         cookie = os.urandom(20).hex().encode("ascii")
         await check_AF_UNIX(b"\x00trio-test-" + cookie)
     except FileNotFoundError:
-        # MacOS doesn't support abstract filenames with the leading NUL byte
+        # macOS doesn't support abstract filenames with the leading NUL byte
         pass
 
 

--- a/trio/tests/test_ssl.py
+++ b/trio/tests/test_ssl.py
@@ -139,7 +139,7 @@ class PyOpenSSLEchoStream:
         # renegotiations. Of course TLS 1.3 support isn't released yet, but
         # I'm told that this will work once it is. (And once it is we can
         # remove the pragma: no cover too.) Alternatively, once we drop
-        # support for CPython 3.5 on MacOS, then we could switch to using
+        # support for CPython 3.5 on macOS, then we could switch to using
         # TLSv1_2_METHOD.
         #
         # Discussion: https://github.com/pyca/pyopenssl/issues/624

--- a/trio/tests/test_testing.py
+++ b/trio/tests/test_testing.py
@@ -831,7 +831,7 @@ async def test_open_stream_to_socket_listener():
     if hasattr(tsocket, "AF_UNIX"):
         # Listener bound to Unix-domain socket
         sock = tsocket.socket(family=tsocket.AF_UNIX)
-        # can't use pytest's tmpdir; if we try then MacOS says "OSError:
+        # can't use pytest's tmpdir; if we try then macOS says "OSError:
         # AF_UNIX path too long"
         with tempfile.TemporaryDirectory() as tmpdir:
             path = "{}/sock".format(tmpdir)

--- a/trio/tests/test_timeouts.py
+++ b/trio/tests/test_timeouts.py
@@ -16,7 +16,7 @@ async def check_takes_about(f, expected_dur):
     # 1.2 is an arbitrary fudge factor because there's always some delay
     # between when we become eligible to wake up and when we actually do. We
     # used to sleep for 0.05, and regularly observed overruns of 1.6x on
-    # Appveyor, and then started seeing overruns of 2.3x on Travis's MacOS, so
+    # Appveyor, and then started seeing overruns of 2.3x on Travis's macOS, so
     # now we bumped up the sleep to 1 second, marked the tests as slow, and
     # hopefully now the proportional error will be less huge.
     #


### PR DESCRIPTION
https://en.wikipedia.org/wiki/MacOS

We fixed illumos, so hey, why not fix this one too? The only occurrence I left untouched is in setup.py because the PyPI classifier still uses the old name: https://pypi.org/search/?c=Operating+System+%3A%3A+MacOS+%3A%3A+MacOS+X.