### PR TITLE
Another increment for static analysis

### DIFF
--- a/trio/_core/_ki.py
+++ b/trio/_core/_ki.py
@@ -1,7 +1,6 @@
 import inspect
 import signal
 import sys
-import threading
 from contextlib import contextmanager
 from functools import wraps
 

--- a/trio/_core/_multierror.py
+++ b/trio/_core/_multierror.py
@@ -184,11 +184,7 @@ class MultiError(BaseException):
             return self
 
     def __str__(self):
-        def format_child(exc):
-            #return "{}: {}".format(exc.__class__.__name__, exc)
-            return repr(exc)
-
-        return ", ".join(format_child(exc) for exc in self.exceptions)
+        return ", ".join(repr(exc) for exc in self.exceptions)
 
     def __repr__(self):
         return "<MultiError: {}>".format(self)

--- a/trio/_core/_multierror.py
+++ b/trio/_core/_multierror.py
@@ -2,8 +2,6 @@ import sys
 import traceback
 import textwrap
 import warnings
-import types
-from contextlib import contextmanager
 
 import attr
 

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -24,8 +24,7 @@ from . import _public
 from ._entry_queue import EntryQueue, TrioToken
 from ._exceptions import (TrioInternalError, RunFinishedError, Cancelled)
 from ._ki import (
-    LOCALS_KEY_KI_PROTECTION_ENABLED, currently_ki_protected, ki_manager,
-    enable_ki_protection
+    LOCALS_KEY_KI_PROTECTION_ENABLED, ki_manager, enable_ki_protection
 )
 from ._multierror import MultiError
 from ._traps import (

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -444,9 +444,8 @@ class Nursery:
         self.cancel_scope.cancel()
 
     def _check_nursery_closed(self):
-        if (
-            not self._nested_child_running and not self._children
-            and not self._pending_starts
+        if not any(
+            [self._nested_child_running, self._children, self._pending_starts]
         ):
             self._closed = True
             if self._parent_waiting_in_aexit:

--- a/trio/_core/tests/test_multierror.py
+++ b/trio/_core/tests/test_multierror.py
@@ -11,7 +11,6 @@ import warnings
 
 from .tutil import slow
 
-from ..._deprecate import TrioDeprecationWarning
 from .._multierror import MultiError, concat_tb
 
 

--- a/trio/_deprecate.py
+++ b/trio/_deprecate.py
@@ -1,5 +1,5 @@
 import sys
-from functools import wraps, partial
+from functools import wraps
 from types import ModuleType
 import warnings
 

--- a/trio/_socket.py
+++ b/trio/_socket.py
@@ -6,7 +6,6 @@ from functools import wraps as _wraps
 import idna as _idna
 
 from . import _core
-from ._deprecate import deprecated
 from ._threads import run_sync_in_worker_thread
 from ._util import fspath
 

--- a/trio/_ssl.py
+++ b/trio/_ssl.py
@@ -455,7 +455,9 @@ class SSLStream(Stream):
                     ret = fn(*args)
                 except _stdlib_ssl.SSLWantReadError:
                     want_read = True
-                except (SSLError, CertificateError) as exc:
+                except (
+                    _stdlib_ssl.SSLError, _stdlib_ssl.CertificateError
+                ) as exc:
                     self._state = _State.BROKEN
                     raise BrokenStreamError from exc
                 else:
@@ -629,9 +631,10 @@ class SSLStream(Stream):
                 # SSLSyscallError instead of SSLEOFError (e.g. on my linux
                 # laptop, but not on appveyor). Thanks openssl.
                 if (
-                    self._https_compatible and
-                    isinstance(exc.__cause__,
-                               (SSLEOFError, SSLSyscallError))
+                    self._https_compatible and isinstance(
+                        exc.__cause__,
+                        (_stdlib_ssl.SSLEOFError, _stdlib_ssl.SSLSyscallError)
+                    )
                 ):
                     return b""
                 else:

--- a/trio/testing/_checkpoints.py
+++ b/trio/testing/_checkpoints.py
@@ -1,7 +1,6 @@
 from contextlib import contextmanager
 
 from .. import _core
-from .._deprecate import deprecated
 
 __all__ = ["assert_checkpoints", "assert_no_checkpoints"]
 

--- a/trio/tests/test_signals.py
+++ b/trio/tests/test_signals.py
@@ -10,9 +10,7 @@ from .._signals import catch_signals, open_signal_receiver, _signal_handler
 
 # Delete when catch_signals is removed
 async def test_catch_signals(recwarn):
-    print = lambda *args: None
     orig = signal.getsignal(signal.SIGILL)
-    print(orig)
     with catch_signals([signal.SIGILL]) as queue:
         # Raise it a few times, to exercise signal coalescing, both at the
         # call_soon level and at the SignalQueue level

--- a/trio/tests/test_signals.py
+++ b/trio/tests/test_signals.py
@@ -1,4 +1,3 @@
-import os
 import signal
 
 import pytest

--- a/trio/tests/test_ssl.py
+++ b/trio/tests/test_ssl.py
@@ -1,6 +1,5 @@
 import pytest
 
-from pathlib import Path
 import threading
 import socket as stdlib_socket
 import ssl as stdlib_ssl


### PR DESCRIPTION
I'm going in small stages to make review (and debugging) manageable, so:

- Internally get names as attributes of the stdlib `ssl` and `socket` modules, rather than by magic
- Remove a bunch of unused imports (mostly leftover from deleted code)
- Minor cleanups I found in the process