### PR TITLE
Fixes 'invalid escape sequence \s' deprecation warning on python 3.7

### DIFF
--- a/trio/_core/_ki.py
+++ b/trio/_core/_ki.py
@@ -97,7 +97,7 @@ def ki_protection_enabled(frame):
 
 
 def currently_ki_protected():
-    """Check whether the calling code has :exc:`KeyboardInterrupt` protection
+    r"""Check whether the calling code has :exc:`KeyboardInterrupt` protection
     enabled.
 
     It's surprisingly easy to think that one's :exc:`KeyboardInterrupt`

--- a/trio/_highlevel_serve_listeners.py
+++ b/trio/_highlevel_serve_listeners.py
@@ -57,7 +57,7 @@ async def serve_listeners(
     handler_nursery=None,
     task_status=trio.TASK_STATUS_IGNORED
 ):
-    """Listen for incoming connections on ``listeners``, and for each one
+    r"""Listen for incoming connections on ``listeners``, and for each one
     start a task running ``handler(stream)``.
 
     .. warning::

--- a/trio/_ssl.py
+++ b/trio/_ssl.py
@@ -235,7 +235,7 @@ _default_max_refill_bytes = 32 * 1024
 
 
 class SSLStream(Stream):
-    """Encrypted communication using SSL/TLS.
+    r"""Encrypted communication using SSL/TLS.
 
     :class:`SSLStream` wraps an arbitrary :class:`~trio.abc.Stream`, and
     allows you to perform encrypted communication over it using the usual

--- a/trio/_sync.py
+++ b/trio/_sync.py
@@ -607,7 +607,7 @@ class Lock:
 
 
 class StrictFIFOLock(Lock):
-    """A variant of :class:`Lock` where tasks are guaranteed to acquire the
+    r"""A variant of :class:`Lock` where tasks are guaranteed to acquire the
     lock in strict first-come-first-served order.
 
     An example of when this is useful is if you're implementing something like
@@ -791,7 +791,7 @@ class Condition:
         self._lot.repark_all(self._lock._lot)
 
     def statistics(self):
-        """Return an object containing debugging information.
+        r"""Return an object containing debugging information.
 
         Currently the following fields are defined:
 


### PR DESCRIPTION
Some strings contain content that needs these strings now to be raw strings.
This PR fixes this.