### PR TITLE
unix_pipes.PipeSendStream: add send_some method

### DIFF
--- a/trio/tests/subprocess/test_unix_pipes.py
+++ b/trio/tests/subprocess/test_unix_pipes.py
@@ -158,7 +158,7 @@ async def test_pipe_send_some(autojump_clock):
     async def sender():
         nonlocal next_send_offset
         with move_on_after(2.0):
-            while next_send_offset < len(data):
+            while next_send_offset < len(data):  # pragma: no branch
                 next_send_offset = await write.send_some(
                     data, next_send_offset
                 )


### PR DESCRIPTION
`send_some` does not block after its first write completes, and returns
an indication of how much data it sent, so it can be used in cases where
the amount of data sent before a cancellation must be known. This is
needed to implement stdlib-compatible `subprocess.Popen.communicate()`.