### PR TITLE
Don't use asyncio.sleep as a function that waits on an asyncio.Future

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -26,7 +26,7 @@ more-itertools==4.3.0     # via pytest
 parso==0.3.1              # via jedi
 pathlib2==2.3.2           # via pytest
 pexpect==4.6.0            # via ipython
-pickleshare==0.7.4        # via ipython
+pickleshare==0.7.5        # via ipython
 pluggy==0.7.1             # via pytest
 prompt-toolkit==1.0.15    # via ipython
 ptyprocess==0.6.0         # via pexpect

--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -1609,7 +1609,7 @@ def test_nice_error_on_bad_calls_to_run_or_spawn():
 def test_calling_asyncio_function_gives_nice_error():
     async def misguided():
         import asyncio
-        await asyncio.sleep(1)
+        await asyncio.Future()
 
     with pytest.raises(TypeError) as excinfo:
         _core.run(misguided)


### PR DESCRIPTION
In this PR:

  https://github.com/python/cpython/pull/9415

asyncio.sleep switched to requiring a running asyncio event loop. This
is all very sensible, but broke our test that checks what happens when
some accidentally yields an asyncio.Future to the Trio run loop.
Switch the test to waiting on a Future directly.