### PR TITLE
Use module-level Random to shuffle tasks

### DIFF
--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -671,7 +671,6 @@ class Runner:
 
     runq = attr.ib(default=attr.Factory(deque))
     tasks = attr.ib(default=attr.Factory(set))
-    r = attr.ib(default=attr.Factory(random.Random))
 
     # {(deadline, id(CancelScope)): CancelScope}
     # only contains scopes with non-infinite deadlines that are currently
@@ -1433,7 +1432,7 @@ def run_impl(runner, async_fn, args):
         # ordering of task._notify_queues.)
         batch = list(runner.runq)
         runner.runq.clear()
-        runner.r.shuffle(batch)
+        _r.shuffle(batch)
         while batch:
             task = batch.pop()
             GLOBAL_RUN_CONTEXT.task = task


### PR DESCRIPTION
This allows test helpers etc. to reproduce scheduling-dependent heisenbugs by seeding the `Random` instance.  (or at least ensures that *something else* will prevent reproductions instead)

I have draft patches against `pytest-trio` and Hypothesis to take advantage of this, but since this has no observable impact except to enable those future patches I thought this was a good place to start.