### PR TITLE
ci: remove unneeded pyup references

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,5 +43,4 @@ script:
 
 branches:
   except:
-    - /^pyup-.*/
     - /^dependabot/.*/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,5 +31,4 @@ test_script:
 
 branches:
   except:
-    - /pyup-.*/
     - /dependabot/.*/


### PR DESCRIPTION
We only use dependabot. Or at least I think so? I don't know how to check that. So this pull request is my way of asking the question.