### PR TITLE
Subprocess support: tighten and document expectations for how the command is specified

### DIFF
--- a/newsfragments/863.feature.rst
+++ b/newsfragments/863.feature.rst
@@ -1,6 +1,6 @@
 :class:`trio.Process` on POSIX systems no longer accepts the error-prone
 combination of ``shell=False`` with a ``command`` that's a single string,
 or ``shell=True`` with a ``command`` that's a sequence of strings.
-These forms are accepted by the underlying :mod:`subprocess.Popen`
+These forms are accepted by the underlying :class:`subprocess.Popen`
 constructor but don't do what most users expect. Also, added an explanation
 of :ref:`quoting <subprocess-quoting>` to the documentation.

--- a/newsfragments/863.feature.rst
+++ b/newsfragments/863.feature.rst
@@ -1,0 +1,6 @@
+:class:`trio.Process` on POSIX systems no longer accepts the error-prone
+combination of ``shell=False`` with a ``command`` that's a single string,
+or ``shell=True`` with a ``command`` that's a sequence of strings.
+These forms are accepted by the underlying :mod:`subprocess.Popen`
+constructor but don't do what most users expect. Also, added an explanation
+of :ref:`quoting <subprocess-quoting>` to the documentation.

--- a/trio/tests/test_subprocess.py
+++ b/trio/tests/test_subprocess.py
@@ -225,6 +225,12 @@ async def test_errors():
     assert "unbuffered byte streams" in str(excinfo.value)
     assert "the 'encoding' option is not supported" in str(excinfo.value)
 
+    if posix:
+        with pytest.raises(TypeError) as excinfo:
+            Process(["ls"], shell=True)
+        with pytest.raises(TypeError) as excinfo:
+            Process("ls", shell=False)
+
 
 async def test_signals():
     async def test_one_signal(send_it, signum):


### PR DESCRIPTION
On POSIX, don't permit two error-prone combinations that the underlying `subprocess` module supports:
* string command with `shell=False`: user might think it word-splits somehow, but actually it treats the entire string as the name of an executable to invoke with no arguments
* list command with `shell=True`: binds the extra arguments to shell variables `$1`, `$2`, etc, instead of passing them to the command being executed

Add a section on quoting to the subprocess documentation, explaining the above restrictions and acquainting users with the many pitfalls of using `shell=True` on Windows.