### PR TITLE
Remove usages of pytest.config deprecated in pytest 4.1

### DIFF
--- a/trio/_abc.py
+++ b/trio/_abc.py
@@ -659,7 +659,7 @@ class ReceiveChannel(AsyncResource):
 
     @abstractmethod
     def clone(self):
-        """Clone this receive channel object.
+        r"""Clone this receive channel object.
 
         This returns a new :class:`ReceiveChannel` object, which acts as a
         duplicate of the original: receiving on the new object does exactly

--- a/trio/_core/tests/test_ki.py
+++ b/trio/_core/tests/test_ki.py
@@ -15,7 +15,7 @@ from ... import _core
 from ...testing import wait_all_tasks_blocked
 from ..._util import signal_raise, is_main_thread
 from ..._timeouts import sleep
-from .tutil import slow
+from .tutil import skip_slow
 
 
 def ki_self():
@@ -472,8 +472,8 @@ def test_ki_with_broken_threads():
 #   pthread_kill(pthread_self, SIGINT)
 # in the child thread, to make sure signals in non-main threads also wake up
 # the main loop... but currently that test would fail (see gh-109 again).
-@slow
-def test_ki_wakes_us_up():
+def test_ki_wakes_us_up(request):
+    skip_slow(request)
     assert is_main_thread()
 
     # This test is flaky due to a race condition on Windows; see:

--- a/trio/_core/tests/test_multierror.py
+++ b/trio/_core/tests/test_multierror.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import subprocess
 import warnings
 
-from .tutil import slow
+from .tutil import skip_slow
 
 from .._multierror import MultiError, concat_tb
 
@@ -593,23 +593,23 @@ else:
 need_ipython = pytest.mark.skipif(not have_ipython, reason="need IPython")
 
 
-@slow
 @need_ipython
-def test_ipython_exc_handler():
+def test_ipython_exc_handler(request):
+    skip_slow(request)
     completed = run_script("simple_excepthook.py", use_ipython=True)
     check_simple_excepthook(completed)
 
 
-@slow
 @need_ipython
-def test_ipython_imported_but_unused():
+def test_ipython_imported_but_unused(request):
+    skip_slow(request)
     completed = run_script("simple_excepthook_IPython.py")
     check_simple_excepthook(completed)
 
 
-@slow
 @need_ipython
-def test_ipython_custom_exc_handler():
+def test_ipython_custom_exc_handler(request):
+    skip_slow(request)
     # Check we get a nice warning (but only one!) if the user is using IPython
     # and already has some other set_custom_exc handler installed.
     completed = run_script("ipython_custom_exc.py", use_ipython=True)

--- a/trio/_core/tests/test_windows.py
+++ b/trio/_core/tests/test_windows.py
@@ -8,7 +8,7 @@ on_windows = (os.name == "nt")
 # Mark all the tests in this file as being windows-only
 pytestmark = pytest.mark.skipif(not on_windows, reason="windows only")
 
-from .tutil import slow, gc_collect_harder
+from .tutil import skip_slow, gc_collect_harder
 from ... import _core, sleep, move_on_after
 from ...testing import wait_all_tasks_blocked
 if on_windows:
@@ -148,8 +148,8 @@ def test_forgot_to_register_with_iocp():
         gc_collect_harder()
 
 
-@slow
-async def test_too_late_to_cancel():
+async def test_too_late_to_cancel(request):
+    skip_slow(request)
     import time
 
     with pipe_with_overlapped_read() as (write_fp, read_handle):

--- a/trio/_core/tests/tutil.py
+++ b/trio/_core/tests/tutil.py
@@ -5,11 +5,12 @@ import pytest
 
 import gc
 
+
 # See trio/tests/conftest.py for the other half of this
-slow = pytest.mark.skipif(
-    not pytest.config.getoption("--run-slow", True),
-    reason="use --run-slow to run slow tests",
-)
+def skip_slow(request):
+    if not request.config.getoption("--run-slow", True):
+        pytest.skip("use --run-slow to run slow tests")
+
 
 try:
     s = stdlib_socket.socket(

--- a/trio/tests/test_highlevel_open_tcp_listeners.py
+++ b/trio/tests/test_highlevel_open_tcp_listeners.py
@@ -11,7 +11,7 @@ from trio import (
 )
 from trio.testing import open_stream_to_socket_listener
 from .. import socket as tsocket
-from .._core.tests.tutil import slow, creates_ipv6, binds_ipv6
+from .._core.tests.tutil import skip_slow, creates_ipv6, binds_ipv6
 
 
 async def test_open_tcp_listeners_basic():
@@ -90,8 +90,9 @@ async def measure_backlog(listener, limit):
     return len(client_streams)
 
 
-@slow
-async def test_open_tcp_listeners_backlog():
+async def test_open_tcp_listeners_backlog(request):
+    skip_slow(request)
+
     # Operating systems don't necessarily use the exact backlog you pass
     async def check_backlog(nominal, required_min, required_max):
         listeners = await open_tcp_listeners(0, backlog=nominal)

--- a/trio/tests/test_ssl.py
+++ b/trio/tests/test_ssl.py
@@ -20,7 +20,7 @@ from .. import socket as tsocket
 from .._ssl import SSLStream, SSLListener, NeedHandshakeError
 from .._util import ConflictDetector
 
-from .._core.tests.tutil import slow
+from .._core.tests.tutil import skip_slow
 
 from ..testing import (
     assert_checkpoints,
@@ -522,10 +522,10 @@ async def test_renegotiation_simple():
         await s.aclose()
 
 
-@slow
-async def test_renegotiation_randomized(mock_clock):
+async def test_renegotiation_randomized(mock_clock, request):
     # The only blocking things in this function are our random sleeps, so 0 is
     # a good threshold.
+    skip_slow(request)
     mock_clock.autojump_threshold = 0
 
     import random

--- a/trio/tests/test_subprocess.py
+++ b/trio/tests/test_subprocess.py
@@ -9,7 +9,7 @@ import pytest
 from .. import (
     _core, move_on_after, fail_after, sleep, sleep_forever, Process
 )
-from .._core.tests.tutil import slow
+from .._core.tests.tutil import skip_slow
 from ..testing import wait_all_tasks_blocked
 
 posix = os.name == "posix"
@@ -262,8 +262,8 @@ async def test_wait_reapable_fails():
         signal.signal(signal.SIGCHLD, old_sigchld)
 
 
-@slow
-def test_waitid_eintr():
+def test_waitid_eintr(request):
+    skip_slow(request)
     # This only matters on PyPy (where we're coding EINTR handling
     # ourselves) but the test works on all waitid platforms.
     from .._subprocess_platform import wait_child_exiting

--- a/trio/tests/test_threads.py
+++ b/trio/tests/test_threads.py
@@ -13,7 +13,6 @@ from ..testing import wait_all_tasks_blocked
 from .._threads import *
 
 from .._core.tests.test_ki import ki_self
-from .._core.tests.tutil import slow
 
 
 async def test_do_in_trio_thread():

--- a/trio/tests/test_timeouts.py
+++ b/trio/tests/test_timeouts.py
@@ -2,7 +2,7 @@ import outcome
 import pytest
 import time
 
-from .._core.tests.tutil import slow
+from .._core.tests.tutil import skip_slow
 from .. import _core
 from ..testing import assert_checkpoints
 from .._timeouts import *
@@ -41,8 +41,9 @@ async def check_takes_about(f, expected_dur):
 TARGET = 1.0
 
 
-@slow
-async def test_sleep():
+async def test_sleep(request):
+    skip_slow(request)
+
     async def sleep_1():
         await sleep_until(_core.current_time() + TARGET)
 
@@ -64,8 +65,8 @@ async def test_sleep():
             await sleep(0)
 
 
-@slow
-async def test_move_on_after():
+async def test_move_on_after(request):
+    skip_slow(request)
     with pytest.raises(ValueError):
         with move_on_after(-1):
             pass  # pragma: no cover
@@ -77,8 +78,9 @@ async def test_move_on_after():
     await check_takes_about(sleep_3, TARGET)
 
 
-@slow
-async def test_fail():
+async def test_fail(request):
+    skip_slow(request)
+
     async def sleep_4():
         with fail_at(_core.current_time() + TARGET):
             await sleep(100)

--- a/trio/tests/test_wait_for_object.py
+++ b/trio/tests/test_wait_for_object.py
@@ -7,7 +7,7 @@ on_windows = (os.name == "nt")
 # Mark all the tests in this file as being windows-only
 pytestmark = pytest.mark.skipif(not on_windows, reason="windows only")
 
-from .._core.tests.tutil import slow
+from .._core.tests.tutil import skip_slow
 from .. import _core
 from .. import _timeouts
 if on_windows:
@@ -68,10 +68,10 @@ async def test_WaitForMultipleObjects_sync():
     print('test_WaitForMultipleObjects_sync close second OK')
 
 
-@slow
-async def test_WaitForMultipleObjects_sync_slow():
+async def test_WaitForMultipleObjects_sync_slow(request):
     # This does a series of test in which the main thread sync-waits for
     # handles, while we spawn a thread to set the handles after a short while.
+    skip_slow(request)
 
     TIMEOUT = 0.3
 
@@ -160,10 +160,10 @@ async def test_WaitForSingleObject():
     print('test_WaitForSingleObject not a handle OK')
 
 
-@slow
-async def test_WaitForSingleObject_slow():
+async def test_WaitForSingleObject_slow(request):
     # This does a series of test for setting the handle in another task,
     # and cancelling the wait task.
+    skip_slow(request)
 
     # Set the timeout used in the tests. We test the waiting time against
     # the timeout with a certain margin.


### PR DESCRIPTION
Follow up to https://github.com/python-trio/trio/pull/856