### PR TITLE
Fix error messages for host not found when `host` is passed in as bytes

### DIFF
--- a/newsfragments/633.bugfix.rst
+++ b/newsfragments/633.bugfix.rst
@@ -1,0 +1,3 @@
+Updates the formatting of exception messages raised by :func:`trio.open_tcp_stream` 
+to correctly handle a hostname passed in as bytes, by converting the hostname to
+a string.

--- a/trio/_highlevel_open_tcp_stream.py
+++ b/trio/_highlevel_open_tcp_stream.py
@@ -132,6 +132,7 @@ def reorder_for_rfc_6555_section_5_4(targets):
 
 
 def format_host_port(host, port):
+    host = host.decode() if isinstance(host, bytes) else host
     if ":" in host:
         return "[{}]:{}".format(host, port)
     else:

--- a/trio/_highlevel_open_tcp_stream.py
+++ b/trio/_highlevel_open_tcp_stream.py
@@ -132,7 +132,7 @@ def reorder_for_rfc_6555_section_5_4(targets):
 
 
 def format_host_port(host, port):
-    host = host.decode() if isinstance(host, bytes) else host
+    host = host.decode("ascii") if isinstance(host, bytes) else host
     if ":" in host:
         return "[{}]:{}".format(host, port)
     else:

--- a/trio/tests/test_highlevel_open_tcp_stream.py
+++ b/trio/tests/test_highlevel_open_tcp_stream.py
@@ -64,8 +64,11 @@ def test_reorder_for_rfc_6555_section_5_4():
 
 def test_format_host_port():
     assert format_host_port("127.0.0.1", 80) == "127.0.0.1:80"
+    assert format_host_port(b"127.0.0.1", 80) == "127.0.0.1:80"
     assert format_host_port("example.com", 443) == "example.com:443"
+    assert format_host_port(b"example.com", 443) == "example.com:443"
     assert format_host_port("::1", "http") == "[::1]:http"
+    assert format_host_port(b"::1", "http") == "[::1]:http"
 
 
 # Make sure we can connect to localhost using real kernel sockets


### PR DESCRIPTION
open_tcp_stream can take `host` as either bytes or str, but the formatting for the error message when a host is not found depends on host being a string. When trying to connect to a non-existent host, if passed as a string I would get the exception:

OSError: all attempts to connect to localhost:8081 failed

but when passed as bytes I would get the exception:

    if ":" in host:
TypeError: a bytes-like object is required, not 'str'

This PR adds a single line to convert bytes to a string before running the rest of the function (and some tests).


