### PR TITLE
Improve support for systems with IPv4 or IPv6 administratively disabled

### DIFF
--- a/newsfragments/853.bugfix.rst
+++ b/newsfragments/853.bugfix.rst
@@ -1,0 +1,4 @@
+Allow :func:`trio.open_tcp_listeners` to ignore socket creation errors with
+errno ``EAFNOSUPPORT`` ("Address family not supported"), which can occur
+on systems which have either IPv4 or IPv6 administratively disabled, as long
+as at least one listener gets created successfully.

--- a/newsfragments/853.bugfix.rst
+++ b/newsfragments/853.bugfix.rst
@@ -1,4 +1,2 @@
-Allow :func:`trio.open_tcp_listeners` to ignore socket creation errors with
-errno ``EAFNOSUPPORT`` ("Address family not supported"), which can occur
-on systems which have either IPv4 or IPv6 administratively disabled, as long
-as at least one listener gets created successfully.
+Stop :func:`trio.open_tcp_listeners` from crashing on systems that have
+disabled IPv6.

--- a/trio/_core/tests/tutil.py
+++ b/trio/_core/tests/tutil.py
@@ -12,15 +12,24 @@ slow = pytest.mark.skipif(
 )
 
 try:
-    with stdlib_socket.socket(
+    s = stdlib_socket.socket(
         stdlib_socket.AF_INET6, stdlib_socket.SOCK_STREAM, 0
-    ) as s:
-        s.bind(('::1', 0))
-    have_ipv6 = True
+    )
 except OSError:
-    have_ipv6 = False
+    can_create_ipv6 = False
+    can_bind_ipv6 = False
+else:
+    can_create_ipv6 = True
+    with s:
+        try:
+            s.bind(('::1', 0))
+        except OSError:
+            can_bind_ipv6 = False
+        else:
+            can_bind_ipv6 = True
 
-need_ipv6 = pytest.mark.skipif(not have_ipv6, reason="need IPv6")
+creates_ipv6 = pytest.mark.skipif(not can_create_ipv6, reason="need IPv6")
+binds_ipv6 = pytest.mark.skipif(not can_bind_ipv6, reason="need IPv6")
 
 
 def gc_collect_harder():

--- a/trio/_core/tests/tutil.py
+++ b/trio/_core/tests/tutil.py
@@ -15,7 +15,11 @@ try:
     s = stdlib_socket.socket(
         stdlib_socket.AF_INET6, stdlib_socket.SOCK_STREAM, 0
     )
-except OSError:
+except OSError:  # pragma: no cover
+    # Some systems don't even support creating an IPv6 socket, let alone
+    # binding it. (ex: Linux with 'ipv6.disable=1' in the kernel command line)
+    # We don't have any of those in our CI, and there's nothing that gets
+    # tested _only_ if can_create_ipv6 = False, so we'll just no-cover this.
     can_create_ipv6 = False
     can_bind_ipv6 = False
 else:

--- a/trio/_highlevel_open_tcp_listeners.py
+++ b/trio/_highlevel_open_tcp_listeners.py
@@ -147,14 +147,11 @@ async def open_tcp_listeners(port, *, host=None, backlog=None):
         raise
 
     if unsupported_address_families and not listeners:
-        if len(unsupported_address_families) == 1:
-            raise unsupported_address_families[0]
-        else:
-            raise OSError(
-                errno.EAFNOSUPPORT,
-                "This system doesn't support any of the kinds of "
-                "socket that that address could use"
-            ) from trio.MultiError(unsupported_address_families)
+        raise OSError(
+            errno.EAFNOSUPPORT,
+            "This system doesn't support any of the kinds of "
+            "socket that that address could use"
+        ) from trio.MultiError(unsupported_address_families)
 
     return listeners
 

--- a/trio/tests/test_socket.py
+++ b/trio/tests/test_socket.py
@@ -455,7 +455,7 @@ async def test_SocketType_resolve(socket_type, addrs):
             assert await res(("1::2", 80, 1, 2)) == ("1::2", 80, 1, 2)
 
             # V4 mapped addresses resolved if V6ONLY is False
-            sock6.setsockopt(tsocket.IPPROTO_IPV6, tsocket.IPV6_V6ONLY, False)
+            sock.setsockopt(tsocket.IPPROTO_IPV6, tsocket.IPV6_V6ONLY, False)
             assert await res(("1.2.3.4",
                               "http")) == ("::ffff:1.2.3.4", 80, 0, 0)
 

--- a/trio/tests/test_socket.py
+++ b/trio/tests/test_socket.py
@@ -6,7 +6,7 @@ import socket as stdlib_socket
 import inspect
 import tempfile
 
-from .._core.tests.tutil import need_ipv6
+from .._core.tests.tutil import creates_ipv6, binds_ipv6
 from .. import _core
 from .. import _socket as _tsocket
 from .. import socket as tsocket
@@ -256,7 +256,7 @@ async def test_socket():
         assert s.family == tsocket.AF_INET
 
 
-@need_ipv6
+@creates_ipv6
 async def test_socket_v6():
     with tsocket.socket(tsocket.AF_INET6, tsocket.SOCK_DGRAM) as s:
         assert isinstance(s, tsocket.SocketType)
@@ -361,7 +361,7 @@ async def test_SocketType_shutdown():
 @pytest.mark.parametrize(
     "address, socket_type", [
         ('127.0.0.1', tsocket.AF_INET),
-        pytest.param('::1', tsocket.AF_INET6, marks=need_ipv6)
+        pytest.param('::1', tsocket.AF_INET6, marks=binds_ipv6)
     ]
 )
 async def test_SocketType_simple_server(address, socket_type):
@@ -424,7 +424,7 @@ class Addresses:
                 broadcast="::ffff:255.255.255.255",
                 extra=(0, 0),
             ),
-            marks=need_ipv6,
+            marks=creates_ipv6,
         ),
     ]
 )

--- a/trio/tests/test_socket.py
+++ b/trio/tests/test_socket.py
@@ -461,7 +461,7 @@ async def test_SocketType_resolve(socket_type, addrs):
 
         # Check the <broadcast> special case, because why not
         assert await res(("<broadcast>",
-                          123)) == (addrs.broadcast, 123, *extra)
+                          123)) == (addrs.broadcast, 123, *addrs.extra)
 
         # But not if it's true (at least on systems where getaddrinfo works
         # correctly)

--- a/trio/tests/test_testing.py
+++ b/trio/tests/test_testing.py
@@ -6,7 +6,7 @@ import tempfile
 
 import pytest
 
-from .._core.tests.tutil import have_ipv6
+from .._core.tests.tutil import can_bind_ipv6
 from .. import sleep
 from .. import _core
 from .._highlevel_generic import aclose_forcefully
@@ -822,7 +822,7 @@ async def test_open_stream_to_socket_listener():
     sock.listen(10)
     await check(SocketListener(sock))
 
-    if have_ipv6:
+    if can_bind_ipv6:
         # Listener bound to IPv6 wildcard (needs special handling)
         sock = tsocket.socket(family=tsocket.AF_INET6)
         await sock.bind(("::", 0))


### PR DESCRIPTION
Closes #853.

- Some such systems return both address families from `getaddrinfo` but fail with `EAFNOSUPPORT` in `socket`. Allow `open_tcp_listeners()` to ignore `EAFNOSUPPORT` as long as at least one listener is created successfully.
- Fix socket tests to be more careful about not even trying to create an IPv6 socket on systems that don't support IPv6.