### PR TITLE
Exceptions don't need to be hashable (see #767 and #1005)

### DIFF
--- a/newsfragments/1005.bugfix.rst
+++ b/newsfragments/1005.bugfix.rst
@@ -1,5 +1,8 @@
 An exception encapsulated within a :class:`MultiError` doesn't need to be
 hashable anymore.
-.. note:: This is only supported if you are running python >= 3.6.4. You can
-          refer to `this github PR <https://github.com/python/cpython/pull/4014>`_
-          for details.
+
+.. note::
+
+   This is only supported if you are running python >= 3.6.4. You can
+   refer to `this github PR <https://github.com/python/cpython/pull/4014>`_
+   for details.

--- a/newsfragments/1005.bugfix.rst
+++ b/newsfragments/1005.bugfix.rst
@@ -1,0 +1,5 @@
+An exception encapsulated within a :class:`MultiError` doesn't need to be
+hashable anymore.
+.. note:: This is only supported if you are running python >= 3.6.4. You can
+          refer to `this github PR <https://github.com/python/cpython/pull/4014>`_
+          for details.

--- a/trio/_core/_multierror.py
+++ b/trio/_core/_multierror.py
@@ -7,6 +7,13 @@ import attr
 
 __all__ = ["MultiError"]
 
+# python traceback.TracebackException < 3.6.4 does not support unhashable exceptions
+# see https://github.com/python/cpython/pull/4014 for details
+if sys.version_info < (3, 6, 4):
+    exc_key = lambda exc: exc
+else:
+    exc_key = id
+
 ################################################################
 # MultiError
 ################################################################
@@ -375,7 +382,7 @@ def traceback_exception_init(
     if isinstance(exc_value, MultiError):
         embedded = []
         for exc in exc_value.exceptions:
-            if id(exc) not in _seen:
+            if exc_key(exc) not in _seen:
                 embedded.append(
                     traceback.TracebackException.from_exception(
                         exc,

--- a/trio/_core/_multierror.py
+++ b/trio/_core/_multierror.py
@@ -86,7 +86,7 @@ def _filter_impl(handler, root_exc):
             elif changed:
                 return MultiError(new_exceptions)
             else:
-                preserved.add(exc)
+                preserved.add(id(exc))
                 return exc
         else:
             new_exc = handler(exc)
@@ -96,7 +96,7 @@ def _filter_impl(handler, root_exc):
             return new_exc
 
     def push_tb_down(tb, exc, preserved):
-        if exc in preserved:
+        if id(exc) in preserved:
             return
         new_tb = concat_tb(tb, exc.__traceback__)
         if isinstance(exc, MultiError):
@@ -375,7 +375,7 @@ def traceback_exception_init(
     if isinstance(exc_value, MultiError):
         embedded = []
         for exc in exc_value.exceptions:
-            if exc not in _seen:
+            if id(exc) not in _seen:
                 embedded.append(
                     traceback.TracebackException.from_exception(
                         exc,

--- a/trio/_core/tests/test_multierror.py
+++ b/trio/_core/tests/test_multierror.py
@@ -113,6 +113,12 @@ def test_MultiError():
     sys.version_info < (3, 6, 4), reason="Unsupported in python < 3.6.4"
 )
 async def test_MultiErrorNotHashable():
+    exc1 = NotHashableException(42)
+    exc2 = NotHashableException(4242)
+    exc3 = ValueError()
+    assert exc1 != exc2
+    assert exc1 != exc3
+
     with pytest.raises(MultiError):
         async with open_nursery() as nursery:
             nursery.start_soon(raise_nothashable, 42)

--- a/trio/_core/tests/test_multierror.py
+++ b/trio/_core/tests/test_multierror.py
@@ -113,9 +113,6 @@ def test_MultiError():
         MultiError([KeyError(), ValueError])
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 6, 4), reason="Unsupported in python < 3.6.4"
-)
 async def test_MultiErrorNotHashable():
     exc1 = NotHashableException(42)
     exc2 = NotHashableException(4242)


### PR DESCRIPTION
This PR refers to #767 and #1005 in order to allow unhashable exceptions in `MultiError`s.

There is still a limitation though, you need to run python > 3.6.4 because `MultiError` relies on `traceback.TracebackException` which gained the support of unhashable Exceptions in 3.6.4.