### PR TITLE
Add a warning about return statements in nurseries

### DIFF
--- a/docs/source/reference-core.rst
+++ b/docs/source/reference-core.rst
@@ -651,19 +651,18 @@ Since all tasks are descendents of the initial task, one consequence
 of this is that :func:`run` can't finish until all tasks have
 finished.
 
-.. warning::
+.. note::
 
-  A return statement will not cancel the nursery if it still has tasks running.
+  A return statement will not cancel the nursery if it still has tasks running::
 
-  .. code-block:: python
-  
-      with trio.open_nursery() as nursery:
-          nursery.start_soon(trio.sleep(5))
-
-          await trio.sleep(1)
+    async def main():
+      async with trio.open_nursery() as nursery:
+          nursery.start_soon(trio.sleep, 5)
           return
 
-  This code will wait 5 seconds, NOT 1.
+    trio.run(main)
+
+  This code will wait 5 seconds (for the child task to finish), and then return.
 
 Child tasks and cancellation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/reference-core.rst
+++ b/docs/source/reference-core.rst
@@ -651,6 +651,19 @@ Since all tasks are descendents of the initial task, one consequence
 of this is that :func:`run` can't finish until all tasks have
 finished.
 
+.. warning::
+
+  A return statement will not cancel the nursery if it still has tasks running.
+
+  .. code-block:: python
+  
+      with trio.open_nursery() as nursery:
+          nursery.start_soon(trio.sleep(5))
+
+          await trio.sleep(1)
+          return
+
+  This code will wait 5 seconds, NOT 1.
 
 Child tasks and cancellation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/reference-core.rst
+++ b/docs/source/reference-core.rst
@@ -653,16 +653,16 @@ finished.
 
 .. note::
 
-  A return statement will not cancel the nursery if it still has tasks running::
+   A return statement will not cancel the nursery if it still has tasks running::
 
-    async def main():
-      async with trio.open_nursery() as nursery:
-          nursery.start_soon(trio.sleep, 5)
-          return
+     async def main():
+         async with trio.open_nursery() as nursery:
+             nursery.start_soon(trio.sleep, 5)
+             return
 
-    trio.run(main)
+     trio.run(main)
 
-  This code will wait 5 seconds (for the child task to finish), and then return.
+   This code will wait 5 seconds (for the child task to finish), and then return.
 
 Child tasks and cancellation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Regarding this issue: #1009

I'm not sure if it's too emphasized, though. It looks like this:

![image](https://user-images.githubusercontent.com/15224242/56394160-c22ffb00-6279-11e9-8708-d53f03dff80d.png)

And I couldn't get reStructuredText to do a code block *inside* a warning using just indentation (like it's done in the rest of the docs). I had to add the prefix `.. code-block:: python`.