### PR TITLE
Change to high-resolution clock per #33

### DIFF
--- a/docs/source/reference-core.rst
+++ b/docs/source/reference-core.rst
@@ -198,7 +198,7 @@ Time and clocks
 
 Every call to :func:`run` has an associated clock.
 
-By default, trio uses an unspecified monotonic clock, but this can be
+By default, trio uses the `time.perf_counter` clock, but this can be
 changed by passing a custom clock object to :func:`run` (e.g. for
 testing).
 
@@ -206,9 +206,9 @@ You should not assume that trio's internal clock matches any other
 clock you have access to, including the clocks of simultaneous calls
 to :func:`trio.run` happening in other processes or threads!
 
-The default clock is currently implemented as :func:`time.monotonic`
+The default clock is currently implemented as :func:`time.perf_counter`
 plus a large random offset. The idea here is to catch code that
-accidentally uses :func:`time.monotonic` early, which should help keep
+accidentally uses :func:`time.perf_counter` early, which should help keep
 our options open for `changing the clock implementation later
 <https://github.com/python-trio/trio/issues/33>`__, and (more importantly)
 make sure you can be confident that custom clocks like

--- a/docs/source/reference-core.rst
+++ b/docs/source/reference-core.rst
@@ -198,7 +198,7 @@ Time and clocks
 
 Every call to :func:`run` has an associated clock.
 
-By default, trio uses the `time.perf_counter` clock, but this can be
+By default, trio uses an unspecified monotonic clock, but this can be
 changed by passing a custom clock object to :func:`run` (e.g. for
 testing).
 

--- a/docs/source/reference-testing/across-realtime.py
+++ b/docs/source/reference-testing/across-realtime.py
@@ -45,9 +45,9 @@ async def main():
         nursery.start_soon(task2)
 
 def run_example(clock):
-    real_start = time.monotonic()
+    real_start = time.perf_counter()
     trio.run(main, clock=clock)
-    real_duration = time.monotonic() - real_start
+    real_duration = time.perf_counter() - real_start
     print("Total real time elapsed: {} seconds".format(real_duration))
 
 print("Clock where time passes at 100 years per second:\n")

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -267,12 +267,12 @@ this, that tries to call an async function but leaves out the
 
    async def broken_double_sleep(x):
        print("*yawn* Going to sleep")
-       start_time = time.monotonic()
+       start_time = time.perf_counter()
 
        # Whoops, we forgot the 'await'!
        trio.sleep(2 * x)
 
-       sleep_time = time.monotonic() - start_time
+       sleep_time = time.perf_counter() - start_time
        print("Woke up after {:.2f} seconds, feeling well rested!".format(sleep_time))
 
    trio.run(broken_double_sleep, 3)

--- a/newsfragments/33.feature.rst
+++ b/newsfragments/33.feature.rst
@@ -1,1 +1,2 @@
-The Trio main loop clock now requests a performance counter, resulting in higher precision on Windows.
+Trio's default internal clock is now based on :func:`time.perf_counter` instead of :func:`time.monotonic`.
+This makes time-keeping more precise on Windows, and has no effect on other platforms.

--- a/newsfragments/33.feature.rst
+++ b/newsfragments/33.feature.rst
@@ -1,1 +1,1 @@
-The Trio main loop now uses a higher-precision clock by default.
+The Trio main loop clock now requests a performance counter, resulting in higher precision on Windows.

--- a/newsfragments/33.feature.rst
+++ b/newsfragments/33.feature.rst
@@ -1,0 +1,1 @@
+The Trio main loop now uses a higher-precision clock by default.

--- a/notes-to-self/file-read-latency.py
+++ b/notes-to-self/file-read-latency.py
@@ -11,14 +11,14 @@ COUNT = 1000000
 f = open("/etc/passwd", "rb")#, buffering=0)
 
 while True:
-    start = time.monotonic()
+    start = time.perf_counter()
     for _ in range(COUNT):
         f.seek(0)
         f.read(1)
-    between = time.monotonic()
+    between = time.perf_counter()
     for _ in range(COUNT):
         f.seek(0)
-    end = time.monotonic()
+    end = time.perf_counter()
 
     both = (between - start) / COUNT * 1e9
     seek = (end - between) / COUNT * 1e9

--- a/notes-to-self/proxy-benchmarks.py
+++ b/notes-to-self/proxy-benchmarks.py
@@ -145,11 +145,11 @@ else:
 while True:
     print("-------")
     for obj in objs:
-        start = time.monotonic()
+        start = time.perf_counter()
         for _ in range(COUNT):
             obj.fileno()
             #obj.fileno
-        end = time.monotonic()
+        end = time.perf_counter()
         per_usec = COUNT / (end - start) / 1e6
         print("{:7.2f} / us: {} ({})"
               .format(per_usec, obj.strategy, obj.works_for))

--- a/notes-to-self/schedule-timing.py
+++ b/notes-to-self/schedule-timing.py
@@ -19,9 +19,9 @@ async def report_loop():
     try:
         while True:
             start_count = LOOPS
-            start_time = time.monotonic()
+            start_time = time.perf_counter()
             await trio.sleep(1)
-            end_time = time.monotonic()
+            end_time = time.perf_counter()
             end_count = LOOPS
             loops = end_count - start_count
             duration = end_time - start_time

--- a/notes-to-self/wakeup-fd-racer.py
+++ b/notes-to-self/wakeup-fd-racer.py
@@ -61,13 +61,13 @@ def main():
 
         # Fake an IO loop that's trying to sleep for 10 seconds (but will
         # hopefully get interrupted after just 1 second)
-        start = time.monotonic()
+        start = time.perf_counter()
         target = start + 10
         try:
             select_calls = 0
             drained = 0
             while True:
-                now = time.monotonic()
+                now = time.perf_counter()
                 if now > target:
                     break
                 select_calls += 1
@@ -85,7 +85,7 @@ def main():
         # We expect a successful run to take 1 second, and a failed run to
         # take 10 seconds, so 2 seconds is a reasonable cutoff to distinguish
         # them.
-        duration = time.monotonic() - start
+        duration = time.perf_counter() - start
         if duration < 2:
             print(f"Attempt {attempt}: OK, trying again "
                   f"(select_calls = {select_calls}, drained = {drained})")

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -11,7 +11,7 @@ from contextlib import contextmanager, closing
 
 from contextvars import copy_context
 from math import inf
-from time import monotonic
+from time import perf_counter
 
 from sniffio import current_async_library_cvar
 
@@ -101,7 +101,7 @@ class SystemClock:
         pass
 
     def current_time(self):
-        return self.offset + monotonic()
+        return self.offset + perf_counter()
 
     def deadline_to_sleep_time(self, deadline):
         return deadline - self.current_time()

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -1236,7 +1236,7 @@ def run(
       args: Positional arguments to be passed to *async_fn*. If you need to
           pass keyword arguments, then use :func:`functools.partial`.
 
-      clock: ``None`` to use the default system-specific perf_counter clock;
+      clock: ``None`` to use the default system-specific monotonic clock;
           otherwise, an object implementing the :class:`trio.abc.Clock`
           interface, like (for example) a :class:`trio.testing.MockClock`
           instance.

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -93,13 +93,16 @@ CONTEXT_RUN_TB_FRAMES = _count_context_run_tb_frames()
 @attr.s(frozen=True)
 class SystemClock:
     # Add a large random offset to our clock to ensure that if people
-    # accidentally call time.monotonic() directly or start comparing clocks
+    # accidentally call time.perf_counter() directly or start comparing clocks
     # between different runs, then they'll notice the bug quickly:
     offset = attr.ib(default=attr.Factory(lambda: _r.uniform(10000, 200000)))
 
     def start_clock(self):
         pass
 
+    # In cPython 3, on every platform except Windows, perf_counter is
+    # exactly the same as time.monotonic; and on Windows, it uses
+    # QueryPerformanceCounter instead of GetTickCount64.
     def current_time(self):
         return self.offset + perf_counter()
 
@@ -1233,7 +1236,7 @@ def run(
       args: Positional arguments to be passed to *async_fn*. If you need to
           pass keyword arguments, then use :func:`functools.partial`.
 
-      clock: ``None`` to use the default system-specific monotonic clock;
+      clock: ``None`` to use the default system-specific perf_counter clock;
           otherwise, an object implementing the :class:`trio.abc.Clock`
           interface, like (for example) a :class:`trio.testing.MockClock`
           instance.

--- a/trio/_core/tests/test_ki.py
+++ b/trio/_core/tests/test_ki.py
@@ -581,11 +581,11 @@ def test_ki_wakes_us_up():
             print("joining thread", sys.exc_info())
             thread.join()
 
-    start = time.monotonic()
+    start = time.perf_counter()
     try:
         _core.run(main)
     finally:
-        end = time.monotonic()
+        end = time.perf_counter()
         print("duration", end - start)
         print("sys.exc_info", sys.exc_info())
     assert 1.0 <= (end - start) < 2

--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -253,7 +253,7 @@ async def test_current_time():
     t1 = _core.current_time()
     # Windows clock is pretty low-resolution -- appveyor tests fail unless we
     # sleep for a bit here.
-    time.sleep(time.get_clock_info("monotonic").resolution)
+    time.sleep(time.get_clock_info("perf_counter").resolution)
     t2 = _core.current_time()
     assert t1 < t2
 
@@ -834,15 +834,15 @@ async def test_timekeeping():
     TARGET = 0.1
     # give it a few tries in case of random CI server flakiness
     for _ in range(4):
-        real_start = time.monotonic()
+        real_start = time.perf_counter()
         with _core.open_cancel_scope() as scope:
             scope.deadline = _core.current_time() + TARGET
             await sleep_forever()
-        real_duration = time.monotonic() - real_start
+        real_duration = time.perf_counter() - real_start
         accuracy = real_duration / TARGET
         print(accuracy)
         # Actual time elapsed should always be >= target time
-        # (== is possible because time.monotonic on Windows is really low res)
+        # (== is possible depending on system behavior for time.perf_counter resolution
         if 1.0 <= accuracy < 2:  # pragma: no branch
             break
     else:  # pragma: no cover

--- a/trio/testing/_mock_clock.py
+++ b/trio/testing/_mock_clock.py
@@ -92,7 +92,7 @@ class MockClock(Clock):
         self._autojump_task = None
         self._autojump_cancel_scope = None
         # kept as an attribute so that our tests can monkeypatch it
-        self._real_clock = time.monotonic
+        self._real_clock = time.perf_counter
 
         # use the property update logic to set initial values
         self.rate = rate

--- a/trio/tests/test_testing.py
+++ b/trio/tests/test_testing.py
@@ -310,7 +310,7 @@ async def test_mock_clock_autojump(mock_clock):
     mock_clock.autojump_threshold = 0
     assert mock_clock.autojump_threshold == 0
 
-    real_start = time.monotonic()
+    real_start = time.perf_counter()
 
     virtual_start = _core.current_time()
     for i in range(10):
@@ -320,7 +320,7 @@ async def test_mock_clock_autojump(mock_clock):
         assert virtual_start + 10 * i == _core.current_time()
         virtual_start = _core.current_time()
 
-    real_duration = time.monotonic() - real_start
+    real_duration = time.perf_counter() - real_start
     print(
         "Slept {} seconds in {} seconds"
         .format(10 * sum(range(10)), real_duration)
@@ -378,9 +378,9 @@ def test_mock_clock_autojump_preset():
     # actually in use, and it gets picked up
     mock_clock = MockClock(autojump_threshold=0.1)
     mock_clock.autojump_threshold = 0.01
-    real_start = time.monotonic()
+    real_start = time.perf_counter()
     _core.run(sleep, 10000, clock=mock_clock)
-    assert time.monotonic() - real_start < 1
+    assert time.perf_counter() - real_start < 1
 
 
 async def test_mock_clock_autojump_0_and_wait_all_tasks_blocked(mock_clock):

--- a/trio/tests/test_timeouts.py
+++ b/trio/tests/test_timeouts.py
@@ -9,9 +9,9 @@ from .._timeouts import *
 
 
 async def check_takes_about(f, expected_dur):
-    start = time.monotonic()
+    start = time.perf_counter()
     result = await outcome.acapture(f)
-    dur = time.monotonic() - start
+    dur = time.perf_counter() - start
     print(dur / expected_dur)
     # 1.2 is an arbitrary fudge factor because there's always some delay
     # between when we become eligible to wake up and when we actually do. We


### PR DESCRIPTION
Per the discussion in issue #33 this changes the clock to use time.perf_counter() rather than time.monotonic() on all platforms.