### PR TITLE
Revert "Skip 3.8-dev as cffi build fails"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,7 @@ matrix:
     - python: 3.5-dev
     - python: 3.6-dev
     - python: 3.7-dev
-    # https://bitbucket.org/cffi/cffi/issues/403/build-fails-on-38-dev-pyinterpreterstate
-    # - python: 3.8-dev
+    - python: 3.8-dev
 
 script:
   - ci/ci.sh

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -121,10 +121,9 @@ else
     INSTALLDIR=$(python -c "import os, trio; print(os.path.dirname(trio.__file__))")
     pytest -W error -ra --junitxml=../test-results.xml --run-slow --faulthandler-timeout=60 ${INSTALLDIR} --cov="$INSTALLDIR" --cov-config=../.coveragerc --verbose
 
-    # Disable coverage on 3.8-dev, at least until it's fixed (or a1 comes out):
-    #   https://github.com/python-trio/trio/issues/711
-    #   https://github.com/nedbat/coveragepy/issues/707#issuecomment-426455490
-    if [ "$(python -V)" != "Python 3.8.0a0" ]; then
+    # Disable coverage on 3.8 until we run 3.8 on Windows CI too
+    #   https://github.com/python-trio/trio/pull/784#issuecomment-446438407
+    if [[ "$(python -V)" != Python\ 3.8* ]]; then
         # Disable coverage on pypy py3.6 nightly for now:
         # https://bitbucket.org/pypy/pypy/issues/2943/
         if [ "$PYPY_NIGHTLY_BRANCH" != "py3.6" ]; then

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -10,7 +10,7 @@ async-generator==1.10
 atomicwrites==1.3.0       # via pytest
 attrs==18.2.0
 backcall==0.1.0           # via ipython
-cffi==1.12.1              # via cryptography
+cffi==1.12.2              # via cryptography
 contextvars==2.3 ; python_version < "3.7"
 coverage==4.5.2           # via pytest-cov
 cryptography==2.5         # via pyopenssl, trustme


### PR DESCRIPTION
This reverts commit 678878e2b15c55b9e6e0f38e9a7ab908b4fcb7e6. cffi has been released with a temporary fix, it should work on 3.8-dev from now on.