### PR TITLE
[travis] Use xenial environment for all builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
-sudo: false
-dist: trusty
+dist: xenial
 
 matrix:
   include:
@@ -18,16 +17,10 @@ matrix:
     - python: 3.5.2
     - python: 3.6
     - python: 3.7
-      dist: xenial
-      sudo: required
     - python: 3.5-dev
     - python: 3.6-dev
     - python: 3.7-dev
-      dist: xenial
-      sudo: required
     - python: 3.8-dev
-      dist: xenial
-      sudo: required
     - os: osx
       language: generic
       env: MACPYTHON=3.5.4


### PR DESCRIPTION
This is now officially supported:
  https://blog.travis-ci.com/2018-11-08-xenial-release

It should make cryptography happier on our pypy builds because it has
a newer openssl:
  https://github.com/python-trio/trio/pull/781

Also dropped the sudo: tags, because Travis is in the process of
switching all builds to run on the old 'sudo: required' infrastructure
unconditionally:
  https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

Conveniently, this also removes the penalty that used to exist for
using xenial.