### PR TITLE
Add trio.hazmat.batch_cancellations()

### DIFF
--- a/docs/source/reference-hazmat.rst
+++ b/docs/source/reference-hazmat.rst
@@ -492,6 +492,13 @@ this does serve to illustrate the basic structure of the
                trio.hazmat.reschedule(woken_task)
 
 
+Low-level cancellation control
+------------------------------
+
+.. autofunction:: batch_cancellations()
+   :with:
+
+
 Task API
 --------
 

--- a/newsfragments/900.feature.rst
+++ b/newsfragments/900.feature.rst
@@ -1,0 +1,4 @@
+Added :func:`trio.hazmat.batch_cancellations`, allowing user-defined
+cancellation abstractions to cancel multiple cancel scopes "at the
+same time" with the same semantics (outermost one wins) as when
+Trio does this itself.

--- a/trio/hazmat.py
+++ b/trio/hazmat.py
@@ -20,7 +20,7 @@ from ._core import (
     current_statistics, reschedule, remove_instrument, add_instrument,
     current_clock, current_root_task, checkpoint_if_cancelled,
     spawn_system_task, wait_socket_readable, wait_socket_writable,
-    notify_socket_close
+    notify_socket_close, batch_cancellations
 )
 
 # Unix-specific symbols


### PR DESCRIPTION
This generalizes the "cancel multiple scopes without waking up the tasks, then wake up all the tasks at once" pattern that was previously a special case for handling cancellations on a deadline. It will simplify the
implementation of #886, and exposing it as part of hazmat lets users write their own cancellation
abstractions that work the way the native ones do.