### PR TITLE
ci: re-enable 3.8-dev coverage reports

### DIFF
--- a/ci/travis.sh
+++ b/ci/travis.sh
@@ -75,10 +75,5 @@ else
     INSTALLDIR=$(python -c "import os, trio; print(os.path.dirname(trio.__file__))")
     pytest -W error -ra --run-slow --faulthandler-timeout=60 ${INSTALLDIR} --cov="$INSTALLDIR" --cov-config=../.coveragerc --verbose
 
-    # Disable coverage on 3.8-dev, at least until it's fixed (or a1 comes out):
-    #   https://github.com/python-trio/trio/issues/711
-    #   https://github.com/nedbat/coveragepy/issues/707#issuecomment-426455490
-    if [ "$(python -V)" != "Python 3.8.0a0" ]; then
-        bash <(curl -s https://codecov.io/bash)
-    fi
+    bash <(curl -s https://codecov.io/bash)
 fi


### PR DESCRIPTION
The coverage.py bugs appear to have been fixed, let's see if that fixes our problem!