### PR TITLE
Correct example in reference-io.rst

### DIFF
--- a/docs/source/reference-io.rst
+++ b/docs/source/reference-io.rst
@@ -53,7 +53,7 @@ create complex transport configurations. Here's some examples:
      # Set up SSL connection to proxy:
      s1 = SSLStream(s0, proxy_ssl_context, server_hostname="proxy")
      # Request a connection to the website
-     await s1.send_all(b"CONNECT website:443 / HTTP/1.0\r\n")
+     await s1.send_all(b"CONNECT website:443 / HTTP/1.0\r\n\r\n")
      await check_CONNECT_response(s1)
 
      # Set up SSL connection to the real website. Notice that s1 is
@@ -61,7 +61,7 @@ create complex transport configurations. Here's some examples:
      # SSLStream object around it.
      s2 = SSLStream(s1, website_ssl_context, server_hostname="website")
      # Make our request
-     await s2.send_all("GET /index.html HTTP/1.0\r\n")
+     await s2.send_all(b"GET /index.html HTTP/1.0\r\n\r\n")
      ...
 
 * The :mod:`trio.testing` module provides a set of :ref:`flexible


### PR DESCRIPTION
On top of that, I'm not sure about the single `\r\n` sequence finishing the http requests
Considering the following code:
```python
import trio
import sys

async def test():
    ssl_context = trio.ssl.create_default_context()
    raw_stream = await trio.open_tcp_stream('example.com', 443)
    print('Opened:', raw_stream)
    cooked_stream = trio.ssl.SSLStream(raw_stream, ssl_context, server_hostname='example.com')
    await cooked_stream.send_all(b"GET /index.html HTTP/1.0\r\n")
    if '--double-lf' in sys.argv:
        await cooked_stream.send_all(b"\r\n")
    print('waiting answer...')
    ret = await cooked_stream.receive_some(100)
    print(ret)

trio.run(test)
```

I'm getting a timeout if I'm not using a double `\r\n`
```shell
$ python test_stapledSSL.py 
Opened: <trio.SocketStream object at 0x7fc31cfa10f0>
waiting answer...
b'HTTP/1.0 408 Request Timeout\r\nContent-Type: text/html\r\nContent-Length: 431\r\nConnection: close\r\nDate:'
$ python test_stapledSSL.py  --double-lf
Opened: <trio.SocketStream object at 0x7f72a15620b8>
waiting answer...
b'HTTP/1.0 200 OK\r\nAccept-Ranges: bytes\r\nContent-Type: text/html\r\nDate: Tue, 02 Oct 2018 11:04:41 GMT\r'
```

If I read the [HTTP1/1 standard](https://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html) right, it seems a single CRLF is fine as long as there is no headers in the request (which is the case here). On the other hand, providing an example which timeout on `https://example.com` is not really cool :'(