### PR TITLE
Rationalize generic exception names

### DIFF
--- a/docs/source/history.rst
+++ b/docs/source/history.rst
@@ -471,7 +471,7 @@ Other changes
 
 * New class :class:`StrictFIFOLock`
 
-* New exception :exc:`ResourceBusyError`
+* New exception ``ResourceBusyError``
 
 * The :class:`trio.hazmat.ParkingLot` class (which is used to
   implement many of Trio's synchronization primitives) was rewritten

--- a/docs/source/reference-core.rst
+++ b/docs/source/reference-core.rst
@@ -1544,9 +1544,11 @@ Exceptions and warnings
 
 .. autoexception:: WouldBlock
 
-.. autoexception:: ResourceBusyError
+.. autoexception:: BusyResourceError
 
 .. autoexception:: ClosedResourceError
+
+.. autoexception:: BrokenResourceError
 
 .. autoexception:: RunFinishedError
 

--- a/docs/source/reference-hazmat.rst
+++ b/docs/source/reference-hazmat.rst
@@ -134,7 +134,7 @@ All environments provide the following functions:
    different, and this works on ``SOCKET`` handles or Python socket
    objects.
 
-   :raises trio.ResourceBusyError:
+   :raises trio.BusyResourceError:
        if another task is already waiting for the given socket to
        become readable.
 
@@ -148,7 +148,7 @@ All environments provide the following functions:
    different, and this works on ``SOCKET`` handles or Python socket
    objects.
 
-   :raises trio.ResourceBusyError:
+   :raises trio.BusyResourceError:
        if another task is already waiting for the given socket to
        become writable.
    :raises trio.ClosedResourceError:
@@ -192,7 +192,7 @@ Unix-like systems provide the following functions:
 
    :arg fd:
        integer file descriptor, or else an object with a ``fileno()`` method
-   :raises trio.ResourceBusyError:
+   :raises trio.BusyResourceError:
        if another task is already waiting for the given fd to
        become readable.
    :raises trio.ClosedResourceError:
@@ -213,7 +213,7 @@ Unix-like systems provide the following functions:
 
    :arg fd:
        integer file descriptor, or else an object with a ``fileno()`` method
-   :raises trio.ResourceBusyError:
+   :raises trio.BusyResourceError:
        if another task is already waiting for the given fd to
        become writable.
    :raises trio.ClosedResourceError:

--- a/docs/source/reference-io.rst
+++ b/docs/source/reference-io.rst
@@ -144,10 +144,6 @@ Abstract base classes
    :members:
    :show-inheritance:
 
-.. currentmodule:: trio
-
-.. autoexception:: BrokenStreamError
-
 .. currentmodule:: trio.abc
 
 .. autoclass:: trio.abc.Listener

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -987,7 +987,7 @@ to isolate that to making just this one task crash, without taking
 down the whole program. For example, if the client closes the
 connection at the wrong moment then it's possible this code will end
 up calling ``send_all`` on a closed connection and get an
-:exc:`BrokenStreamError`; that's unfortunate, and in a more serious
+:exc:`BrokenResourceError`; that's unfortunate, and in a more serious
 program we might want to handle it more explicitly, but it doesn't
 indicate a problem for any *other* connections. On the other hand, if
 the exception is something like a :exc:`KeyboardInterrupt`, we *do*

--- a/newsfragments/620.removal.rst
+++ b/newsfragments/620.removal.rst
@@ -1,3 +1,3 @@
-:exc:`ResourceBusyError` is now a deprecated alias for the new
-:exc:`BusyResourceError`, and :exc:`BrokenStreamError` is a deprecated
+``ResourceBusyError`` is now a deprecated alias for the new
+:exc:`BusyResourceError`, and ``BrokenStreamError`` is a deprecated
 alias for the new :exc:`BrokenResourceError`.

--- a/newsfragments/620.removal.rst
+++ b/newsfragments/620.removal.rst
@@ -1,0 +1,3 @@
+:exc:`ResourceBusyError` is now a deprecated alias for the new
+:exc:`BusyResourceError`, and :exc:`BrokenStreamError` is a deprecated
+alias for the new :exc:`BrokenResourceError`.

--- a/trio/__init__.py
+++ b/trio/__init__.py
@@ -17,9 +17,9 @@ from ._version import __version__
 
 from ._core import (
     TrioInternalError, RunFinishedError, WouldBlock, Cancelled,
-    ResourceBusyError, ClosedResourceError, MultiError, run, open_nursery,
+    BusyResourceError, ClosedResourceError, MultiError, run, open_nursery,
     open_cancel_scope, current_effective_deadline, TASK_STATUS_IGNORED,
-    current_time
+    current_time, BrokenResourceError
 )
 
 from ._timeouts import (
@@ -36,9 +36,7 @@ from ._threads import (
     BlockingTrioPortal
 )
 
-from ._highlevel_generic import (
-    aclose_forcefully, BrokenStreamError, StapledStream
-)
+from ._highlevel_generic import aclose_forcefully, StapledStream
 
 from ._signals import catch_signals, open_signal_receiver
 
@@ -86,6 +84,17 @@ __deprecated_attributes__ = {
             "0.5.0",
             issue=36,
             instead=ClosedResourceError
+        ),
+    "BrokenStreamError":
+        _deprecate.DeprecatedAttribute(
+            BrokenResourceError,
+            "0.8.0",
+            issue=620,
+            instead=BrokenResourceError
+        ),
+    "ResourceBusyError":
+        _deprecate.DeprecatedAttribute(
+            BusyResourceError, "0.8.0", issue=620, instead=BusyResourceError
         ),
 }
 

--- a/trio/_abc.py
+++ b/trio/_abc.py
@@ -296,10 +296,10 @@ class SendStream(AsyncResource):
           data (bytes, bytearray, or memoryview): The data to send.
 
         Raises:
-          trio.ResourceBusyError: if another task is already executing a
+          trio.BusyResourceError: if another task is already executing a
               :meth:`send_all`, :meth:`wait_send_all_might_not_block`, or
               :meth:`HalfCloseableStream.send_eof` on this stream.
-          trio.BrokenStreamError: if something has gone wrong, and the stream
+          trio.BrokenResourceError: if something has gone wrong, and the stream
               is broken.
           trio.ClosedResourceError: if you previously closed this stream
               object, or if another task closes this stream object while
@@ -329,10 +329,10 @@ class SendStream(AsyncResource):
         return. When implementing it, err on the side of returning early.
 
         Raises:
-          trio.ResourceBusyError: if another task is already executing a
+          trio.BusyResourceError: if another task is already executing a
               :meth:`send_all`, :meth:`wait_send_all_might_not_block`, or
               :meth:`HalfCloseableStream.send_eof` on this stream.
-          trio.BrokenStreamError: if something has gone wrong, and the stream
+          trio.BrokenResourceError: if something has gone wrong, and the stream
               is broken.
           trio.ClosedResourceError: if you previously closed this stream
               object, or if another task closes this stream object while
@@ -406,9 +406,9 @@ class ReceiveStream(AsyncResource):
           bytes or bytearray: The data received.
 
         Raises:
-          trio.ResourceBusyError: if two tasks attempt to call
+          trio.BusyResourceError: if two tasks attempt to call
               :meth:`receive_some` on the same stream at the same time.
-          trio.BrokenStreamError: if something has gone wrong, and the stream
+          trio.BrokenResourceError: if something has gone wrong, and the stream
               is broken.
           trio.ClosedResourceError: if you previously closed this stream
               object, or if another task closes this stream object while
@@ -474,11 +474,11 @@ class HalfCloseableStream(Stream):
         succeed.
 
         Raises:
-          trio.ResourceBusyError: if another task is already executing a
+          trio.BusyResourceError: if another task is already executing a
               :meth:`~SendStream.send_all`,
               :meth:`~SendStream.wait_send_all_might_not_block`, or
               :meth:`send_eof` on this stream.
-          trio.BrokenStreamError: if something has gone wrong, and the stream
+          trio.BrokenResourceError: if something has gone wrong, and the stream
               is broken.
           trio.ClosedResourceError: if you previously closed this stream
               object, or if another task closes this stream object while
@@ -504,7 +504,7 @@ class Listener(AsyncResource):
           SOCK_SEQPACKET sockets or similar.
 
         Raises:
-          trio.ResourceBusyError: if two tasks attempt to call
+          trio.BusyResourceError: if two tasks attempt to call
               :meth:`accept` on the same listener at the same time.
           trio.ClosedResourceError: if you previously closed this listener
               object, or if another task closes this listener object while

--- a/trio/_core/__init__.py
+++ b/trio/_core/__init__.py
@@ -16,7 +16,7 @@ def _public(fn):
 
 from ._exceptions import (
     TrioInternalError, RunFinishedError, WouldBlock, Cancelled,
-    ResourceBusyError, ClosedResourceError
+    BusyResourceError, ClosedResourceError, BrokenResourceError
 )
 
 from ._multierror import MultiError

--- a/trio/_core/_exceptions.py
+++ b/trio/_core/_exceptions.py
@@ -1,15 +1,5 @@
 import attr
 
-# Re-exported
-__all__ = [
-    "TrioInternalError",
-    "RunFinishedError",
-    "WouldBlock",
-    "Cancelled",
-    "ResourceBusyError",
-    "ClosedResourceError",
-]
-
 
 class TrioInternalError(Exception):
     """Raised by :func:`run` if we encounter a bug in trio, or (possibly) a
@@ -95,12 +85,12 @@ class Cancelled(BaseException):
         return cls(_marker=cls.__marker)
 
 
-class ResourceBusyError(Exception):
+class BusyResourceError(Exception):
     """Raised when a task attempts to use a resource that some other task is
     already using, and this would lead to bugs and nonsense.
 
     For example, if two tasks try to send data through the same socket at the
-    same time, trio will raise :class:`ResourceBusyError` instead of letting
+    same time, trio will raise :class:`BusyResourceError` instead of letting
     the data get scrambled.
 
     """
@@ -114,6 +104,22 @@ class ClosedResourceError(Exception):
     by exiting a context manager. If a problem arises elsewhere – for example,
     because of a network failure, or because a remote peer closed their end of
     a connection – then that should be indicated by a different exception
-    class, like :exc:`BrokenStreamError` or an :exc:`OSError` subclass.
+    class, like :exc:`BrokenResourceError` or an :exc:`OSError` subclass.
+
+    """
+
+
+class BrokenResourceError(Exception):
+    """Raised when an attempt to use a resource fails due to external
+    circumstances.
+
+    For example, you might get this if you try to send data on a stream where
+    the remote side has already closed the connection.
+
+    You *don't* get this error if *you* closed the resource – in that case you
+    get :class:`ClosedResourceError`.
+
+    This exception's ``__cause__`` attribute will often contain more
+    information about the underlying error.
 
     """

--- a/trio/_core/_io_epoll.py
+++ b/trio/_core/_io_epoll.py
@@ -104,7 +104,7 @@ class EpollIOManager:
         waiters = self._registered[fd]
         if getattr(waiters, attr_name) is not None:
             await _core.checkpoint()
-            raise _core.ResourceBusyError(
+            raise _core.BusyResourceError(
                 "another task is already reading / writing this fd"
             )
         setattr(waiters, attr_name, _core.current_task())

--- a/trio/_core/_io_kqueue.py
+++ b/trio/_core/_io_kqueue.py
@@ -82,7 +82,7 @@ class KqueueIOManager:
     def monitor_kevent(self, ident, filter):
         key = (ident, filter)
         if key in self._registered:
-            raise _core.ResourceBusyError(
+            raise _core.BusyResourceError(
                 "attempt to register multiple listeners for same "
                 "ident/filter pair"
             )
@@ -98,7 +98,7 @@ class KqueueIOManager:
         key = (ident, filter)
         if key in self._registered:
             await _core.checkpoint()
-            raise _core.ResourceBusyError(
+            raise _core.BusyResourceError(
                 "attempt to register multiple listeners for same "
                 "ident/filter pair"
             )

--- a/trio/_core/_io_windows.py
+++ b/trio/_core/_io_windows.py
@@ -299,7 +299,7 @@ class WindowsIOManager:
         if isinstance(lpOverlapped, int):
             lpOverlapped = ffi.cast("LPOVERLAPPED", lpOverlapped)
         if lpOverlapped in self._overlapped_waiters:
-            raise _core.ResourceBusyError(
+            raise _core.BusyResourceError(
                 "another task is already waiting on that lpOverlapped"
             )
         task = _core.current_task()
@@ -340,7 +340,7 @@ class WindowsIOManager:
             sock = sock.fileno()
         if sock in self._socket_waiters[which]:
             await _core.checkpoint()
-            raise _core.ResourceBusyError(
+            raise _core.BusyResourceError(
                 "another task is already waiting to {} this socket"
                 .format(which)
             )

--- a/trio/_core/tests/test_io.py
+++ b/trio/_core/tests/test_io.py
@@ -157,7 +157,7 @@ async def test_double_read(socketpair, wait_readable):
         nursery.start_soon(wait_readable, a)
         await wait_all_tasks_blocked()
         with assert_checkpoints():
-            with pytest.raises(_core.ResourceBusyError):
+            with pytest.raises(_core.BusyResourceError):
                 await wait_readable(a)
         nursery.cancel_scope.cancel()
 
@@ -172,7 +172,7 @@ async def test_double_write(socketpair, wait_writable):
         nursery.start_soon(wait_writable, a)
         await wait_all_tasks_blocked()
         with assert_checkpoints():
-            with pytest.raises(_core.ResourceBusyError):
+            with pytest.raises(_core.BusyResourceError):
                 await wait_writable(a)
         nursery.cancel_scope.cancel()
 

--- a/trio/_highlevel_generic.py
+++ b/trio/_highlevel_generic.py
@@ -3,12 +3,6 @@ import attr
 from . import _core
 from .abc import HalfCloseableStream
 
-__all__ = [
-    "aclose_forcefully",
-    "BrokenStreamError",
-    "StapledStream",
-]
-
 
 async def aclose_forcefully(resource):
     """Close an async resource or async generator immediately, without
@@ -38,23 +32,6 @@ async def aclose_forcefully(resource):
     with _core.open_cancel_scope() as cs:
         cs.cancel()
         await resource.aclose()
-
-
-class BrokenStreamError(Exception):
-    """Raised when an attempt to use a stream fails due to external
-    circumstances.
-
-    For example, you might get this if you try to send data on a stream where
-    the remote side has already closed the connection.
-
-    You *don't* get this error if *you* closed the stream – in that case you
-    get :class:`ClosedResourceError`.
-
-    This exception's ``__cause__`` attribute will often contain more
-    information about the underlying error.
-
-    """
-    pass
 
 
 @attr.s(cmp=False, hash=False)

--- a/trio/_highlevel_socket.py
+++ b/trio/_highlevel_socket.py
@@ -7,7 +7,6 @@ from . import _core
 from . import socket as tsocket
 from ._util import ConflictDetector
 from .abc import HalfCloseableStream, Listener
-from ._highlevel_generic import BrokenStreamError
 
 __all__ = ["SocketStream", "SocketListener"]
 
@@ -29,7 +28,7 @@ def _translate_socket_errors_to_stream_errors():
                 "this socket was already closed"
             ) from None
         else:
-            raise BrokenStreamError(
+            raise _core.BrokenResourceError(
                 "socket connection broken: {}".format(exc)
             ) from exc
 

--- a/trio/_subprocess/unix_pipes.py
+++ b/trio/_subprocess/unix_pipes.py
@@ -2,7 +2,7 @@ import fcntl
 import os
 from typing import Tuple
 
-from .. import _core, BrokenStreamError
+from .. import _core, BrokenResourceError
 from .._abc import SendStream, ReceiveStream
 
 __all__ = ["PipeSendStream", "PipeReceiveStream", "make_pipe"]
@@ -65,7 +65,7 @@ class PipeSendStream(_PipeMixin, SendStream):
                         total_sent += os.write(self._pipe, remaining)
                     except BrokenPipeError as e:
                         await _core.checkpoint()
-                        raise BrokenStreamError from e
+                        raise BrokenResourceError from e
                     except BlockingIOError:
                         await self.wait_send_all_might_not_block()
 
@@ -82,7 +82,7 @@ class PipeSendStream(_PipeMixin, SendStream):
             # also doesn't checkpoint so we have to do that
             # ourselves here too
             await _core.checkpoint()
-            raise BrokenStreamError from e
+            raise BrokenResourceError from e
 
 
 class PipeReceiveStream(_PipeMixin, ReceiveStream):

--- a/trio/_util.py
+++ b/trio/_util.py
@@ -112,7 +112,7 @@ class _ConflictDetectorSync:
 
     def __enter__(self):
         if self._held:
-            raise _core.ResourceBusyError(self._msg)
+            raise _core.BusyResourceError(self._msg)
         else:
             self._held = True
 

--- a/trio/testing/_memory_streams.py
+++ b/trio/testing/_memory_streams.py
@@ -1,7 +1,7 @@
 import operator
 
 from .. import _core
-from .._highlevel_generic import BrokenStreamError, StapledStream
+from .._highlevel_generic import StapledStream
 from .. import _util
 from ..abc import SendStream, ReceiveStream
 
@@ -309,7 +309,7 @@ def memory_stream_pump(
         else:
             memory_receive_stream.put_data(data)
     except _core.ClosedResourceError:
-        raise BrokenStreamError("MemoryReceiveStream was closed")
+        raise _core.BrokenResourceError("MemoryReceiveStream was closed")
     return True
 
 
@@ -484,7 +484,7 @@ class _LockstepByteQueue:
             if self._sender_closed:
                 raise _core.ClosedResourceError
             if self._receiver_closed:
-                raise BrokenStreamError
+                raise _core.BrokenResourceError
             assert not self._data
             self._data += data
             self._something_happened()
@@ -492,7 +492,7 @@ class _LockstepByteQueue:
             if self._sender_closed:
                 raise _core.ClosedResourceError
             if self._data and self._receiver_closed:
-                raise BrokenStreamError
+                raise _core.BrokenResourceError
 
     async def wait_send_all_might_not_block(self):
         async with self._send_conflict_detector:

--- a/trio/tests/test_highlevel_ssl_helpers.py
+++ b/trio/tests/test_highlevel_ssl_helpers.py
@@ -22,7 +22,7 @@ async def echo_handler(stream):
                 if not data:
                     break
                 await stream.send_all(data)
-        except trio.BrokenStreamError:
+        except trio.BrokenResourceError:
             pass
 
 
@@ -58,7 +58,7 @@ async def test_open_ssl_over_tcp_stream_and_everything_else():
         # We don't have the right trust set up
         # (checks that ssl_context=None is doing some validation)
         stream = await open_ssl_over_tcp_stream("trio-test-1.example.org", 80)
-        with pytest.raises(trio.BrokenStreamError):
+        with pytest.raises(trio.BrokenResourceError):
             await stream.do_handshake()
 
         # We have the trust but not the hostname
@@ -68,7 +68,7 @@ async def test_open_ssl_over_tcp_stream_and_everything_else():
             80,
             ssl_context=CLIENT_CTX,
         )
-        with pytest.raises(trio.BrokenStreamError):
+        with pytest.raises(trio.BrokenResourceError):
             await stream.do_handshake()
 
         # This one should work!

--- a/trio/tests/test_signals.py
+++ b/trio/tests/test_signals.py
@@ -82,7 +82,7 @@ async def test_catch_signals_wrong_thread():
 
 
 async def test_open_signal_receiver_conflict():
-    with pytest.raises(trio.ResourceBusyError):
+    with pytest.raises(trio.BusyResourceError):
         with open_signal_receiver(signal.SIGILL) as receiver:
             async with trio.open_nursery() as nursery:
                 nursery.start_soon(receiver.__anext__)

--- a/trio/tests/test_testing.py
+++ b/trio/tests/test_testing.py
@@ -469,8 +469,8 @@ async def test__UnboundeByteQueue():
         nursery.start_soon(getter, b"xyz")
         nursery.start_soon(putter, b"xyz")
 
-    # Two gets at the same time -> ResourceBusyError
-    with pytest.raises(_core.ResourceBusyError):
+    # Two gets at the same time -> BusyResourceError
+    with pytest.raises(_core.BusyResourceError):
         async with _core.open_nursery() as nursery:
             nursery.start_soon(getter, b"asdf")
             nursery.start_soon(getter, b"asdf")
@@ -524,7 +524,7 @@ async def test_MemorySendStream():
     with assert_checkpoints():
         assert await mss.get_data() == b"456"
 
-    # Call send_all twice at once; one should get ResourceBusyError and one
+    # Call send_all twice at once; one should get BusyResourceError and one
     # should succeed. But we can't let the error propagate, because it might
     # cause the other to be cancelled before it can finish doing its thing,
     # and we don't know which one will get the error.
@@ -534,7 +534,7 @@ async def test_MemorySendStream():
         nonlocal resource_busy_count
         try:
             await do_send_all(b"xxx")
-        except _core.ResourceBusyError:
+        except _core.BusyResourceError:
             resource_busy_count += 1
 
     async with _core.open_nursery() as nursery:
@@ -606,7 +606,7 @@ async def test_MemoryReceiveStream():
     with pytest.raises(TypeError):
         await do_receive_some(None)
 
-    with pytest.raises(_core.ResourceBusyError):
+    with pytest.raises(_core.BusyResourceError):
         async with _core.open_nursery() as nursery:
             nursery.start_soon(do_receive_some, 10)
             nursery.start_soon(do_receive_some, 10)

--- a/trio/tests/test_util.py
+++ b/trio/tests/test_util.py
@@ -40,7 +40,7 @@ async def test_ConflictDetector():
             async with ul2:
                 print("ok")
 
-    with pytest.raises(_core.ResourceBusyError) as excinfo:
+    with pytest.raises(_core.BusyResourceError) as excinfo:
         async with ul1:
             with assert_checkpoints():
                 async with ul1:
@@ -51,14 +51,14 @@ async def test_ConflictDetector():
         async with ul1:
             await wait_all_tasks_blocked()
 
-    with pytest.raises(_core.ResourceBusyError) as excinfo:
+    with pytest.raises(_core.BusyResourceError) as excinfo:
         async with _core.open_nursery() as nursery:
             nursery.start_soon(wait_with_ul1)
             nursery.start_soon(wait_with_ul1)
     assert "ul1" in str(excinfo.value)
 
     # mixing sync and async entry
-    with pytest.raises(_core.ResourceBusyError) as excinfo:
+    with pytest.raises(_core.BusyResourceError) as excinfo:
         with ul1.sync:
             with assert_checkpoints():
                 async with ul1:


### PR DESCRIPTION
- Rename BrokenStreamError to BrokenResourceError
- Rename ResourceBusyError to BusyResourceError

Fixes gh-620 (and see there for the rationale).