### PR TITLE
A few more small cleanups to tracebacks

### DIFF
--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -1317,7 +1317,12 @@ def run(
                 ) from exc
             finally:
                 GLOBAL_RUN_CONTEXT.__dict__.clear()
-            return runner.main_task_result.unwrap()
+            # Inlined copy of runner.main_task_result.unwrap() to avoid
+            # cluttering every single trio traceback with an extra frame.
+            if type(runner.main_task_result) is Value:
+                return runner.main_task_result.value
+            else:
+                raise runner.main_task_result.error
     finally:
         # To guarantee that we never swallow a KeyboardInterrupt, we have to
         # check for pending ones once more after leaving the context manager:

--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -1008,6 +1008,7 @@ def test_system_task_crash_KeyboardInterrupt():
         _core.run(main)
     assert isinstance(excinfo.value.__cause__, KeyboardInterrupt)
 
+
 # This used to fail because checkpoint was a yield followed by an immediate
 # reschedule. So we had:
 # 1) this task yields


### PR DESCRIPTION
This is going to be easiest to review as individual commits.

- Reworks how exceptions pass through run() to remove 3 frames from
  every trio traceback
- Makes the remaining traceback frames for nursery __aexit__ and
  cancel scope __exit__ easier to understand out of context.
- Cleans up some confusing terminology in _run.py

No newsfragment because this is a followup to #640 and that PR's
newsfragment covers these changes too.

Relevant bug: #56