### PR TITLE
Cancel a cancel scope upon entry if its deadline is in the past

### DIFF
--- a/newsfragments/320.misc.rst
+++ b/newsfragments/320.misc.rst
@@ -1,0 +1,4 @@
+Entering a cancel scope whose deadline is in the past now immediately
+cancels it, so :exc:`~trio.Cancelled` will be raised by the first
+checkpoint in the cancel scope rather than the second one.
+This also affects constructs like ``with trio.move_on_after(0):``.

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -201,6 +201,8 @@ class CancelScope:
             )
         self._scope_task = task
         self.cancelled_caught = False
+        if current_time() >= self._deadline:
+            self.cancel_called = True
         with self._might_change_effective_deadline():
             self._add_task(task)
         return self

--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -411,9 +411,14 @@ def test_instruments(recwarn):
     # reschedules the task immediately upon yielding, before the
     # after_task_step event fires.
     expected = (
-        [("before_run",), ("schedule", task)] +
-        [("before", task), ("schedule", task), ("after", task)] * 5 +
-        [("before", task), ("after", task), ("after_run",)]
+        [("before_run",),
+         ("schedule", task)] +
+        [("before", task),
+         ("schedule", task),
+         ("after", task)] * 5 + [
+             ("before", task),
+             ("after", task), ("after_run",)
+         ]
     )
     assert len(r1.record) > len(r2.record) > len(r3.record)
     assert r1.record == r2.record + r3.record

--- a/trio/_core/tests/tutil.py
+++ b/trio/_core/tests/tutil.py
@@ -52,7 +52,7 @@ def gc_collect_harder():
 
 
 # template is like:
-#   [1, {2.1, 2.2}, 3] -> matches [1, 2.1, 3] or [1, 2.2, 3]
+#   [1, {2.1, 2.2}, 3] -> matches [1, 2.1, 2.2, 3] or [1, 2.2, 2.1, 3]
 def check_sequence_matches(seq, template):
     i = 0
     for pattern in template:


### PR DESCRIPTION
Fixes #320. Now that #901 is implemented, the concerns discussed in #835 don't apply.