### PR TITLE
Elide task.context.run() and contextvars.callable() frames from tracebacks

### DIFF
--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -3,8 +3,8 @@ import logging
 import os
 import random
 import select
+import sys
 import threading
-import traceback
 from collections import deque
 import collections.abc
 from contextlib import contextmanager, closing
@@ -1378,13 +1378,12 @@ def run_impl(runner, async_fn, args):
                 final_result = Value(stop_iteration.value)
             except BaseException as task_exc:
                 # Store for later, removing uninteresting top frames:
-                tb = task_exc.__traceback__
-                for path, _, _, _ in traceback.extract_tb(tb):
-                    if '/trio/_core/' in path or '/contextvars/' in path:
-                        tb = tb.tb_next
-                    else:
-                        break
-                final_result = Error(task_exc.with_traceback(tb))
+                #   1. trio._core._run.run_impl()
+                #   2. contextvars.Context.run() (< Python 3.7 only)
+                tb_next = task_exc.__traceback__.tb_next
+                if sys.version_info < (3, 7):
+                    tb_next = tb_next.tb_next
+                final_result = Error(task_exc.with_traceback(tb_next))
 
             if final_result is not None:
                 # We can't call this directly inside the except: blocks above,

--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -1920,9 +1920,11 @@ async def test_traceback_frame_removal():
         # is too eager.
         #frame = first_exc.__traceback__.tb_frame
         #assert frame.f_code is my_child_task.__code__
-        # ...but we're not there yet.  Only as far as open_cancel_scope().
-        _, _, function, _ = traceback.extract_tb(first_exc.__traceback__)[0]
-        assert function == 'open_cancel_scope'
+        # ...but we're not there yet.  There are several frames from nursery's
+        # __aexit__, starting with _nested_child_finished().
+        frames = traceback.extract_tb(first_exc.__traceback__)
+        functions = [function for _, _, function, _ in frames]
+        assert functions[-2:] == ['_nested_child_finished', 'my_child_task']
 
 
 def test_contextvar_support():


### PR DESCRIPTION
for #56 

TODO:
  * [x] write tests
