### PR TITLE
Removes call to getpeername in SocketStream

### DIFF
--- a/newsfragments/609.bugfix.rst
+++ b/newsfragments/609.bugfix.rst
@@ -1,5 +1,2 @@
-This removes a check in the ``SocketStream`` constructor which was 
-making a call to ``getpeername`` method off of the trio socket object.
-This check was throwing an error in OSX due to an 
-`unreliable API <https://github.com/python-trio/trio/issues/609#issuecomment-414023026>`_
-in that platform. 
+Fixed a race condition on macOS, where Trio's TCP listener would crash if an
+incoming TCP connection was closed before the listener had a chance to accept it.

--- a/newsfragments/609.bugfix.rst
+++ b/newsfragments/609.bugfix.rst
@@ -1,0 +1,5 @@
+This removes a check in the ``SocketStream`` constructor which was 
+making a call to ``getpeername`` method off of the trio socket object.
+This check was throwing an error in OSX due to an 
+`unreliable API <https://github.com/python-trio/trio/issues/609#issuecomment-414023026>`_
+in that platform. 

--- a/trio/_highlevel_socket.py
+++ b/trio/_highlevel_socket.py
@@ -62,11 +62,6 @@ class SocketStream(HalfCloseableStream):
             raise TypeError("SocketStream requires trio socket object")
         if socket.type != tsocket.SOCK_STREAM:
             raise ValueError("SocketStream requires a SOCK_STREAM socket")
-        try:
-            socket.getpeername()
-        except OSError:
-            err = ValueError("SocketStream requires a connected socket")
-            raise err from None
 
         self.socket = socket
         self._send_conflict_detector = ConflictDetector(

--- a/trio/tests/test_highlevel_open_tcp_stream.py
+++ b/trio/tests/test_highlevel_open_tcp_stream.py
@@ -128,9 +128,6 @@ class FakeSocket(trio.socket.SocketType):
     def setsockopt(self, *args, **kwargs):
         pass
 
-    def getpeername(self):
-        return (self.ip, self.port)
-
 
 class Scenario(trio.abc.SocketFactory, trio.abc.HostnameResolver):
     def __init__(self, port, ip_list, ipv6_supported):

--- a/trio/tests/test_highlevel_socket.py
+++ b/trio/tests/test_highlevel_socket.py
@@ -24,11 +24,6 @@ async def test_SocketStream_basics():
         with pytest.raises(ValueError):
             SocketStream(sock)
 
-    # disconnected socket bad
-    with tsocket.socket() as sock:
-        with pytest.raises(ValueError):
-            SocketStream(sock)
-
     a, b = tsocket.socketpair()
     with a, b:
         s = SocketStream(a)

--- a/trio/tests/test_highlevel_socket.py
+++ b/trio/tests/test_highlevel_socket.py
@@ -215,10 +215,6 @@ async def test_SocketListener_accept_errors():
         def setsockopt(self, level, opt, value):
             pass
 
-        # Fool the check for connection in SocketStream.__init__
-        def getpeername(self):
-            pass
-
         async def accept(self):
             await _core.checkpoint()
             event = next(self._events)

--- a/trio/tests/test_highlevel_socket.py
+++ b/trio/tests/test_highlevel_socket.py
@@ -262,3 +262,12 @@ async def test_SocketListener_accept_errors():
     with assert_checkpoints():
         s = await l.accept()
         assert s.socket is fake_server_sock
+
+
+async def test_socket_stream_works_when_peer_has_already_closed():
+    sock_a, sock_b = tsocket.socketpair()
+    await sock_b.send(b"x")
+    sock_b.close()
+    stream = SocketStream(sock_a)
+    assert await stream.receive_some(1) == b"x"
+    assert await stream.receive_some(1) == b""


### PR DESCRIPTION
Fixes #609.

I have a few questions:
- What should I do about this test which fails without the getpeername check? https://github.com/wgwz/trio/blob/wgwz/fix-for-609/trio/tests/test_highlevel_socket.py#L27-L30 I'm thinking it might be that the test just doesn't matter anymore. 
- What type of a newsfragment should I use? I'm guessing bugfix or removal.. 