### PR TITLE
Remove undocumented public API usage of UnboundedQueue

### DIFF
--- a/trio/_channel.py
+++ b/trio/_channel.py
@@ -168,8 +168,12 @@ class MemorySendChannel(SendChannel):
 
     @_core.enable_ki_protection
     async def aclose(self):
+        self.close()
+        await _core.checkpoint()
+
+    @_core.enable_ki_protection
+    def close(self):
         if self._closed:
-            await _core.checkpoint()
             return
         self._closed = True
         for task in self._tasks:
@@ -183,7 +187,6 @@ class MemorySendChannel(SendChannel):
                 task.custom_sleep_data._tasks.remove(task)
                 _core.reschedule(task, Error(_core.EndOfChannel()))
             self._state.receive_tasks.clear()
-        await _core.checkpoint()
 
 
 @attr.s(cmp=False, repr=False)
@@ -250,8 +253,12 @@ class MemoryReceiveChannel(ReceiveChannel):
 
     @_core.enable_ki_protection
     async def aclose(self):
+        self.close()
+        await _core.checkpoint()
+
+    @_core.enable_ki_protection
+    def close(self):
         if self._closed:
-            await _core.checkpoint()
             return
         self._closed = True
         for task in self._tasks:
@@ -266,4 +273,3 @@ class MemoryReceiveChannel(ReceiveChannel):
                 _core.reschedule(task, Error(_core.BrokenResourceError()))
             self._state.send_tasks.clear()
             self._state.data.clear()
-        await _core.checkpoint()

--- a/trio/_core/_io_kqueue.py
+++ b/trio/_core/_io_kqueue.py
@@ -93,6 +93,7 @@ class KqueueIOManager:
         try:
             yield recv_channel
         finally:
+            send_channel.close()
             del self._registered[key]
 
     @_public
@@ -155,8 +156,5 @@ class KqueueIOManager:
                 _core.reschedule(receiver, outcome.Error(exc))
                 del self._registered[key]
             else:
-                # XX this is an interesting example of a case where being able
-                # to close a send_channel would be useful...
-                raise NotImplementedError(
-                    "can't close an fd that monitor_kevent is using"
-                )
+                receiver.close()
+                del self._registered[key]

--- a/trio/_core/_io_windows.py
+++ b/trio/_core/_io_windows.py
@@ -429,6 +429,7 @@ class WindowsIOManager:
         try:
             yield (key, recv_channel)
         finally:
+            send_channel.close()
             del self._completion_key_channels[key]
 
     async def _wait_socket(self, which, sock):


### PR DESCRIPTION
Long time lurker here, I was tinkering around with using IOCP on Windows (messing with ReadDirectoryChanges), dug into some of the undocumented public methods here, as well as the deprecated warning going along with its usage of UnboundedQueue.

So: I updated it to use channels instead, (as well as the kqueue IOManager version).  I have a few questions though:

1. The kqueue IOManager doesn't appear to have any tests for the similar API (`monitor_kevent`).  Should one be written? And if so maybe some guidance on tests, I'm pretty new to those, and don't have the appropriate machine setup ATM.  This also seems to be why coverage dropped?
2. My second commit adds a synchronous `close()` method to channels (does the exact same thing, just never awaits a checkpoint).  Not sure if this is a thing that makes sense to have or not, but it seemed like it was something that should be used to close the send side of the channel when the IOManager doesn't need it anymore.  Maybe there's a better way (queue the `aclose()` version in the scheduler?).
3. This changes a public API (`monitor_completion_key` and `monitor_kevent` yield `MemoryRecieveChannel`s instead of `UnboundedQueue`s).  But the API was undocumented to begin with...should I add documentation?  Should a news fragment go with this since *someone* may have been relying on the old interface?  And if so, should this wait until `UnboundedQueue` goes from deprecated to removed?
4. As far as I can tell `UnboundedQueue` isn't used anywhere else after these changes (I know, not a question).

This is pretty much just to squash the deprecation warning, as I tinker around I'll have more things I might want to change (ex: the context manager for `monitor_completion_key` is cumbersome to use some cases, though that could just be cause I'm designing my classes wrong for the API).