### PR TITLE
Enable codecov flag support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,8 @@ test_script:
   - "python -c \"import os, trio; print(os.path.dirname(trio.__file__))\""
   # -u makes sure we get prompt output
   - "python -u -m pytest -W error -ra --run-slow --faulthandler-timeout=60 ../trio -v -s --cov=trio --cov-config=../.coveragerc"
-  - "codecov"
+  # TODO: figure out how to include the python version in the flag
+  - "codecov -F win"
 
 branches:
   except:

--- a/ci/travis.sh
+++ b/ci/travis.sh
@@ -4,10 +4,10 @@ set -ex
 
 git rev-parse HEAD
 
-CODECOV_FLAG="${TRAVIS_OS_NAME}-${TRAVIS_PYTHON_VERSION:-<unknown>}"
+CODECOV_FLAG="${TRAVIS_OS_NAME}_${TRAVIS_PYTHON_VERSION:-unknown}"
 
 if [ "$TRAVIS_OS_NAME" = "osx" ]; then
-    CODECOV_FLAG="osx-${MACPYTHON}"
+    CODECOV_FLAG="osx_${MACPYTHON}"
     curl -Lo macpython.pkg https://www.python.org/ftp/python/${MACPYTHON}/python-${MACPYTHON}-macosx10.6.pkg
     sudo installer -pkg macpython.pkg -target /
     ls /Library/Frameworks/Python.framework/Versions/*/bin/
@@ -20,7 +20,7 @@ if [ "$TRAVIS_OS_NAME" = "osx" ]; then
 fi
 
 if [ "$PYPY_NIGHTLY_BRANCH" != "" ]; then
-    CODECOV_FLAG="pypy-nightly-${PYPY_NIGHTLY_BRANCH}"
+    CODECOV_FLAG="pypy_nightly_${PYPY_NIGHTLY_BRANCH}"
     curl -fLo pypy.tar.bz2 http://buildbot.pypy.org/nightly/${PYPY_NIGHTLY_BRANCH}/pypy-c-jit-latest-linux64.tar.bz2
     if [ ! -s pypy.tar.bz2 ]; then
         # We know:
@@ -57,6 +57,8 @@ pip install -U pip setuptools wheel
 
 python setup.py sdist --formats=zip
 pip install dist/*.zip
+
+CODECOV_FLAG=$(echo -n "$CODECOV_FLAG" | tr -c a-z0-9 _)
 
 if [ "$CHECK_DOCS" = "1" ]; then
     pip install -r ci/rtd-requirements.txt

--- a/ci/travis.sh
+++ b/ci/travis.sh
@@ -4,7 +4,10 @@ set -ex
 
 git rev-parse HEAD
 
+CODECOV_FLAG="${TRAVIS_OS_NAME}-${TRAVIS_PYTHON_VERSION:-<unknown>}"
+
 if [ "$TRAVIS_OS_NAME" = "osx" ]; then
+    CODECOV_FLAG="osx-${MACPYTHON}"
     curl -Lo macpython.pkg https://www.python.org/ftp/python/${MACPYTHON}/python-${MACPYTHON}-macosx10.6.pkg
     sudo installer -pkg macpython.pkg -target /
     ls /Library/Frameworks/Python.framework/Versions/*/bin/
@@ -17,6 +20,7 @@ if [ "$TRAVIS_OS_NAME" = "osx" ]; then
 fi
 
 if [ "$PYPY_NIGHTLY_BRANCH" != "" ]; then
+    CODECOV_FLAG="pypy-nightly-${PYPY_NIGHTLY_BRANCH}"
     curl -fLo pypy.tar.bz2 http://buildbot.pypy.org/nightly/${PYPY_NIGHTLY_BRANCH}/pypy-c-jit-latest-linux64.tar.bz2
     if [ ! -s pypy.tar.bz2 ]; then
         # We know:
@@ -79,6 +83,6 @@ else
     #   https://github.com/python-trio/trio/issues/711
     #   https://github.com/nedbat/coveragepy/issues/707#issuecomment-426455490
     if [ "$(python -V)" != "Python 3.8.0a0" ]; then
-        bash <(curl -s https://codecov.io/bash)
+        bash <(curl -s https://codecov.io/bash) -F "${CODECOV_FLAG}"
     fi
 fi


### PR DESCRIPTION
See: https://docs.codecov.io/docs/flags

When we get bizarro coverage results (e.g. complaints about comments
not executing), then I'm hoping this will help us track them down.