### PR TITLE
Add pylint missing-await checker

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -14,7 +14,7 @@ flake8 trio/ \
     || EXIT_STATUS=$?
 
 # pylint to at least cover common omissions of "await" and "async" qualifiers
-find trio/ -name '*.py' |
+find trio/ -not -name 'test_pylint_missing_await.py' -name '*.py' |
     PYTHONPATH=. xargs pylint --load-plugins=trio.testing.pylint-missing-await \
     --disable=all --enable=missing-await,not-an-iterable,not-context-manager \
     || EXIT_STATUS=$?

--- a/check.sh
+++ b/check.sh
@@ -13,6 +13,12 @@ flake8 trio/ \
     --ignore=D,E,W,F401,F403,F405,F821,F822\
     || EXIT_STATUS=$?
 
+# pylint to at least cover common omissions of "await" and "async" qualifiers
+find trio/ -name '*.py' |
+    PYTHONPATH=. xargs pylint --load-plugins=trio.testing.pylint-missing-await \
+    --disable=all --enable=missing-await,not-an-iterable,not-context-manager \
+    || EXIT_STATUS=$?
+
 # Finally, leave a really clear warning of any issues and exit
 if [ $EXIT_STATUS -ne 0 ]; then
     cat <<EOF

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -7,6 +7,8 @@ trustme        # for the ssl tests
 pytest-faulthandler
 pylint         # for pylint finding all symbols tests
 jedi           # for jedi code completion tests
+# astroid is a pylint dependency.  Need master for https://github.com/PyCQA/astroid/issues/663
+-e git+https://github.com/PyCQA/astroid.git#egg=astroid
 
 # Tools
 yapf ==0.26.0  # formatting

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,8 +4,8 @@
 #
 #    pip-compile --output-file test-requirements.txt test-requirements.in
 #
+-e git+https://github.com/PyCQA/astroid.git#egg=astroid  # via pylint
 asn1crypto==0.24.0        # via cryptography
-astroid==2.2.5            # via pylint
 async-generator==1.10
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0

--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -1636,14 +1636,14 @@ def test_nice_error_on_bad_calls_to_run_or_spawn():
                 pass
 
             with pytest.raises(TypeError) as excinfo:
-                bad_call(f())
+                bad_call(f())  # pylint: disable=missing-await
             assert "expecting an async function" in str(excinfo.value)
 
             import asyncio
 
             @asyncio.coroutine
             def generator_based_coro():  # pragma: no cover
-                yield from asyncio.sleep(1)
+                yield from asyncio.sleep(1)  # pylint: disable=missing-await
 
             with pytest.raises(TypeError) as excinfo:
                 bad_call(generator_based_coro())

--- a/trio/_subprocess_platform/__init__.py
+++ b/trio/_subprocess_platform/__init__.py
@@ -25,7 +25,7 @@ async def wait_child_exiting(process: "_subprocess.Process") -> None:
     raise NotImplementedError from wait_child_exiting._error  # pragma: no cover
 
 
-async def create_pipe_to_child_stdin() -> Tuple[SendStream, int]:
+def create_pipe_to_child_stdin() -> Tuple[SendStream, int]:
     """Create a new pipe suitable for sending data from this
     process to the standard input of a child we're about to spawn.
 
@@ -40,7 +40,7 @@ async def create_pipe_to_child_stdin() -> Tuple[SendStream, int]:
     )
 
 
-async def create_pipe_from_child_output() -> Tuple[ReceiveStream, int]:
+def create_pipe_from_child_output() -> Tuple[ReceiveStream, int]:
     """Create a new pipe suitable for receiving data into this
     process from the standard output or error stream of a child
     we're about to spawn.

--- a/trio/testing/pylint-missing-await.py
+++ b/trio/testing/pylint-missing-await.py
@@ -1,0 +1,89 @@
+"""
+Checker for various async/await syntax, in the context of Trio.
+
+Included checks:
+    * missing-await (e.g. "await async_func()")
+
+Detection is subject to the type inference limitations of the astroid library.
+
+Async-for case is covered by the standard "not-an-iterable" check.
+
+Async-with case is covered by the standard "not-context-manager" check,
+assuming no anti-pattern such as __enter__/__exit__ with NotImplementedError.
+
+See  http://pylint.pycqa.org/en/latest/how_tos/custom_checkers.html
+and pylint typecheck.py for hints on implementing checkers.
+
+# TODO: name this more generally (pylint-awaitables)
+"""
+
+import astroid
+from pylint.checkers import BaseChecker
+from pylint.interfaces import IAstroidChecker
+
+
+def register(linter):
+    linter.register_checker(MissingAwaitChecker(linter))
+
+
+def has_yield(node):
+    return any(node.nodes_of_class(astroid.Yield)) or \
+           any(node.nodes_of_class(astroid.YieldFrom))
+
+
+class MissingAwaitChecker(BaseChecker):
+    __implements__ = IAstroidChecker
+
+    name = "missing-await"
+    priority = -1
+    msgs = {
+        'W5680':
+            (
+                "Called an async function without immediate 'await'.",
+                # TODO: narrow scope to "trio-missing-await"?  Other projects
+                # will certainly have missing-await-ish things.
+                "missing-await",
+                "According to the style of the Trio async I/O library, awaitables "
+                "returned from an async function call should be immediately consumed "
+                "by 'await'.",
+            ),
+    }
+    options = ()
+
+    def __init__(self, *args, **kwargs):
+        super(MissingAwaitChecker, self).__init__(*args, **kwargs)
+        self._last_awaited_funcs = None
+
+    def visit_await(self, node):
+        # print('** await', node.value)
+        if hasattr(node.value, 'func'):
+            self._last_awaited_funcs = [node.value.func]
+
+    def visit_asyncwith(self, node):
+        # print('** async with', node)
+        self._last_awaited_funcs = [item[0] for item in node.items]
+
+    def visit_asyncfor(self, node):
+        # print('** async for', node)
+        # self._last_awaited_funcs = [item[0] for item in node.items]
+        self._last_awaited_funcs = []  # how to resolve?
+
+    def visit_call(self, call_node):
+        # print(call_node)
+        nodes = [call_node]
+        while nodes:
+            node = nodes.pop()
+            try:
+                if isinstance(node, astroid.AsyncFunctionDef):
+                    if not has_yield(node) and \
+                            self._last_awaited_funcs is None:
+                        # or call_node.func not in self._last_awaited_funcs):
+                        self.add_message('missing-await', node=call_node)
+                        break
+                elif isinstance(node, astroid.Call):
+                    nodes += node.func.inferred()
+                elif isinstance(node, astroid.BoundMethod):
+                    nodes += node.inferred()
+            except astroid.InferenceError:
+                continue
+        self._last_awaited_funcs = None

--- a/trio/tests/pylint-expect-message.py
+++ b/trio/tests/pylint-expect-message.py
@@ -1,0 +1,49 @@
+"""
+pylint helper plugin which reports "# expect=symbol,..." annotations
+
+Output is to stdout in the form "<line_number>:<symbol>", one line per expected
+symbol instance.  Example output:
+
+    23:missing-await
+    33:missing-async-for
+    52:not-context-manager
+    56:not-context-manager
+
+For easy comparison with pylint runs, the output format of this helper matches
+that of pylint when using option --msg-template '{line}:{symbol}'.
+
+This plugin does not itself emit pylint messages.
+
+See https://github.com/PyCQA/pylint/issues/2863, which proposes tighter
+integration of this testing approach into pylint.
+
+TODO: support multiple symbols in one annotation
+TODO: add target module path to output
+"""
+
+import tokenize
+
+from pylint.checkers import BaseTokenChecker
+from pylint.interfaces import ITokenChecker
+
+
+def register(linter):
+    linter.register_checker(ExpectedMessageReporter(linter))
+
+
+PREFIX = '# expect='
+
+
+class ExpectedMessageReporter(BaseTokenChecker):
+    __implements__ = ITokenChecker
+
+    name = 'expect-message'
+    msgs = {'W5682': ('', 'unused-w5682', '')}
+
+    def process_tokens(self, tokens):
+        for (tok_type, token, (start_row, _), _, _) in tokens:
+            if tok_type == tokenize.COMMENT:
+                if token.startswith(PREFIX):
+                    symbol = token[len(PREFIX):]
+                    assert ',' not in symbol, 'multiple symbols not supported'
+                    print('%s:%s' % (start_row, symbol))

--- a/trio/tests/test_pylint_missing_await.py
+++ b/trio/tests/test_pylint_missing_await.py
@@ -1,0 +1,65 @@
+"""
+Test the pylint-missing-await custom checker.
+
+This file is run through pylint separately.  The error metadata is collected
+and compared to "# expect=..." annotations.
+
+Except for test_pylint(), code in this module is not executed, only linted.
+"""
+import sys
+import warnings
+
+import pytest
+from pylint.lint import Run
+
+
+async def missing_await():
+    async def async_func():
+        pass
+
+    async_func()  # expect=missing-await
+
+    def wrapped():
+        return async_func
+
+    wrapped()()  # expect=missing-await
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 5, 6), reason="strange TypeError from pylint"
+)
+def test_pylint(capsys):
+    # Run pylint on this file with the pylint-expect-message plugin enabled
+    # and compare actual vs. expected pylint messages.
+    #
+    # pylint output synopsis:
+    #    expected_line1:expected_symbol1
+    #    expected_line2:expected_symbol2
+    #    ...
+    #    *** delimiter message
+    #    actual_line1:actual_symbol1
+    #    actual_line2:actual_symbol2
+    #    ...
+    with warnings.catch_warnings():
+        # https://github.com/PyCQA/pylint/issues/2866
+        # https://github.com/PyCQA/pylint/issues/2867
+        warnings.simplefilter("ignore", category=DeprecationWarning)
+        Run(
+            [
+                '--load-plugins=trio.testing.pylint-missing-await,trio.tests.pylint-expect-message',
+                '--disable=all',
+                '--enable=expect-message,missing-await,not-context-manager,not-an-iterable',
+                '--score=n', '--msg-template={line}:{symbol}', __file__
+            ],
+            do_exit=False
+        )
+    expected = set()  # set of (line_number, symbol)
+    actual = set()
+    target = expected
+    for line in capsys.readouterr().out.splitlines():
+        if line.startswith('*'):
+            # end of expected section
+            target = actual
+            continue
+        target.add(tuple(line.split(':')))
+    assert actual == expected, 'pylint message check (ACTUAL == EXPECTED) failed'


### PR DESCRIPTION
pylint support for #671 

TODO:
  * [x] fix async generator false positive
  * [x] tests
  * [ ] settle error name(s) and code numbers

This runs fine on trio codebase and my own codebase.  I haven't looked hard for false negatives.

Run on trio codebase:
```
PYTHONPATH=. python3 -m pylint --load-plugins=trio.testing.pylint-missing-await --disable=all --enable=missing-await trio/
```
