### PR TITLE
Raise warning in case a SSLStream method returns none because no handshake was established

### DIFF
--- a/trio/__init__.py
+++ b/trio/__init__.py
@@ -19,7 +19,7 @@ from ._core import (
     TrioInternalError, RunFinishedError, WouldBlock, Cancelled,
     BusyResourceError, ClosedResourceError, MultiError, run, open_nursery,
     open_cancel_scope, current_effective_deadline, TASK_STATUS_IGNORED,
-    current_time, BrokenResourceError, EndOfChannel
+    current_time, BrokenResourceError, EndOfChannel, NoHandshakeError
 )
 
 from ._timeouts import (

--- a/trio/_core/__init__.py
+++ b/trio/_core/__init__.py
@@ -15,8 +15,8 @@ def _public(fn):
 
 
 from ._exceptions import (
-    TrioInternalError, RunFinishedError, WouldBlock, Cancelled,
-    BusyResourceError, ClosedResourceError, BrokenResourceError, EndOfChannel
+    TrioInternalError, RunFinishedError, WouldBlock, Cancelled, BusyResourceError,
+    ClosedResourceError, BrokenResourceError, EndOfChannel, NoHandshakeError
 )
 
 from ._multierror import MultiError

--- a/trio/_core/_exceptions.py
+++ b/trio/_core/_exceptions.py
@@ -125,6 +125,33 @@ class BrokenResourceError(Exception):
     """
 
 
+class NoHandshakeError(Exception):
+    """Raised when a method like ``select_alpn_protocol`` is called
+    before the handshake is established.
+
+    Some methods defined in the :class:`ssl.SSLSocket` from the stdlib
+    return ``None`` if the handshake hasn't happened yet.
+
+    These are:
+
+    - ``get_channel_binding``: https://docs.python.org/3/library/ssl.html#ssl.SSLSocket.get_channel_binding
+    - ``selected_alpn_protocol``: https://docs.python.org/3/library/ssl.html#ssl.SSLSocket.selected_alpn_protocol
+    - ``selected_npn_protocol``: https://docs.python.org/3/library/ssl.html#ssl.SSLSocket.selected_npn_protocol
+
+    Note that these methods might also return ``None```in other cases.
+    `
+    In case of calling `selected_alpn_protocol`` and ``selected_npn_protocol``
+    other cases of returning ``None`` are:
+
+    - If the other party does not support ALPN/NPN.
+    - If ``SSLContext.set_alpn_protocols()`` or ``SSLContext.set_npn_protocols()`` was not called.
+
+    and in the case of ``get_channel_binding``:
+
+    - If not connected.
+    """
+
+
 class EndOfChannel(Exception):
     """Raised when trying to receive from a :class:`trio.abc.ReceiveChannel`
     that has no more data to receive.

--- a/trio/_ssl.py
+++ b/trio/_ssl.py
@@ -402,13 +402,9 @@ class SSLStream(Stream):
 
     def __getattr__(self, name):
         if name in self._forwarded:
-            if name in self._after_handshake:
-                if not self._handshook.done:
-                    # TODO descrpitive error
-                    raise _core.NoHandshakeError('name', name, "state", self._state,\
-                    "handshake started", self._handshook.started, "handshake done", self._handshook.done)
-                    # if not self._handshook.done():
-                    #     raise _core.NoHandshakeError
+            if name in self._after_handshake and not self._handshook.done:
+                raise _core.NoHandshakeError
+
             return getattr(self._ssl_object, name)
         else:
             raise AttributeError(name)


### PR DESCRIPTION
References the issue #735 
The problem could be extended to the following methods in SSLStream which return none in case the handshake is not established:

- `get_channel_binding`: https://docs.python.org/3/library/ssl.html#ssl.SSLSocket.get_channel_binding
- `selected_alpn_protocol`: https://docs.python.org/3/library/ssl.html#ssl.SSLSocket.selected_alpn_protocol
- `selected_npn_protocol`: https://docs.python.org/3/library/ssl.html#ssl.SSLSocket.selected_npn_protocol

These methods raise now a `NoHandshakeError` if the handshake wasn't established. Note that they still return `None` in the cases when:

- If the other party does not support ALPN/NPN.
- If `SSLContext.set_alpn_protocols()` or `SSLContext.set_npn_protocols()` was not called.

and in the case of `get_channel_binding` in the case when there is no connection.