### PR TITLE
Reduce extraneous exception frames

### DIFF
--- a/newsfragments/56.feature.rst
+++ b/newsfragments/56.feature.rst
@@ -1,0 +1,3 @@
+The length of typical exception traces coming from Trio has been
+greatly reduced.  This was done by eliminating many of the
+exception frames related to details of the implementation.

--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -1924,7 +1924,7 @@ async def test_traceback_frame_removal():
         # __aexit__, starting with _nested_child_finished().
         frames = traceback.extract_tb(first_exc.__traceback__)
         functions = [function for _, _, function, _ in frames]
-        assert functions[-2:] == ['_nested_child_finished', 'my_child_task']
+        assert functions[-2:] == ['open_cancel_scope', 'my_child_task']
 
 
 def test_contextvar_support():


### PR DESCRIPTION
For #56:
  * _nested_child_finished() returns rather than raises MultiError
  * implement explicit context manager for CancelScope rather than @contextmanager
  * propagate exceptions from cancel scope to nursery `__aexit__` manually

TODO:
  * [x] fix `test_nursery_exception_chaining_doesnt_make_context_loops()` test error
  * [x] remove more frames by propagating exceptions from cancel scope to nursery `__aexit__` manually
  * [x] fix `test_slow_abort_edge_cases()` etc. test errors