### PR TITLE
improve error handling in open_tcp_stream

### DIFF
--- a/newsfragments/809.bugfix.rst
+++ b/newsfragments/809.bugfix.rst
@@ -1,0 +1,2 @@
+:func:`trio.open_tcp_stream()` has been refactored to clean up
+unsuccessful connection attempts more reliably.

--- a/trio/_highlevel_open_tcp_stream.py
+++ b/trio/_highlevel_open_tcp_stream.py
@@ -110,8 +110,14 @@ def close_all():
     try:
         yield sockets_to_close
     finally:
+        errs = []
         for sock in sockets_to_close:
-            sock.close()
+            try:
+                sock.close()
+            except BaseException as exc:
+                errs.append(exc)
+        if errs:
+            raise trio.MultiError(errs)
 
 
 def reorder_for_rfc_6555_section_5_4(targets):

--- a/trio/_highlevel_open_tcp_stream.py
+++ b/trio/_highlevel_open_tcp_stream.py
@@ -105,15 +105,6 @@ DEFAULT_DELAY = 0.300
 
 
 @contextmanager
-def close_on_error(obj):
-    try:
-        yield obj
-    except:
-        obj.close()
-        raise
-
-
-@contextmanager
 def close_all():
     sockets_to_close = set()
     try:

--- a/trio/_highlevel_open_unix_stream.py
+++ b/trio/_highlevel_open_unix_stream.py
@@ -1,5 +1,6 @@
+from contextlib import contextmanager
+
 import trio
-from trio._highlevel_open_tcp_stream import close_on_error
 from trio.socket import socket, SOCK_STREAM
 
 try:
@@ -9,6 +10,15 @@ except ImportError:
     has_unix = False
 
 __all__ = ["open_unix_socket"]
+
+
+@contextmanager
+def close_on_error(obj):
+    try:
+        yield obj
+    except:
+        obj.close()
+        raise
 
 
 async def open_unix_socket(filename,):

--- a/trio/tests/test_highlevel_open_tcp_stream.py
+++ b/trio/tests/test_highlevel_open_tcp_stream.py
@@ -278,7 +278,8 @@ async def test_one_host_slow_fail(autojump_clock):
 
 async def test_one_host_failed_after_connect(autojump_clock):
     exc, scenario = await run_scenario(
-        83, [("1.2.3.4", 1, "postconnect_fail")], expect_error=KeyboardInterrupt
+        83, [("1.2.3.4", 1, "postconnect_fail")],
+        expect_error=KeyboardInterrupt
     )
     assert isinstance(exc, KeyboardInterrupt)
 

--- a/trio/tests/test_highlevel_open_tcp_stream.py
+++ b/trio/tests/test_highlevel_open_tcp_stream.py
@@ -6,9 +6,30 @@ import trio
 from trio.socket import AF_INET, AF_INET6, SOCK_STREAM, IPPROTO_TCP
 from trio._highlevel_open_tcp_stream import (
     reorder_for_rfc_6555_section_5_4,
+    close_all,
     open_tcp_stream,
     format_host_port,
 )
+
+
+def test_close_all():
+    class CloseMe:
+        closed = False
+
+        def close(self):
+            self.closed = True
+
+    c = CloseMe()
+    with close_all() as to_close:
+        to_close.add(c)
+    assert c.closed
+
+    c = CloseMe()
+    with pytest.raises(RuntimeError):
+        with close_all() as to_close:
+            to_close.add(c)
+            raise RuntimeError
+    assert c.closed
 
 
 def test_reorder_for_rfc_6555_section_5_4():

--- a/trio/tests/test_highlevel_open_tcp_stream.py
+++ b/trio/tests/test_highlevel_open_tcp_stream.py
@@ -29,6 +29,13 @@ def test_close_all():
     assert c.closed
 
     c = CloseMe()
+    with pytest.raises(RuntimeError):
+        with close_all() as to_close:
+            to_close.add(c)
+            raise RuntimeError
+    assert c.closed
+
+    c = CloseMe()
     with pytest.raises(OSError):
         with close_all() as to_close:
             to_close.add(CloseKiller())

--- a/trio/tests/test_highlevel_open_tcp_stream.py
+++ b/trio/tests/test_highlevel_open_tcp_stream.py
@@ -6,27 +6,9 @@ import trio
 from trio.socket import AF_INET, AF_INET6, SOCK_STREAM, IPPROTO_TCP
 from trio._highlevel_open_tcp_stream import (
     reorder_for_rfc_6555_section_5_4,
-    close_on_error,
     open_tcp_stream,
     format_host_port,
 )
-
-
-def test_close_on_error():
-    class CloseMe:
-        closed = False
-
-        def close(self):
-            self.closed = True
-
-    with close_on_error(CloseMe()) as c:
-        pass
-    assert not c.closed
-
-    with pytest.raises(RuntimeError):
-        with close_on_error(CloseMe()) as c:
-            raise RuntimeError
-    assert c.closed
 
 
 def test_reorder_for_rfc_6555_section_5_4():

--- a/trio/tests/test_highlevel_open_tcp_stream.py
+++ b/trio/tests/test_highlevel_open_tcp_stream.py
@@ -19,16 +19,20 @@ def test_close_all():
         def close(self):
             self.closed = True
 
+    class CloseKiller:
+        def close(self):
+            raise OSError
+
     c = CloseMe()
     with close_all() as to_close:
         to_close.add(c)
     assert c.closed
 
     c = CloseMe()
-    with pytest.raises(RuntimeError):
+    with pytest.raises(OSError):
         with close_all() as to_close:
+            to_close.add(CloseKiller())
             to_close.add(c)
-            raise RuntimeError
     assert c.closed
 
 

--- a/trio/tests/test_highlevel_open_tcp_stream.py
+++ b/trio/tests/test_highlevel_open_tcp_stream.py
@@ -97,7 +97,7 @@ async def test_open_tcp_stream_input_validation():
 # Now, thorough tests using fake sockets
 
 
-@attr.s
+@attr.s(cmp=False)
 class FakeSocket(trio.socket.SocketType):
     scenario = attr.ib()
     family = attr.ib()


### PR DESCRIPTION
improve handling of `open_tcp_stream` in the case of errors/exceptions being thrown.  previously it looked like there were a few places the code could be interrupted and it would end up leaking file descriptors

I've changed it to track everything in `open_sockets`, and only have a single winner.

I started writing this along with [Nathaniel's PyCon 2018](https://www.youtube.com/watch?v=oLkfnc_UMcE) talk but ended up structuring the retry behaviour differently as I found his confusing to follow.  Not sure if my code will catch all the cases appropriately or is actually better, hence the WIP.

Comments appreciated!