### PR TITLE
 Remove xfail now that IPython tests pass on 3.8

### DIFF
--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -119,6 +119,7 @@ else
     cd empty
 
     INSTALLDIR=$(python -c "import os, trio; print(os.path.dirname(trio.__file__))")
+    cp ../setup.cfg $INSTALLDIR
     pytest -W error -ra --junitxml=../test-results.xml --run-slow --faulthandler-timeout=60 ${INSTALLDIR} --cov="$INSTALLDIR" --cov-config=../.coveragerc --verbose
 
     # Disable coverage on 3.8 until we run 3.8 on Windows CI too

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[tool:pytest]
+xfail_strict = true

--- a/trio/_core/tests/test_multierror.py
+++ b/trio/_core/tests/test_multierror.py
@@ -593,16 +593,10 @@ else:
     have_ipython = True
 
 need_ipython = pytest.mark.skipif(not have_ipython, reason="need IPython")
-# https://github.com/ipython/ipython/issues/11590
-fails_on_38 = pytest.mark.xfail(
-    sys.version_info >= (3, 8),
-    reason="IPython is currently broken on 3.8-dev"
-)
 
 
 @slow
 @need_ipython
-@fails_on_38
 def test_ipython_exc_handler():
     completed = run_script("simple_excepthook.py", use_ipython=True)
     check_simple_excepthook(completed)
@@ -617,7 +611,6 @@ def test_ipython_imported_but_unused():
 
 @slow
 @need_ipython
-@fails_on_38
 def test_ipython_custom_exc_handler():
     # Check we get a nice warning (but only one!) if the user is using IPython
     # and already has some other set_custom_exc handler installed.


### PR DESCRIPTION
I only noticed this issue when looking at an unrelated 3.8-dev failure (which is now fixed). So I also configured pytest to fail any passing xfail test.

Now that we no longer have xfail tests, how do you convince yourself that xfail_strict works? You can:

 * run `pytest trio --run-slow` without the first commit
 * look at https://travis-ci.org/pquentin/trio/jobs/521670563 which fails because it only contains the xfail_strict change.

Also, in all builds pytest now mentions the `setup.cfg` file like this:

```
rootdir: /home/travis/virtualenv/python3.8-dev/lib/python3.8/site-packages/trio, inifile: setup.cfg
```