### PR TITLE
fix formatting with yapf 0.27.0 (should make #995 happy)

### DIFF
--- a/test-requirements.in
+++ b/test-requirements.in
@@ -9,7 +9,7 @@ pylint         # for pylint finding all symbols tests
 jedi           # for jedi code completion tests
 
 # Tools
-yapf ==0.26.0  # formatting
+yapf ==0.27.0  # formatting
 flake8
 
 # https://github.com/python-trio/trio/pull/654#issuecomment-420518745

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -51,4 +51,4 @@ trustme==0.5.1
 typed-ast==1.3.1 ; python_version < "3.7" and implementation_name == "cpython"
 wcwidth==0.1.7            # via prompt-toolkit
 wrapt==1.11.1             # via astroid
-yapf==0.26.0
+yapf==0.27.0

--- a/trio/_core/tests/test_multierror.py
+++ b/trio/_core/tests/test_multierror.py
@@ -169,9 +169,9 @@ def test_MultiError_filter():
     assert isinstance(orig.exceptions[0].exceptions[1], KeyError)
     # get original traceback summary
     orig_extracted = (
-        extract_tb(orig.__traceback__) + extract_tb(
-            orig.exceptions[0].__traceback__
-        ) + extract_tb(orig.exceptions[0].exceptions[1].__traceback__)
+        extract_tb(orig.__traceback__) +
+        extract_tb(orig.exceptions[0].__traceback__) +
+        extract_tb(orig.exceptions[0].exceptions[1].__traceback__)
     )
 
     def p(exc):

--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -412,9 +412,8 @@ def test_instruments(recwarn):
     # after_task_step event fires.
     expected = (
         [("before_run",), ("schedule", task)] +
-        [("before", task), ("schedule", task), ("after", task)] * 5 + [
-            ("before", task), ("after", task), ("after_run",)
-        ]
+        [("before", task), ("schedule", task), ("after", task)] * 5 +
+        [("before", task), ("after", task), ("after_run",)]
     )
     assert len(r1.record) > len(r2.record) > len(r3.record)
     assert r1.record == r2.record + r3.record

--- a/trio/tests/test_highlevel_ssl_helpers.py
+++ b/trio/tests/test_highlevel_ssl_helpers.py
@@ -102,7 +102,7 @@ async def test_open_ssl_over_tcp_stream_and_everything_else():
 async def test_open_ssl_over_tcp_listeners():
     (listener,) = await open_ssl_over_tcp_listeners(
         0, SERVER_CTX, host="127.0.0.1"
-    )
+    )  # yapf: disable
     async with listener:
         assert isinstance(listener, trio.SSLListener)
         tl = listener.transport_listener

--- a/trio/tests/test_socket.py
+++ b/trio/tests/test_socket.py
@@ -471,6 +471,7 @@ async def test_SocketType_resolve(socket_type, addrs):
         async def res(*args):
             return await getattr(sock, resolver)(*args)
 
+        # yapf: disable
         assert await res((addrs.arbitrary,
                           "http")) == (addrs.arbitrary, 80, *addrs.extra)
         if v6:
@@ -485,6 +486,7 @@ async def test_SocketType_resolve(socket_type, addrs):
         # Check the <broadcast> special case, because why not
         assert await res(("<broadcast>",
                           123)) == (addrs.broadcast, 123, *addrs.extra)
+        # yapf: enable
 
         # But not if it's true (at least on systems where getaddrinfo works
         # correctly)


### PR DESCRIPTION
yapf 0.27.0 introduce some formatting changes. We should apply them to make #995 happy.

I added a couple `# yapf: disable` because I thought the code as is is more readable.
I don't quite like the lines starting with `) =` but that's my own opinion.

Example of suggested change were:

```patch
--- trio/tests/test_socket.py   (original)                                                                                                                                                                                                     
+++ trio/tests/test_socket.py   (reformatted)        
@@ -471,20 +471,20 @@                                                   
         async def res(*args):                                                    
             return await getattr(sock, resolver)(*args)
                                                                                                   
-        assert await res((addrs.arbitrary,                        
-                          "http")) == (addrs.arbitrary, 80, *addrs.extra)
+        assert await res((addrs.arbitrary, "http")                         
+                         ) == (addrs.arbitrary, 80, *addrs.extra)
         if v6:                                                                                
             assert await res(("1::2", 80, 1)) == ("1::2", 80, 1, 0)                      
             assert await res(("1::2", 80, 1, 2)) == ("1::2", 80, 1, 2)

             # V4 mapped addresses resolved if V6ONLY is False
             sock.setsockopt(tsocket.IPPROTO_IPV6, tsocket.IPV6_V6ONLY, False)
-            assert await res(("1.2.3.4",
-                              "http")) == ("::ffff:1.2.3.4", 80, 0, 0)
+            assert await res(("1.2.3.4", "http")
+                             ) == ("::ffff:1.2.3.4", 80, 0, 0)

         # Check the <broadcast> special case, because why not
-        assert await res(("<broadcast>",
-                          123)) == (addrs.broadcast, 123, *addrs.extra)
+        assert await res(("<broadcast>", 123)
+                         ) == (addrs.broadcast, 123, *addrs.extra)

         # But not if it's true (at least on systems where getaddrinfo works
         # correctly)
--- trio/tests/test_highlevel_ssl_helpers.py    (original)                                                                                                                                                                                     
+++ trio/tests/test_highlevel_ssl_helpers.py    (reformatted)                                                                                                                                                                                  
@@ -100,9 +100,8 @@                                                                                                                                                                                                                            
                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                               
 async def test_open_ssl_over_tcp_listeners():                                                                                                                                                                                                 
-    (listener,) = await open_ssl_over_tcp_listeners(                                                                                                                                                                                          
-        0, SERVER_CTX, host="127.0.0.1"                                                                                                                                                                                                       
-    )                                                      
+    (listener,
+     ) = await open_ssl_over_tcp_listeners(0, SERVER_CTX, host="127.0.0.1")
     async with listener:                     
         assert isinstance(listener, trio.SSLListener)                                                          
         tl = listener.transport_listener
```