### PR TITLE
Run flake8 in CI, split out check script

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -ex
+
+EXIT_STATUS=0
+
+# Autoformatter *first*, to avoid double-reporting errors
+yapf -rpd setup.py trio \
+    || EXIT_STATUS=$?
+
+# Run flake8 with lots of ignores (mostly import-related)
+flake8 trio/ \
+    --ignore=D,E201,E402,E501,E722,E741,F401,F403,F405,F821,F822,W503 \
+    || EXIT_STATUS=$?
+
+# Finally, leave a really clear warning of any issues and exit
+if [ $EXIT_STATUS -ne 0 ]; then
+    cat <<EOF
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+Problems were found by static analysis (listed above).
+To fix formatting and see remaining errors, run
+
+    pip install -r test-requirements.txt
+    yapf -rpi setup.py trio
+    ./check.sh
+
+in your local checkout.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+EOF
+    exit 1
+fi
+exit 0

--- a/ci/travis.sh
+++ b/ci/travis.sh
@@ -2,8 +2,6 @@
 
 set -ex
 
-YAPF_VERSION=0.22.0
-
 git rev-parse HEAD
 
 if [ "$TRAVIS_OS_NAME" = "osx" ]; then
@@ -53,33 +51,11 @@ pip --version
 
 pip install -U pip setuptools wheel
 
-if [ "$CHECK_FORMATTING" = "1" ]; then
-    pip install yapf==${YAPF_VERSION}
-    if ! yapf -rpd setup.py trio; then
-        cat <<EOF
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-Formatting problems were found (listed above). To fix them, run
-
-   pip install yapf==${YAPF_VERSION}
-   yapf -rpi setup.py trio
-
-in your local checkout.
-
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-EOF
-        exit 1
-    fi
-    exit 0
-fi
-
 python setup.py sdist --formats=zip
 pip install dist/*.zip
 
 if [ "$CHECK_DOCS" = "1" ]; then
-    pip install -Ur ci/rtd-requirements.txt
+    pip install -r ci/rtd-requirements.txt
     towncrier --yes  # catch errors in newsfragments
     cd docs
     # -n (nit-picky): warn on missing references
@@ -87,7 +63,11 @@ if [ "$CHECK_DOCS" = "1" ]; then
     sphinx-build -nW  -b html source build
 else
     # Actual tests
-    pip install -Ur test-requirements.txt
+    pip install -r test-requirements.txt
+
+    if [ "$CHECK_FORMATTING" = "1" ]; then
+        source check.sh
+    fi
 
     mkdir empty
     cd empty

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -1,11 +1,16 @@
+# For tests
 pytest >= 3.3  # for catchlog fixture
 pytest-cov >= 2.6.0
 ipython        # for the IPython traceback integration tests
 pyOpenSSL      # for the ssl tests
 trustme        # for the ssl tests
 pytest-faulthandler
+pylint         # for pylint finding all symbols tests
+jedi           # for jedi code completion tests
+
+# Tools
+yapf == 0.22.0
+flake8
 
 # https://github.com/python-trio/trio/pull/654#issuecomment-420518745
 typed_ast;python_version<"3.7" and implementation_name=="cpython"
-pylint         # for pylint finding all symbols tests
-jedi           # for jedi code completion tests

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,8 +4,6 @@
 #
 #    pip-compile --output-file test-requirements.txt test-requirements.in
 #
---index-url https://clustree:rbLnWxZhMWPRVQCr3ndtHfN7Q4Mah3DxXPvfDCKUzzXxXuPRay@devpi.clustree.net:3141/root/develop
-
 appnope==0.1.0            # via ipython
 asn1crypto==0.24.0        # via cryptography
 astroid==2.0.4            # via pylint
@@ -16,13 +14,14 @@ cffi==1.11.5              # via cryptography
 coverage==4.5.1           # via pytest-cov
 cryptography==2.3.1       # via pyopenssl, trustme
 decorator==4.3.0          # via ipython, traitlets
+flake8==3.5.0
 idna==2.7                 # via cryptography, trustme
 ipython-genutils==0.2.0   # via traitlets
 ipython==6.5.0
 isort==4.3.4              # via pylint
 jedi==0.12.1
 lazy-object-proxy==1.3.1  # via astroid
-mccabe==0.6.1             # via pylint
+mccabe==0.6.1             # via flake8, pylint
 more-itertools==4.3.0     # via pytest
 parso==0.3.1              # via jedi
 pathlib2==2.3.2           # via pytest
@@ -32,7 +31,9 @@ pluggy==0.7.1             # via pytest
 prompt-toolkit==1.0.15    # via ipython
 ptyprocess==0.6.0         # via pexpect
 py==1.6.0                 # via pytest
+pycodestyle==2.3.1        # via flake8
 pycparser==2.18           # via cffi
+pyflakes==1.6.0           # via flake8
 pygments==2.2.0           # via ipython
 pylint==2.1.1
 pyopenssl==18.0.0
@@ -46,3 +47,4 @@ trustme==0.4.0
 typed-ast==1.1.0 ; python_version < "3.7" and implementation_name == "cpython"
 wcwidth==0.1.7            # via prompt-toolkit
 wrapt==1.10.11            # via astroid
+yapf==0.22.0

--- a/trio/_core/_io_epoll.py
+++ b/trio/_core/_io_epoll.py
@@ -29,7 +29,8 @@ class EpollWaiters:
         # XX not sure if EPOLLEXCLUSIVE is actually safe... I think
         # probably we should use it here unconditionally, but:
         # https://stackoverflow.com/questions/41582560/how-does-epolls-epollexclusive-mode-interact-with-level-triggering
-        #flags |= select.EPOLLEXCLUSIVE
+
+        # flags |= select.EPOLLEXCLUSIVE
         # We used to use ONESHOT here also, but it turns out that it's
         # confusing/complicated: you can't use ONESHOT+EPOLLEXCLUSIVE
         # together, you ONESHOT doesn't delete the registration but just

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -746,7 +746,7 @@ class Runner:
     @_public
     def current_root_task(self):
         """Returns the current root :class:`Task`.
-        
+
         This is the task that is the ultimate parent of all other tasks.
 
         """
@@ -1572,7 +1572,7 @@ async def checkpoint():
     :func:`checkpoint`.)
 
     """
-    with open_cancel_scope(deadline=-inf) as scope:
+    with open_cancel_scope(deadline=-inf):
         await _core.wait_task_rescheduled(lambda _: _core.Abort.SUCCEEDED)
 
 

--- a/trio/_core/tests/test_ki.py
+++ b/trio/_core/tests/test_ki.py
@@ -182,7 +182,7 @@ async def test_agen_protection():
         agen_unprotected1,
         agen_unprotected2,
     ]:
-        async for _ in agen_fn():
+        async for _ in agen_fn():  # noqa
             assert not _core.currently_ki_protected()
 
         # asynccontextmanager insists that the function passed must itself be an

--- a/trio/_core/tests/test_multierror.py
+++ b/trio/_core/tests/test_multierror.py
@@ -206,7 +206,10 @@ def test_MultiError_filter():
 
 def test_MultiError_catch():
     # No exception to catch
-    noop = lambda _: None  # pragma: no cover
+
+    def noop(_):
+        pass  # pragma: no cover
+
     with MultiError.catch(noop):
         pass
 

--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -97,7 +97,7 @@ def test_run_nesting():
 async def test_nursery_warn_use_async_with():
     with pytest.raises(RuntimeError) as excinfo:
         on = _core.open_nursery()
-        with on as nursery:
+        with on:
             pass  # pragma: no cover
     excinfo.match(
         r"use 'async with open_nursery\(...\)', not 'with open_nursery\(...\)'"
@@ -112,7 +112,7 @@ async def test_nursery_main_block_error_basic():
     exc = ValueError("whoops")
 
     with pytest.raises(ValueError) as excinfo:
-        async with _core.open_nursery() as nursery:
+        async with _core.open_nursery():
             raise exc
     assert excinfo.value is exc
 
@@ -182,7 +182,7 @@ def test_main_and_task_both_crash():
 
     async def main():
         async with _core.open_nursery() as nursery:
-            crasher_task = nursery.start_soon(crasher)
+            nursery.start_soon(crasher)
             raise KeyError
 
     with pytest.raises(_core.MultiError) as excinfo:
@@ -335,7 +335,7 @@ async def test_current_statistics(mock_clock):
     await _core.checkpoint()
     await _core.checkpoint()
 
-    with _core.open_cancel_scope(deadline=_core.current_time() + 5) as scope:
+    with _core.open_cancel_scope(deadline=_core.current_time() + 5):
         stats = _core.current_statistics()
         print(stats)
         assert stats.seconds_to_next_deadline == 5
@@ -1019,7 +1019,7 @@ def test_system_task_crash_KeyboardInterrupt():
 # 5) ...but it's on the run queue, so the timeout is queued to be delivered
 #    the next time that it's blocked.
 async def test_yield_briefly_checks_for_timeout(mock_clock):
-    with _core.open_cancel_scope(deadline=_core.current_time() + 5) as scope:
+    with _core.open_cancel_scope(deadline=_core.current_time() + 5):
         await _core.checkpoint()
         with pytest.raises(_core.Cancelled):
             mock_clock.jump(10)

--- a/trio/_core/tests/test_unbounded_queue.py
+++ b/trio/_core/tests/test_unbounded_queue.py
@@ -119,7 +119,7 @@ async def test_UnboundedQueue_trivial_yields():
 
     q.put_nowait(None)
     with assert_checkpoints():
-        async for _ in q:  # pragma: no branch
+        async for _ in q:  # noqa # pragma: no branch
             break
 
 

--- a/trio/_path.py
+++ b/trio/_path.py
@@ -134,14 +134,14 @@ class Path(metaclass=AsyncAutoWrapperType):
 
         This is an async method that returns a synchronous iterator, so you
         use it like::
-        
+
            for subpath in await mypath.iterdir():
                ...
-               
+
         Note that it actually loads the whole directory list into memory
         immediately, during the initial call. (See `issue #501
         <https://github.com/python-trio/trio/issues/501>`__ for discussion.)
-        
+
         """
 
         def _load_items():

--- a/trio/_ssl.py
+++ b/trio/_ssl.py
@@ -697,7 +697,7 @@ class SSLStream(Stream):
 
         """
         async with self._outer_recv_conflict_detector, \
-                   self._outer_send_conflict_detector:
+                self._outer_send_conflict_detector:
             self._check_status()
             await self._handshook.ensure(checkpoint=False)
             await self._retry(self._ssl_object.unwrap)

--- a/trio/_util.py
+++ b/trio/_util.py
@@ -83,7 +83,9 @@ if sys.version_info < (3, 5, 2):
 
         return __aiter__
 else:
-    aiter_compat = lambda aiter_impl: aiter_impl
+
+    def aiter_compat(aiter_impl):
+        return aiter_impl
 
 
 # See: #461 as to why this is needed.
@@ -239,4 +241,4 @@ def fspath(path) -> t.Union[str, bytes]:
 
 
 if hasattr(os, "fspath"):
-    fspath = os.fspath
+    fspath = os.fspath  # noqa

--- a/trio/_wait_for_object.py
+++ b/trio/_wait_for_object.py
@@ -16,10 +16,10 @@ class StubLimiter:
 
 async def WaitForSingleObject(obj):
     """Async and cancellable variant of WaitForSingleObject. Windows only.
-    
+
     Args:
       handle: A Win32 handle, as a Python integer.
-    
+
     Raises:
       OSError: If the handle is invalid, e.g. when it is already closed.
 
@@ -56,7 +56,7 @@ async def WaitForSingleObject(obj):
 
 def WaitForMultipleObjects_sync(*handles):
     """Wait for any of the given Windows handles to be signaled.
-    
+
     """
     n = len(handles)
     handle_arr = ffi.new("HANDLE[{}]".format(n))

--- a/trio/testing/_check_streams.py
+++ b/trio/testing/_check_streams.py
@@ -93,7 +93,7 @@ async def check_one_way_stream(stream_maker, clogged_stream_maker):
             nursery.start_soon(send_empty_then_y)
             nursery.start_soon(checked_receive_1, b"y")
 
-        ### Checking various argument types
+        # ---- Checking various argument types ----
 
         # send_all accepts bytearray and memoryview
         async with _core.open_nursery() as nursery:

--- a/trio/tests/test_path.py
+++ b/trio/tests/test_path.py
@@ -54,8 +54,8 @@ async def test_cmp_magic(cls_a, cls_b):
 
     # this is intentionally testing equivalence with none, due to the
     # other=sentinel logic in _forward_magic
-    assert not a == None
-    assert not b == None
+    assert not a == None  # noqa
+    assert not b == None  # noqa
 
 
 # upstream python3.5 bug: we should also test (pathlib.Path, trio.Path), but

--- a/trio/tests/test_socket.py
+++ b/trio/tests/test_socket.py
@@ -512,6 +512,7 @@ async def test_SocketType_non_blocking_paths():
             with pytest.raises(TypeError):
                 await ta.recv("haha")
         # block then succeed
+
         async def do_successful_blocking_recv():
             with assert_checkpoints():
                 assert await ta.recv(10) == b"2"
@@ -521,6 +522,7 @@ async def test_SocketType_non_blocking_paths():
             await wait_all_tasks_blocked()
             b.send(b"2")
         # block then cancelled
+
         async def do_cancelled_blocking_recv():
             with assert_checkpoints():
                 with pytest.raises(_core.Cancelled):

--- a/trio/tests/test_ssl.py
+++ b/trio/tests/test_ssl.py
@@ -420,7 +420,7 @@ async def test_attributes():
 
         # Forwarded attribute getting
         assert s.context is good_ctx
-        assert s.server_side == False
+        assert s.server_side == False  # noqa
         assert s.server_hostname == "trio-test-1.example.org"
         with pytest.raises(AttributeError):
             s.asfdasdfsa
@@ -1004,7 +1004,7 @@ async def test_ssl_handshake_failure_during_aclose():
         # simultaneously is allowed. But I guess when https_compatible=False
         # then it's bad if we can get through a whole connection with a peer
         # that has no valid certificate, and never raise an error.
-        with pytest.raises(BrokenStreamError) as excinfo:
+        with pytest.raises(BrokenStreamError):
             await s.aclose()
 
 

--- a/trio/tests/test_sync.py
+++ b/trio/tests/test_sync.py
@@ -231,7 +231,7 @@ async def test_Semaphore_bounded():
     "lockcls", [Lock, StrictFIFOLock], ids=lambda fn: fn.__name__
 )
 async def test_Lock_and_StrictFIFOLock(lockcls):
-    l = lockcls()
+    l = lockcls()  # noqa
     assert not l.locked()
 
     # make sure locks can be weakref'ed (gh-331)
@@ -310,7 +310,7 @@ async def test_Condition():
         Condition(Semaphore(1))
     with pytest.raises(TypeError):
         Condition(StrictFIFOLock)
-    l = Lock()
+    l = Lock()  # noqa
     c = Condition(l)
     assert not l.locked()
     assert not c.locked()


### PR DESCRIPTION
This catches a whole pile of things that `yapf` doesn't, from trailing whitespace to unused variables or dodgy comparisons.  I've gone for a mixed strategy for existing issues - fixing or suppressing the less common issues so we'll catch any new instances, but globally ignoring a few pervasive lint errors where e.g. `flake8` and `yapf` disagree to favor the latter.

Of course all the import-related issues are behind the `--ignore=` flag, but we'll get #542 eventually!

Finally, I've split out the static analysis job into a new script `check.sh` which can be run locally for quick feedback.  This is also designed to make adding more analysis tools - e.g. `mypy` or `bandit` - as easy as possible.