### PR TITLE
Pinned pytest version to 3.7.4

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-pytest >= 3.3  # for catchlog fixture
+pytest == 3.7.4  # for catchlog fixture
 pytest-cov >= 2.6.0
 ipython        # for the IPython traceback integration tests
 pyOpenSSL      # for the ssl tests


### PR DESCRIPTION
Due to this error we pin the pytest version to 3.7.4 to get CI to pass.
```
============================= test session starts ==============================
platform darwin -- Python 3.5.3, pytest-3.8.0, py-1.6.0, pluggy-0.7.1 -- /Users/jenkins/workspace/-594-SV5AYVYYLSFPHE6/trio/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/jenkins/workspace/-594-SV5AYVYYLSFPHE6/trio, inifile:
plugins: faulthandler-1.5.0, cov-2.6.0
collecting ... collected 434 items / 1 errors


==================================== ERRORS ====================================
 ERROR collecting .venv/lib/python3.5/site-packages/trio/_core/tests/test_multierror.py
../.venv/lib/python3.5/site-packages/trio/_core/tests/test_multierror.py:584: in <module>
    import IPython
../.venv/lib/python3.5/site-packages/IPython/__init__.py:55: in <module>
    from .terminal.embed import embed
../.venv/lib/python3.5/site-packages/IPython/terminal/embed.py:14: in <module>
    from IPython.core.magic import Magics, magics_class, line_magic
../.venv/lib/python3.5/site-packages/IPython/core/magic.py:20: in <module>
    from IPython.core import oinspect
../.venv/lib/python3.5/site-packages/IPython/core/oinspect.py:29: in <module>
    from IPython.lib.pretty import pretty
../.venv/lib/python3.5/site-packages/IPython/lib/pretty.py:91: in <module>
    from IPython.utils.signatures import signature
../.venv/lib/python3.5/site-packages/IPython/utils/signatures.py:9: in <module>
    DeprecationWarning, stacklevel=2)
E   DeprecationWarning: IPython.utils.signatures backport for Python 2 is deprecated in IPython 6, which only supports Python 3
```