### PR TITLE
Support deterministic scheduling

### DIFF
--- a/newsfragments/890.feature.rst
+++ b/newsfragments/890.feature.rst
@@ -1,0 +1,3 @@
+Added an internal mechanism for pytest-trio's
+`Hypothesis <https://hypothesis.readthedocs.io>`__ integration
+to make the task scheduler reproducible and avoid flaky tests.

--- a/trio/tests/test_scheduler_determinism.py
+++ b/trio/tests/test_scheduler_determinism.py
@@ -1,0 +1,42 @@
+import trio
+
+
+async def scheduler_trace():
+    """Returns a scheduler-dependent value we can use to check determinism."""
+    trace = []
+
+    async def tracer(name):
+        for i in range(10):
+            trace.append((name, i))
+            await trio.sleep(0)
+
+    async with trio.open_nursery() as nursery:
+        for i in range(5):
+            nursery.start_soon(tracer, i)
+
+    return tuple(trace)
+
+
+def test_the_trio_scheduler_is_not_deterministic():
+    # At least, not yet.  See https://github.com/python-trio/trio/issues/32
+    traces = []
+    for _ in range(10):
+        traces.append(trio.run(scheduler_trace))
+    assert len(set(traces)) == len(traces)
+
+
+def test_the_trio_scheduler_is_deterministic_if_seeded(monkeypatch):
+    monkeypatch.setattr(
+        trio._core._run, "_ALLOW_DETERMINISTIC_SCHEDULING", True
+    )
+    traces = []
+    for _ in range(10):
+        state = trio._core._run._r.getstate()
+        try:
+            trio._core._run._r.seed(0)
+            traces.append(trio.run(scheduler_trace))
+        finally:
+            trio._core._run._r.setstate(state)
+
+    assert len(traces) == 10
+    assert len(set(traces)) == 1


### PR DESCRIPTION
See python-trio/pytest-trio#73 - this is important for Hypothesis, and arguably for debugging in general.  

I've used the current time as primary sort key, with name and task cancel/schedule points to order tasks that started at the same time according to perf_counter.  This is all deterministic, and any remaining collisions are probably coming from random bitflips.

I've also designed the tests to be imported into pytest-trio's test suite, and the Hypothesis test added.