### PR TITLE
Closes #726 - Documentation should have previous and next button on t…

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -157,6 +157,7 @@ html_theme_options = {
     # versions/settings...
     "navigation_depth": 4,
     "logo_only": True,
+    'prev_next_buttons_location': 'both'
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION
…op as well as bottom.

Updated configuration for sphinx rtd theme, next/previous navigation will be available on top and bottom.