### PR TITLE
Skip 3.8-dev as cffi build fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,8 @@ matrix:
     - python: 3.5-dev
     - python: 3.6-dev
     - python: 3.7-dev
-    - python: 3.8-dev
+    # https://bitbucket.org/cffi/cffi/issues/403/build-fails-on-38-dev-pyinterpreterstate
+    # - python: 3.8-dev
 
 script:
   - ci/ci.sh


### PR DESCRIPTION
See https://bitbucket.org/cffi/cffi/issues/403/build-fails-on-38-dev-pyinterpreterstate for details.