### PR TITLE
Increase sleep time to account for clock differences

### DIFF
--- a/trio/_core/tests/test_ki.py
+++ b/trio/_core/tests/test_ki.py
@@ -538,7 +538,7 @@ def test_ki_wakes_us_up():
         # the IO manager blocking primitive. There really is no way to
         # deterministically interlock with that, so we have to use sleep and
         # hope it's long enough.
-        time.sleep(1)
+        time.sleep(1.1)
         with lock:
             print("thread doing ki_self()")
             ki_self()


### PR DESCRIPTION
Fix for #624 

:wave: So I ran trio's tests using the projects `test-requirements.txt` and all seems well there. I am developing on OSX, so I didn't actually get to run the tests in a windows environment. 

As a side note I got this warning running pytest:
```
(venv) [12:11 PM] ~/code/trio-learn/trio $ pytest                                                                                                                                    
================================================================================ test session starts ================================================================================
platform darwin -- Python 3.7.0, pytest-3.8.2, py-1.6.0, pluggy-0.7.1                                                                                                                
rootdir: /Users/wizdre/code/trio-learn/trio, inifile:                                                                                                                                
plugins: faulthandler-1.5.0, cov-2.6.0                                                                                                                                               
collected 470 items                                                                                                                                                                  
                                                                                                                                                                                     
trio/_core/tests/test_epoll.py s                                                                                                                                              [  0%] 
trio/_core/tests/test_io.py ........................                                                                                                                          [  5%] 
trio/_core/tests/test_ki.py ..........                                                                                                                                        [  7%] 
trio/_core/tests/test_local.py ....                                                                                                                                           [  8%] 
trio/_core/tests/test_multierror.py ............                                                                                                                              [ 10%] 
trio/_core/tests/test_parking_lot.py ....                                                                                                                                     [ 11%] 
trio/_core/tests/test_result.py ......                                                                                                                                        [ 12%] 
trio/_core/tests/test_run.py ...................................................................................                                                              [ 30%] 
trio/_core/tests/test_tutil.py .                                                                                                                                              [ 30%] 
trio/_core/tests/test_unbounded_queue.py .....                                                                                                                                [ 31%] 
trio/_core/tests/test_windows.py s                                                                                                                                            [ 32%] 
trio/tests/test_abc.py .                                                                                                                                                      [ 32%] 
trio/tests/test_channel.py ............                                                                                                                                       [ 34%] 
trio/tests/test_deprecate.py ...........                                                                                                                                      [ 37%]
trio/tests/test_exports.py ...                                                                                                                                                [ 37%]
trio/tests/test_file_io.py ................                                                                                                                                   [ 41%]
trio/tests/test_highlevel_generic.py ..                                                                                                                                       [ 41%]
trio/tests/test_highlevel_open_tcp_listeners.py ........                                                                                                                      [ 43%]
trio/tests/test_highlevel_open_tcp_stream.py ...................                                                                                                              [ 47%]
trio/tests/test_highlevel_open_unix_stream.py ..                                                                                                                              [ 47%]
trio/tests/test_highlevel_serve_listeners.py ....                                                                                                                             [ 48%]
trio/tests/test_highlevel_socket.py ......                                                                                                                                    [ 50%]
trio/tests/test_highlevel_ssl_helpers.py ..                                                                                                                                   [ 50%]
trio/tests/test_path.py .............................                                                                                                                         [ 56%]
trio/tests/test_signals.py ........                                                                                                                                           [ 58%]
trio/tests/test_socket.py .......s...................                                                                                                                         [ 64%]
trio/tests/test_ssl.py ............................                                                                                                                           [ 70%]
trio/tests/test_sync.py ...................................................                                                                                                   [ 80%]
trio/tests/test_testing.py ........................                                                                                                                           [ 85%]
trio/tests/test_threads.py .......................                                                                                                                            [ 90%]
trio/tests/test_timeouts.py ...                                                                                                                                               [ 91%]
trio/tests/test_util.py ..........................                                                                                                                            [ 97%]
trio/tests/test_wait_for_object.py ssss                                                                                                                                       [ 97%]
trio/tests/subprocess/test_unix_pipes.py ........                                                                                                                             [ 99%]
trio/tests/subprocess/test_waitpid_linux.py ss                                                                                                                                [100%]

================================================================================= warnings summary =================================================================================$
/Users/wizdre/code/trio-learn/trio/trio/_abc.py:701: DeprecationWarning: invalid escape sequence \s                                                                                 
  """
```
Similar warning elsewhere in the repo: #681 