### PR TITLE
Rewrite unix pipe fd handling logic

### DIFF
--- a/newsfragments/661.bugfix.rst
+++ b/newsfragments/661.bugfix.rst
@@ -1,3 +1,6 @@
-Fixed several bugs in the new subprocess pipe support, where
-operations on a closed pipe could accidentally affect another
-unrelated pipe due to internal file-descriptor reuse.
+Fixed several bugs in the new subprocess pipe support on Unix, where
+(a) operations on a closed pipe could accidentally affect another
+unrelated pipe due to internal file-descriptor reuse, (b) in very rare
+circumstances, two tasks calling ``send_all`` on the same pipe at the
+same time could end up with intermingled data instead of a
+:exc:`BusyResourceError`.

--- a/newsfragments/661.bugfix.rst
+++ b/newsfragments/661.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed several bugs in the new subprocess pipe support, where
+operations on a closed pipe could accidentally affect another
+unrelated pipe due to internal file-descriptor reuse.

--- a/newsfragments/874.bugfix.rst
+++ b/newsfragments/874.bugfix.rst
@@ -1,0 +1,3 @@
+If you have a :class:`SocketStream` that's already been closed, then
+``await socket_stream.send_all(b"")`` will now correctly raise
+:exc:`ClosedResourceError`.

--- a/trio/_highlevel_socket.py
+++ b/trio/_highlevel_socket.py
@@ -104,6 +104,10 @@ class SocketStream(HalfCloseableStream):
                 with memoryview(data) as data:
                     if not data:
                         await _core.checkpoint()
+                        if self.socket.fileno() == -1:
+                            raise _core.ClosedResourceError(
+                                "socket was already closed"
+                            )
                         return
                     total_sent = 0
                     while total_sent < len(data):

--- a/trio/_unix_pipes.py
+++ b/trio/_unix_pipes.py
@@ -1,13 +1,10 @@
 import fcntl
 import os
-from typing import Tuple
 import errno
 
 from . import _core
 from ._abc import SendStream, ReceiveStream
 from ._util import ConflictDetector
-
-__all__ = ["PipeSendStream", "PipeReceiveStream", "make_pipe"]
 
 
 class _FdHolder:
@@ -156,9 +153,3 @@ class PipeReceiveStream(ReceiveStream):
 
     def fileno(self):
         return self._fd_holder.fd
-
-
-async def make_pipe() -> Tuple[PipeSendStream, PipeReceiveStream]:
-    """Makes a new pair of pipes."""
-    (r, w) = os.pipe()
-    return PipeSendStream(w), PipeReceiveStream(r)

--- a/trio/_unix_pipes.py
+++ b/trio/_unix_pipes.py
@@ -139,7 +139,6 @@ class PipeReceiveStream(ReceiveStream):
                 except BlockingIOError:
                     await _core.wait_readable(self._fd_holder.fd)
                 except OSError as e:
-                    await _core.cancel_shielded_checkpoint()
                     if e.errno == errno.EBADF:
                         raise _core.ClosedResourceError(
                             "this pipe was closed"

--- a/trio/_unix_pipes.py
+++ b/trio/_unix_pipes.py
@@ -26,6 +26,9 @@ class _FdHolder:
     #
     # (This trick was copied from the stdlib socket module.)
     def __init__(self, fd: int):
+        # make sure self.fd is always initialized to *something*, because even
+        # if we error out here then __del__ will run and access it.
+        self.fd = -1
         if not isinstance(fd, int):
             raise TypeError("file descriptor must be an int")
         self.fd = fd

--- a/trio/testing/_check_streams.py
+++ b/trio/testing/_check_streams.py
@@ -164,6 +164,10 @@ async def check_one_way_stream(stream_maker, clogged_stream_maker):
         with _assert_raises(_core.ClosedResourceError):
             await do_send_all(b"x" * 100)
 
+        # even if it's an empty send
+        with _assert_raises(_core.ClosedResourceError):
+            await do_send_all(b"")
+
         # ditto for wait_send_all_might_not_block
         with _assert_raises(_core.ClosedResourceError):
             with assert_checkpoints():

--- a/trio/tests/test_unix_pipes.py
+++ b/trio/tests/test_unix_pipes.py
@@ -1,6 +1,5 @@
 import errno
 import select
-from typing import Tuple
 import os
 
 import pytest
@@ -15,7 +14,8 @@ if posix:
     from .._unix_pipes import PipeSendStream, PipeReceiveStream
 
 
-async def make_pipe() -> Tuple[PipeSendStream, PipeReceiveStream]:
+# Have to use quoted types so import doesn't crash on windows
+async def make_pipe() -> "Tuple[PipeSendStream, PipeReceiveStream]":
     """Makes a new pair of pipes."""
     (r, w) = os.pipe()
     return PipeSendStream(w), PipeReceiveStream(r)

--- a/trio/tests/test_unix_pipes.py
+++ b/trio/tests/test_unix_pipes.py
@@ -237,7 +237,7 @@ async def test_bizarro_OSError_from_receive():
     # we set up a strange scenario where the pipe fd somehow transmutes into a
     # directory fd, causing os.read to raise IsADirectoryError (yes, that's a
     # real built-in exception type).
-    s, r = make_pipe()
+    s, r = await make_pipe()
     async with s, r:
         dir_fd = os.open("/", os.O_DIRECTORY, 0)
         try:

--- a/trio/tests/test_unix_pipes.py
+++ b/trio/tests/test_unix_pipes.py
@@ -1,7 +1,8 @@
 import errno
 import select
-
+from typing import Tuple
 import os
+
 import pytest
 
 from .._core.tests.tutil import gc_collect_harder
@@ -11,7 +12,13 @@ from ..testing import wait_all_tasks_blocked, check_one_way_stream
 posix = os.name == "posix"
 pytestmark = pytest.mark.skipif(not posix, reason="posix only")
 if posix:
-    from .._unix_pipes import PipeSendStream, PipeReceiveStream, make_pipe
+    from .._unix_pipes import PipeSendStream, PipeReceiveStream
+
+
+async def make_pipe() -> Tuple[PipeSendStream, PipeReceiveStream]:
+    """Makes a new pair of pipes."""
+    (r, w) = os.pipe()
+    return PipeSendStream(w), PipeReceiveStream(r)
 
 
 async def test_send_pipe():


### PR DESCRIPTION
This addresses a number of issues:

- Fixes a major issue where `aclose()` called `notify_fd_close()`
  unconditionally, even if the fd was closed; if the fd had already
  been recycled this could (and did) affect unrelated file
  descriptors:
    https://github.com/python-trio/trio/issues/661#issuecomment-456582356
- Fixes a theoretical issue (not yet observed in the wild) where a
  poorly timed close could fail to be noticed by other tasks (gh-661)
- Adds `ConflictDetector`s to catch attempts to use the same stream from
  multiple tasks simultaneously
- Switches from inheritance to composition (gh-830)

Still todo:

- [x] Tests for these race conditions that snuck through
- [x] Audit `_windows_pipes.py` and `_socket.py` for related issues