### PR TITLE
Filter out DeprecationWarning on IPython import in test suite

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-pytest == 3.7.4  # for catchlog fixture
+pytest >= 3.3  # for catchlog fixture
 pytest-cov >= 2.6.0
 ipython        # for the IPython traceback integration tests
 pyOpenSSL      # for the ssl tests

--- a/trio/_core/tests/test_multierror.py
+++ b/trio/_core/tests/test_multierror.py
@@ -7,6 +7,7 @@ import os
 import re
 from pathlib import Path
 import subprocess
+import warnings
 
 from .tutil import slow
 
@@ -580,6 +581,13 @@ def test_custom_excepthook():
     )
 
 
+# Before importing IPython, filter out a warning that happens in IPython 6.5.0
+# (at least), and that pytest will complain about otherwise:
+#
+#   .../IPython/lib/pretty.py:91: DeprecationWarning: IPython.utils.signatures backport for Python 2 is deprecated in IPython 6, which only supports Python 3
+warnings.filterwarnings(
+    "ignore", category=DeprecationWarning, module="IPython.lib.pretty"
+)
 try:
     import IPython
 except ImportError:  # pragma: no cover

--- a/trio/_core/tests/test_multierror.py
+++ b/trio/_core/tests/test_multierror.py
@@ -588,6 +588,14 @@ def test_custom_excepthook():
 warnings.filterwarnings(
     "ignore", category=DeprecationWarning, module="IPython.lib.pretty"
 )
+# And another from prompt_toolkit 1.11.0:
+#
+#  .../prompt_toolkit/styles/from_dict.py:9: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
+warnings.filterwarnings(
+    "ignore",
+    category=DeprecationWarning,
+    module="prompt_toolkit.styles.from_dict"
+)
 try:
     import IPython
 except ImportError:  # pragma: no cover


### PR DESCRIPTION
And unpin pytest again, since the pin in gh-650 was just a temporary
fix.

Fixes gh-651.