### PR TITLE
Migrate trio.abc from star import to explicit imports, to aid static analysis

### DIFF
--- a/trio/_abc.py
+++ b/trio/_abc.py
@@ -2,21 +2,6 @@ from abc import ABCMeta, abstractmethod
 from ._util import aiter_compat
 from . import _core
 
-__all__ = [
-    "Clock",
-    "Instrument",
-    "AsyncResource",
-    "SendStream",
-    "ReceiveStream",
-    "Stream",
-    "HalfCloseableStream",
-    "SocketFactory",
-    "HostnameResolver",
-    "Listener",
-    "SendChannel",
-    "ReceiveChannel",
-]
-
 
 # We use ABCMeta instead of ABC, plus set __slots__=(), so as not to force a
 # __dict__ onto subclasses.

--- a/trio/abc.py
+++ b/trio/abc.py
@@ -4,5 +4,8 @@
 # temporaries, imports, etc. when implementing the module. So we put the
 # implementation in an underscored module, and then re-export the public parts
 # here.
-from ._abc import *
-from ._abc import __all__
+from ._abc import (
+    Clock, Instrument, AsyncResource, SendStream, ReceiveStream, Stream,
+    HalfCloseableStream, SocketFactory, HostnameResolver, Listener,
+    SendChannel, ReceiveChannel
+)


### PR DESCRIPTION
We continue to work towards making the code easier for static analysis tools.