### PR TITLE
Bandit - a security-oriented linter

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -13,6 +13,10 @@ flake8 trio/ \
     --ignore=D,E201,E402,E501,E722,E741,F401,F403,F405,F821,F822,W503 \
     || EXIT_STATUS=$?
 
+# Bandit is a security-oriented linter
+bandit --recursive --exclude=trio/tests --skip=B101,B311,B404 trio/ \
+    || EXIT_STATUS=$?
+
 # Finally, leave a really clear warning of any issues and exit
 if [ $EXIT_STATUS -ne 0 ]; then
     cat <<EOF

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -11,6 +11,7 @@ jedi           # for jedi code completion tests
 # Tools
 yapf == 0.22.0
 flake8
+bandit
 
 # https://github.com/python-trio/trio/pull/654#issuecomment-420518745
 typed_ast;python_version<"3.7" and implementation_name=="cpython"

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -10,11 +10,14 @@ astroid==2.0.4            # via pylint
 atomicwrites==1.2.1       # via pytest
 attrs==18.2.0             # via pytest
 backcall==0.1.0           # via ipython
+bandit==1.5.1
 cffi==1.11.5              # via cryptography
 coverage==4.5.1           # via pytest-cov
 cryptography==2.3.1       # via pyopenssl, trustme
 decorator==4.3.0          # via ipython, traitlets
 flake8==3.5.0
+gitdb2==2.0.4             # via gitpython
+gitpython==2.1.11         # via bandit
 idna==2.7                 # via cryptography, trustme
 ipython-genutils==0.2.0   # via traitlets
 ipython==6.5.0
@@ -26,6 +29,7 @@ more-itertools==4.3.0     # via pytest
 parso==0.3.1              # via jedi
 pathlib2==2.3.2           # via pytest
 pexpect==4.6.0            # via ipython
+pbr==4.2.0                # via stevedore
 pickleshare==0.7.4        # via ipython
 pluggy==0.7.1             # via pytest
 prompt-toolkit==1.0.15    # via ipython
@@ -40,8 +44,11 @@ pyopenssl==18.0.0
 pytest-cov==2.6.0
 pytest-faulthandler==1.5.0
 pytest==3.8.1
+pyyaml==3.13              # via bandit
 simplegeneric==0.8.1      # via ipython
-six==1.11.0               # via astroid, cryptography, more-itertools, pathlib2, prompt-toolkit, pyopenssl, pytest, traitlets
+six==1.11.0               # via astroid, bandit, cryptography, more-itertools, pathlib2, prompt-toolkit, pyopenssl, pytest, stevedore, traitlets
+smmap2==2.0.4             # via gitdb2
+stevedore==1.29.0         # via bandit
 traitlets==4.3.2          # via ipython
 trustme==0.4.0
 typed-ast==1.1.0 ; python_version < "3.7" and implementation_name == "cpython"

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -1632,7 +1632,8 @@ def _generate_method_wrappers(cls, path_to_instance):
                 "LOCALS_KEY_KI_PROTECTION_ENABLED":
                     LOCALS_KEY_KI_PROTECTION_ENABLED
             }
-            exec(_WRAPPER_TEMPLATE.format(path_to_instance, methname), ns)
+            code = _WRAPPER_TEMPLATE.format(path_to_instance, methname)
+            exec(code, ns)  # nosec
             wrapper = ns["wrapper"]
             # 'fn' is the *unbound* version of the method, but our exported
             # function has the same API as the *bound* version of the

--- a/trio/_core/tests/test_multierror.py
+++ b/trio/_core/tests/test_multierror.py
@@ -537,7 +537,7 @@ def run_script(name, use_ipython=False):
     else:
         cmd = [sys.executable, "-u", str(script_path)]
     print("running:", cmd)
-    completed = subprocess.run(
+    completed = subprocess.run(  # nosec
         cmd, env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
     )
     print("process output:")

--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -1100,7 +1100,7 @@ async def test_exc_info_after_yield_error():
         except Exception:
             try:
                 await sleep_forever()
-            except Exception:
+            except Exception:  # nosec
                 pass
             raise
 

--- a/trio/testing/_network.py
+++ b/trio/testing/_network.py
@@ -1,5 +1,5 @@
 from .. import socket as tsocket
-from .._highlevel_socket import SocketListener, SocketStream
+from .._highlevel_socket import SocketStream
 
 __all__ = ["open_stream_to_socket_listener"]
 
@@ -25,7 +25,7 @@ async def open_stream_to_socket_listener(socket_listener):
     sockaddr = socket_listener.socket.getsockname()
     if family in (tsocket.AF_INET, tsocket.AF_INET6):
         sockaddr = list(sockaddr)
-        if sockaddr[0] == "0.0.0.0":
+        if sockaddr[0] == "0.0.0.0":  # nosec
             sockaddr[0] = "127.0.0.1"
         if sockaddr[0] == "::":
             sockaddr[0] = "::1"


### PR DESCRIPTION
[Bandit](https://bandit.readthedocs.io/en/latest/) is a security-focused static analysis tool, which looks for potential problems like use of `exec` or `subprocess`, or possibly binding to all interfaces (with `"0.0.0.0"`).  The argument for using it is basically that it's trivially easy to do so, and wouldn't we feel silly otherwise about avoidable security problems?  

That's not hypothetical by the way - we ran it against Hypothesis a while ago and it was fine, so we left it out of CI.  Subsequent versions allowed it to spot internal use of `pickle` in a cache file that may be shared from other users, and warn that deserialising pickle data gives the author arbitrary code execution.  That cache file is now written as JSON and Bandit runs in Hypothesis CI.