### PR TITLE
Migrate hazmat to faked explicit importing and reexporting, to aid static analysis (issue #542)

### DIFF
--- a/trio/hazmat.py
+++ b/trio/hazmat.py
@@ -13,13 +13,12 @@ import sys
 from ._core import (
     cancel_shielded_checkpoint, Abort, wait_task_rescheduled,
     enable_ki_protection, disable_ki_protection, currently_ki_protected, Task,
-    checkpoint, current_task, ParkingLot, UnboundedQueue, RunVar,
-    notify_fd_close, wait_socket_readable, wait_socket_writable,
-    notify_socket_close, TrioToken, current_trio_token,
-    temporarily_detach_coroutine_object, permanently_detach_coroutine_object,
-    reattach_detached_coroutine_object, current_statistics, reschedule,
-    remove_instrument, add_instrument, current_clock, current_root_task,
-    checkpoint_if_cancelled, spawn_system_task
+    checkpoint, current_task, ParkingLot, UnboundedQueue, RunVar, TrioToken,
+    current_trio_token, temporarily_detach_coroutine_object,
+    permanently_detach_coroutine_object, reattach_detached_coroutine_object,
+    current_statistics, reschedule, remove_instrument, add_instrument,
+    current_clock, current_root_task, checkpoint_if_cancelled,
+    spawn_system_task
 )
 
 try:
@@ -36,6 +35,10 @@ try:
         # non windows symbols
         wait_writable,
         wait_readable,
+        notify_fd_close,
+        wait_socket_readable,
+        wait_socket_writable,
+        notify_socket_close
     )
 except ImportError:
     pass

--- a/trio/hazmat.py
+++ b/trio/hazmat.py
@@ -17,14 +17,17 @@ from ._core import (
     wait_writable, wait_readable, notify_fd_close, wait_socket_readable,
     wait_socket_writable, notify_socket_close, TrioToken, current_trio_token,
     temporarily_detach_coroutine_object, permanently_detach_coroutine_object,
-    reattach_detached_coroutine_object, current_kqueue, monitor_kevent,
-    wait_kevent, current_statistics, reschedule, remove_instrument,
-    add_instrument, current_clock, current_root_task, checkpoint_if_cancelled,
-    spawn_system_task
+    reattach_detached_coroutine_object, current_statistics, reschedule,
+    remove_instrument, add_instrument, current_clock, current_root_task,
+    checkpoint_if_cancelled, spawn_system_task
 )
 
 try:
     from ._core import (
+        # kqueue symbols
+        current_kqueue,
+        monitor_kevent,
+        wait_kevent,
         # windows symbols
         current_iocp,
         register_with_iocp,

--- a/trio/hazmat.py
+++ b/trio/hazmat.py
@@ -14,8 +14,8 @@ from ._core import (
     cancel_shielded_checkpoint, Abort, wait_task_rescheduled,
     enable_ki_protection, disable_ki_protection, currently_ki_protected, Task,
     checkpoint, current_task, ParkingLot, UnboundedQueue, RunVar,
-    wait_writable, wait_readable, notify_fd_close, wait_socket_readable,
-    wait_socket_writable, notify_socket_close, TrioToken, current_trio_token,
+    notify_fd_close, wait_socket_readable, wait_socket_writable,
+    notify_socket_close, TrioToken, current_trio_token,
     temporarily_detach_coroutine_object, permanently_detach_coroutine_object,
     reattach_detached_coroutine_object, current_statistics, reschedule,
     remove_instrument, add_instrument, current_clock, current_root_task,
@@ -32,7 +32,10 @@ try:
         current_iocp,
         register_with_iocp,
         wait_overlapped,
-        monitor_completion_key
+        monitor_completion_key,
+        # non windows symbols
+        wait_writable,
+        wait_readable,
     )
 except ImportError:
     pass

--- a/trio/hazmat.py
+++ b/trio/hazmat.py
@@ -10,43 +10,21 @@ import sys
 # this lists all possible symbols from trio._core, and then we prune those that
 # aren't available on this system. After that we add some symbols from trio/*.py.
 
+from ._core import (
+    cancel_shielded_checkpoint, Abort, wait_task_rescheduled,
+    enable_ki_protection, disable_ki_protection, currently_ki_protected, Task,
+    checkpoint, current_task, ParkingLot, UnboundedQueue, RunVar,
+    wait_writable, wait_readable, notify_fd_close, wait_socket_readable,
+    wait_socket_writable, notify_socket_close, TrioToken, current_trio_token,
+    temporarily_detach_coroutine_object, permanently_detach_coroutine_object,
+    reattach_detached_coroutine_object, current_kqueue, monitor_kevent,
+    wait_kevent, current_statistics, reschedule, remove_instrument,
+    add_instrument, current_clock, current_root_task, checkpoint_if_cancelled,
+    spawn_system_task
+)
+
 try:
     from ._core import (
-        cancel_shielded_checkpoint,
-        Abort,
-        wait_task_rescheduled,
-        enable_ki_protection,
-        disable_ki_protection,
-        currently_ki_protected,
-        Task,
-        checkpoint,
-        current_task,
-        current_root_task,
-        checkpoint_if_cancelled,
-        spawn_system_task,
-        reschedule,
-        remove_instrument,
-        add_instrument,
-        current_clock,
-        current_statistics,
-        ParkingLot,
-        UnboundedQueue,
-        RunVar,
-        wait_writable,
-        wait_readable,
-        notify_fd_close,
-        wait_socket_readable,
-        wait_socket_writable,
-        notify_socket_close,
-        TrioToken,
-        current_trio_token,
-        temporarily_detach_coroutine_object,
-        permanently_detach_coroutine_object,
-        reattach_detached_coroutine_object,
-        # kqueue symbols
-        current_kqueue,
-        monitor_kevent,
-        wait_kevent,
         # windows symbols
         current_iocp,
         register_with_iocp,
@@ -57,6 +35,7 @@ except ImportError:
     pass
 
 from . import _core
+
 # Some hazmat symbols are platform specific
 globals().update(
     {

--- a/trio/hazmat.py
+++ b/trio/hazmat.py
@@ -10,6 +10,7 @@ import sys
 # this lists all possible symbols from trio._core, and then we prune those that
 # aren't available on this system. After that we add some symbols from trio/*.py.
 
+# Generally available symbols
 from ._core import (
     cancel_shielded_checkpoint, Abort, wait_task_rescheduled,
     enable_ki_protection, disable_ki_protection, currently_ki_protected, Task,
@@ -18,81 +19,40 @@ from ._core import (
     permanently_detach_coroutine_object, reattach_detached_coroutine_object,
     current_statistics, reschedule, remove_instrument, add_instrument,
     current_clock, current_root_task, checkpoint_if_cancelled,
-    spawn_system_task
+    spawn_system_task, wait_socket_readable, wait_socket_writable,
+    notify_socket_close
 )
 
+# Unix-specific symbols
 try:
     from ._core import (
-        # kqueue symbols
-        current_kqueue,
-        monitor_kevent,
-        wait_kevent,
-        # windows symbols
-        current_iocp,
-        register_with_iocp,
-        wait_overlapped,
-        monitor_completion_key,
-        # non windows symbols
         wait_writable,
         wait_readable,
         notify_fd_close,
-        wait_socket_readable,
-        wait_socket_writable,
-        notify_socket_close
+    )
+except ImportError:
+    pass
+
+# Kqueue-specific symbols
+try:
+    from ._core import (
+        current_kqueue,
+        monitor_kevent,
+        wait_kevent,
+    )
+except ImportError:
+    pass
+
+# Windows symbols
+try:
+    from ._core import (
+        current_iocp, register_with_iocp, wait_overlapped,
+        monitor_completion_key
     )
 except ImportError:
     pass
 
 from . import _core
-
-# Some hazmat symbols are platform specific
-globals().update(
-    {
-        _name: _value
-        for (_name, _value) in _core.__dict__.items() if _name in [
-            "cancel_shielded_checkpoint",
-            "Abort",
-            "wait_task_rescheduled",
-            "enable_ki_protection",
-            "disable_ki_protection",
-            "currently_ki_protected",
-            "Task",
-            "checkpoint",
-            "current_task",
-            "current_root_task",
-            "checkpoint_if_cancelled",
-            "spawn_system_task",
-            "reschedule",
-            "remove_instrument",
-            "add_instrument",
-            "current_clock",
-            "current_statistics",
-            "ParkingLot",
-            "UnboundedQueue",
-            "RunVar",
-            "wait_writable",
-            "wait_readable",
-            "notify_fd_close",
-            "wait_socket_readable",
-            "wait_socket_writable",
-            "notify_socket_close",
-            "TrioToken",
-            "current_trio_token",
-            "temporarily_detach_coroutine_object",
-            "permanently_detach_coroutine_object",
-            "reattach_detached_coroutine_object",
-            # kqueue symbols
-            "current_kqueue",
-            "monitor_kevent",
-            "wait_kevent",
-            # windows symbols
-            "current_iocp",
-            "register_with_iocp",
-            "wait_overlapped",
-            "monitor_completion_key",
-        ]
-    }
-)
 
 # Import bits from trio/*.py
 if sys.platform.startswith("win"):

--- a/trio/hazmat.py
+++ b/trio/hazmat.py
@@ -12,54 +12,99 @@ import sys
 
 try:
     from ._core import (
-    cancel_shielded_checkpoint,
-    Abort,
-    wait_task_rescheduled,
-    enable_ki_protection,
-    disable_ki_protection,
-    currently_ki_protected,
-    Task,
-    checkpoint,
-    current_task,
-    current_root_task,
-    checkpoint_if_cancelled,
-    spawn_system_task,
-    reschedule,
-    remove_instrument,
-    add_instrument,
-    current_clock,
-    current_statistics,
-    ParkingLot,
-    UnboundedQueue,
-    RunVar,
-    wait_writable,
-    wait_readable,
-    notify_fd_close,
-    wait_socket_readable,
-    wait_socket_writable,
-    notify_socket_close,
-    TrioToken,
-    current_trio_token,
-    temporarily_detach_coroutine_object,
-    permanently_detach_coroutine_object,
-    reattach_detached_coroutine_object,
-    # kqueue symbols
-    current_kqueue,
-    monitor_kevent,
-    wait_kevent,
-    # windows symbols
-    current_iocp,
-    register_with_iocp,
-    wait_overlapped,
-    monitor_completion_key)
+        cancel_shielded_checkpoint,
+        Abort,
+        wait_task_rescheduled,
+        enable_ki_protection,
+        disable_ki_protection,
+        currently_ki_protected,
+        Task,
+        checkpoint,
+        current_task,
+        current_root_task,
+        checkpoint_if_cancelled,
+        spawn_system_task,
+        reschedule,
+        remove_instrument,
+        add_instrument,
+        current_clock,
+        current_statistics,
+        ParkingLot,
+        UnboundedQueue,
+        RunVar,
+        wait_writable,
+        wait_readable,
+        notify_fd_close,
+        wait_socket_readable,
+        wait_socket_writable,
+        notify_socket_close,
+        TrioToken,
+        current_trio_token,
+        temporarily_detach_coroutine_object,
+        permanently_detach_coroutine_object,
+        reattach_detached_coroutine_object,
+        # kqueue symbols
+        current_kqueue,
+        monitor_kevent,
+        wait_kevent,
+        # windows symbols
+        current_iocp,
+        register_with_iocp,
+        wait_overlapped,
+        monitor_completion_key
+    )
 except ImportError:
     pass
 
 from . import _core
 # Some hazmat symbols are platform specific
-for _sym in list(_core.__dict__.keys()):
-    if hasattr(_core, _sym):
-        globals()[_sym] = getattr(_core, _sym)
+globals().update(
+    {
+        _name: _value
+        for (_name, _value) in _core.__dict__.items() if _name in [
+            "cancel_shielded_checkpoint",
+            "Abort",
+            "wait_task_rescheduled",
+            "enable_ki_protection",
+            "disable_ki_protection",
+            "currently_ki_protected",
+            "Task",
+            "checkpoint",
+            "current_task",
+            "current_root_task",
+            "checkpoint_if_cancelled",
+            "spawn_system_task",
+            "reschedule",
+            "remove_instrument",
+            "add_instrument",
+            "current_clock",
+            "current_statistics",
+            "ParkingLot",
+            "UnboundedQueue",
+            "RunVar",
+            "wait_writable",
+            "wait_readable",
+            "notify_fd_close",
+            "wait_socket_readable",
+            "wait_socket_writable",
+            "notify_socket_close",
+            "TrioToken",
+            "current_trio_token",
+            "temporarily_detach_coroutine_object",
+            "permanently_detach_coroutine_object",
+            "reattach_detached_coroutine_object",
+            # kqueue symbols
+            "current_kqueue",
+            "monitor_kevent",
+            "wait_kevent",
+            # windows symbols
+            "current_iocp",
+            "register_with_iocp",
+            "wait_overlapped",
+            "monitor_completion_key",
+        ]
+    }
+)
 
 # Import bits from trio/*.py
 if sys.platform.startswith("win"):

--- a/trio/hazmat.py
+++ b/trio/hazmat.py
@@ -10,64 +10,57 @@ import sys
 # this lists all possible symbols from trio._core, and then we prune those that
 # aren't available on this system. After that we add some symbols from trio/*.py.
 
-__all__ = [
-    "cancel_shielded_checkpoint",
-    "Abort",
-    "wait_task_rescheduled",
-    "enable_ki_protection",
-    "disable_ki_protection",
-    "currently_ki_protected",
-    "Task",
-    "checkpoint",
-    "current_task",
-    "current_root_task",
-    "checkpoint_if_cancelled",
-    "spawn_system_task",
-    "reschedule",
-    "remove_instrument",
-    "add_instrument",
-    "current_clock",
-    "current_statistics",
-    "ParkingLot",
-    "UnboundedQueue",
-    "RunVar",
-    "wait_writable",
-    "wait_readable",
-    "notify_fd_close",
-    "wait_socket_readable",
-    "wait_socket_writable",
-    "notify_socket_close",
-    "TrioToken",
-    "current_trio_token",
-    "temporarily_detach_coroutine_object",
-    "permanently_detach_coroutine_object",
-    "reattach_detached_coroutine_object",
+try:
+    from ._core import (
+    cancel_shielded_checkpoint,
+    Abort,
+    wait_task_rescheduled,
+    enable_ki_protection,
+    disable_ki_protection,
+    currently_ki_protected,
+    Task,
+    checkpoint,
+    current_task,
+    current_root_task,
+    checkpoint_if_cancelled,
+    spawn_system_task,
+    reschedule,
+    remove_instrument,
+    add_instrument,
+    current_clock,
+    current_statistics,
+    ParkingLot,
+    UnboundedQueue,
+    RunVar,
+    wait_writable,
+    wait_readable,
+    notify_fd_close,
+    wait_socket_readable,
+    wait_socket_writable,
+    notify_socket_close,
+    TrioToken,
+    current_trio_token,
+    temporarily_detach_coroutine_object,
+    permanently_detach_coroutine_object,
+    reattach_detached_coroutine_object,
     # kqueue symbols
-    "current_kqueue",
-    "monitor_kevent",
-    "wait_kevent",
+    current_kqueue,
+    monitor_kevent,
+    wait_kevent,
     # windows symbols
-    "current_iocp",
-    "register_with_iocp",
-    "wait_overlapped",
-    "monitor_completion_key",
-]
+    current_iocp,
+    register_with_iocp,
+    wait_overlapped,
+    monitor_completion_key)
+except ImportError:
+    pass
 
 from . import _core
 # Some hazmat symbols are platform specific
-for _sym in list(__all__):
+for _sym in list(_core.__dict__.keys()):
     if hasattr(_core, _sym):
         globals()[_sym] = getattr(_core, _sym)
-    else:
-        # Fool static analysis (at least PyCharm's) into thinking that we're
-        # not modifying __all__, so it can trust the static list up above.
-        # https://github.com/python-trio/trio/pull/316#issuecomment-328255867
-        # This was useful in September 2017. If it's not September 2017 then
-        # who knows.
-        remove_from_all = __all__.remove
-        remove_from_all(_sym)
 
 # Import bits from trio/*.py
 if sys.platform.startswith("win"):
     from ._wait_for_object import WaitForSingleObject
-    __all__ += ["WaitForSingleObject"]

--- a/trio/tests/test_exports.py
+++ b/trio/tests/test_exports.py
@@ -50,7 +50,6 @@ def public_namespaces(module):
 NAMESPACES = list(public_namespaces(trio))
 
 # Not yet set up for static analysis:
-NAMESPACES.remove("trio.hazmat")
 NAMESPACES.remove("trio.ssl")
 
 

--- a/trio/tests/test_exports.py
+++ b/trio/tests/test_exports.py
@@ -63,7 +63,7 @@ def test_pylint_sees_all_non_underscore_symbols_in_hazmat_namespace():
     from pylint.lint import PyLinter
     linter = PyLinter()
     ast_set = set(linter.get_ast(trio.hazmat.__file__, 'trio.hazmat'))
-    trio_set = set([symbol for symbol in dir(trio) if symbol[0] != '_'])
+    trio_set = set([symbol for symbol in dir(trio.hazmat) if symbol[0] != '_'])
     assert trio_set - ast_set == set([])
 
 
@@ -96,7 +96,7 @@ def test_jedi_sees_all_trio_socket_completions():
 def test_jedi_sees_all_trio_hazmat_completions():
     # Test the jedi completion library get all in dir(trio.hazmat)
     try:
-        script = jedi.Script("import trio.hazmat; trio.socket.hazmat")
+        script = jedi.Script("import trio.hazmat; trio.hazmat.")
         completions = script.completions()
         trio_set = set(
             [symbol for symbol in dir(trio.hazmat) if symbol[:2] != '__']


### PR DESCRIPTION
Continuing towards finalisation of #542 
We do a try / except import of our symbols to aid static analysis tools to pick them up. Then we update the list dynamically to have python get the correct symbols.