### PR TITLE
Fix invalid documentation link for opentracing.io

### DIFF
--- a/docs/source/reference-core.rst
+++ b/docs/source/reference-core.rst
@@ -1105,7 +1105,7 @@ identifier, and then include this identifier in each log message:
 
 This way we can see that request 1 was slow: it started before request
 2 but finished afterwards. (You can also get `much fancier
-<http://opentracing.io/documentation/>`__, but this is enough for an
+<https://opentracing.io/docs/>`__, but this is enough for an
 example.)
 
 Now, here's the problem: how does the logging code know what the


### PR DESCRIPTION
This pull request fixes the invalid link to the documentation for Open Tracing.