### PR TITLE
Adopt `autoflake` and `pyupgrade` formatters

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -5,6 +5,10 @@ set -ex
 EXIT_STATUS=0
 
 # Autoformatter *first*, to avoid double-reporting errors
+# (we'd like to run further autoformatters but *after* merging;
+# see https://forum.bors.tech/t/pre-test-and-pre-merge-hooks/322)
+# autoflake --recursive --in-place .
+# pyupgrade --py3-plus $(find . -name "*.py")
 yapf -rpd setup.py trio \
     || EXIT_STATUS=$?
 

--- a/docs/source/reference-core/blocking-trio-portal-example.py
+++ b/docs/source/reference-core/blocking-trio-portal-example.py
@@ -1,5 +1,4 @@
 import trio
-import threading
 
 def thread_fn(portal, receive_from_trio, send_to_trio):
     while True:

--- a/notes-to-self/graceful-shutdown-idea.py
+++ b/notes-to-self/graceful-shutdown-idea.py
@@ -1,4 +1,3 @@
-from contextlib import contextmanager
 import trio
 
 class GracefulShutdownManager:

--- a/notes-to-self/how-does-windows-so-reuseaddr-work.py
+++ b/notes-to-self/how-does-windows-so-reuseaddr-work.py
@@ -57,5 +57,5 @@ for i, mode1 in enumerate(modes):
                 entry = table_entry(mode1, bind_type1, mode2, bind_type2)
                 row.append(entry)
                 #print(mode1, bind_type1, mode2, bind_type2, entry)
-        print("%19s | %8s | " % (mode1, bind_type1)
+        print("{:>19} | {:>8} | ".format(mode1, bind_type1)
               + " | ".join(["%7s" % entry for entry in row]))

--- a/notes-to-self/proxy-benchmarks.py
+++ b/notes-to-self/proxy-benchmarks.py
@@ -1,5 +1,4 @@
 import textwrap
-import io
 import time
 
 methods = {"fileno"}

--- a/notes-to-self/ssl-close-notify/ssl2.py
+++ b/notes-to-self/ssl-close-notify/ssl2.py
@@ -4,7 +4,6 @@
 import socket
 import ssl
 import threading
-import os
 
 #client_sock, server_sock = socket.socketpair()
 listen_sock = socket.socket()

--- a/trio/_abc.py
+++ b/trio/_abc.py
@@ -689,7 +689,7 @@ class ReceiveChannel(AsyncResource, Generic[T_co]):
         :ref:`channel-mpmc` for examples.
 
         .. warning:: The clones all share the same underlying channel.
-           Whenever a clone :meth:`receive`\s a value, it is removed from the
+           Whenever a clone :meth:`receive`\\s a value, it is removed from the
            channel and the other clones do *not* receive that value. If you
            want to send multiple copies of the same stream of values to
            multiple destinations, like :func:`itertools.tee`, then you need to

--- a/trio/_core/_exceptions.py
+++ b/trio/_core/_exceptions.py
@@ -15,7 +15,6 @@ class TrioInternalError(Exception):
     tasks.) Again, though, this shouldn't happen.
 
     """
-    pass
 
 
 class RunFinishedError(RuntimeError):
@@ -23,14 +22,12 @@ class RunFinishedError(RuntimeError):
     corresponding call to :func:`trio.run` has already finished.
 
     """
-    pass
 
 
 class WouldBlock(Exception):
     """Raised by ``X_nowait`` functions if ``X`` would block.
 
     """
-    pass
 
 
 class Cancelled(BaseException, metaclass=NoPublicConstructor):

--- a/trio/_core/_io_windows.py
+++ b/trio/_core/_io_windows.py
@@ -1,9 +1,7 @@
-import math
 import itertools
 
 import outcome
 from contextlib import contextmanager
-import socket as stdlib_socket
 from select import select
 import threading
 from collections import deque

--- a/trio/_core/_local.py
+++ b/trio/_core/_local.py
@@ -4,7 +4,7 @@ from . import _run
 __all__ = ["RunVar"]
 
 
-class _RunVarToken(object):
+class _RunVarToken:
     _no_value = object()
 
     __slots__ = ("_var", "previous_value", "redeemed")
@@ -19,7 +19,7 @@ class _RunVarToken(object):
         self.redeemed = False
 
 
-class RunVar(object):
+class RunVar:
     """The run-local variant of a context variable.
 
     :class:`RunVar` objects are similar to context variable objects,

--- a/trio/_core/_traps.py
+++ b/trio/_core/_traps.py
@@ -2,7 +2,6 @@
 
 import types
 import enum
-from functools import wraps
 
 import attr
 import outcome

--- a/trio/_core/_unbounded_queue.py
+++ b/trio/_core/_unbounded_queue.py
@@ -1,4 +1,3 @@
-from collections import deque
 import attr
 
 from .. import _core

--- a/trio/_core/tests/test_epoll.py
+++ b/trio/_core/tests/test_epoll.py
@@ -5,7 +5,6 @@
 
 import pytest
 
-import os
 import select
 import socket as stdlib_socket
 

--- a/trio/_core/tests/test_ki.py
+++ b/trio/_core/tests/test_ki.py
@@ -221,7 +221,7 @@ def test_ki_protection_works():
             while True:
                 await _core.checkpoint()
         except _core.Cancelled:
-            record.add((name + " ok"))
+            record.add(name + " ok")
 
     async def raiser(name, record):
         try:
@@ -233,7 +233,7 @@ def test_ki_protection_works():
             print("raised!")
             # Make sure we aren't getting cancelled as well as siginted
             await _core.checkpoint()
-            record.add((name + " raise ok"))
+            record.add(name + " raise ok")
             raise
         else:
             print("didn't raise!")
@@ -244,7 +244,7 @@ def test_ki_protection_works():
                     lambda _: _core.Abort.SUCCEEDED
                 )
             except _core.Cancelled:
-                record.add((name + " cancel ok"))
+                record.add(name + " cancel ok")
 
     # simulated control-C during raiser, which is *unprotected*
     print("check 1")

--- a/trio/_core/tests/test_multierror.py
+++ b/trio/_core/tests/test_multierror.py
@@ -7,7 +7,6 @@ import os
 import re
 from pathlib import Path
 import subprocess
-import warnings
 
 from .tutil import slow
 

--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -191,7 +191,7 @@ def test_main_and_task_both_crash():
         _core.run(main)
     print(excinfo.value)
     assert {type(exc)
-               for exc in excinfo.value.exceptions} == {ValueError, KeyError}
+            for exc in excinfo.value.exceptions} == {ValueError, KeyError}
 
 
 def test_two_child_crashes():
@@ -206,7 +206,7 @@ def test_two_child_crashes():
     with pytest.raises(_core.MultiError) as excinfo:
         _core.run(main)
     assert {type(exc)
-               for exc in excinfo.value.exceptions} == {ValueError, KeyError}
+            for exc in excinfo.value.exceptions} == {ValueError, KeyError}
 
 
 async def test_child_crash_wakes_parent():
@@ -1725,9 +1725,10 @@ async def test_trivial_yields():
             async with _core.open_nursery():
                 raise KeyError
         assert len(excinfo.value.exceptions) == 2
-        assert {type(e) for e in excinfo.value.exceptions} == {
-            KeyError, _core.Cancelled
-        }
+        assert {type(e)
+                for e in excinfo.value.exceptions} == {
+                    KeyError, _core.Cancelled
+                }
 
 
 async def test_nursery_start(autojump_clock):
@@ -1816,9 +1817,8 @@ async def test_nursery_start(autojump_clock):
             cs.cancel()
             with pytest.raises(_core.MultiError) as excinfo:
                 await nursery.start(raise_keyerror_after_started)
-    assert {type(e) for e in excinfo.value.exceptions} == {
-        _core.Cancelled, KeyError
-    }
+    assert {type(e)
+            for e in excinfo.value.exceptions} == {_core.Cancelled, KeyError}
 
     # trying to start in a closed nursery raises an error immediately
     async with _core.open_nursery() as closed_nursery:

--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -190,8 +190,8 @@ def test_main_and_task_both_crash():
     with pytest.raises(_core.MultiError) as excinfo:
         _core.run(main)
     print(excinfo.value)
-    assert set(type(exc)
-               for exc in excinfo.value.exceptions) == {ValueError, KeyError}
+    assert {type(exc)
+               for exc in excinfo.value.exceptions} == {ValueError, KeyError}
 
 
 def test_two_child_crashes():
@@ -205,8 +205,8 @@ def test_two_child_crashes():
 
     with pytest.raises(_core.MultiError) as excinfo:
         _core.run(main)
-    assert set(type(exc)
-               for exc in excinfo.value.exceptions) == {ValueError, KeyError}
+    assert {type(exc)
+               for exc in excinfo.value.exceptions} == {ValueError, KeyError}
 
 
 async def test_child_crash_wakes_parent():
@@ -1725,7 +1725,7 @@ async def test_trivial_yields():
             async with _core.open_nursery():
                 raise KeyError
         assert len(excinfo.value.exceptions) == 2
-        assert set(type(e) for e in excinfo.value.exceptions) == {
+        assert {type(e) for e in excinfo.value.exceptions} == {
             KeyError, _core.Cancelled
         }
 
@@ -1816,7 +1816,7 @@ async def test_nursery_start(autojump_clock):
             cs.cancel()
             with pytest.raises(_core.MultiError) as excinfo:
                 await nursery.start(raise_keyerror_after_started)
-    assert set(type(e) for e in excinfo.value.exceptions) == {
+    assert {type(e) for e in excinfo.value.exceptions} == {
         _core.Cancelled, KeyError
     }
 
@@ -1933,7 +1933,7 @@ async def test_nursery_stop_iteration():
 
 
 async def test_nursery_stop_async_iteration():
-    class it(object):
+    class it:
         def __init__(self, count):
             self.count = count
             self.val = 0
@@ -1946,7 +1946,7 @@ async def test_nursery_stop_async_iteration():
             self.val += 1
             return val
 
-    class async_zip(object):
+    class async_zip:
         def __init__(self, *largs):
             self.nexts = [obj.__anext__ for obj in largs]
 

--- a/trio/_deprecated_ssl_reexports.py
+++ b/trio/_deprecated_ssl_reexports.py
@@ -20,19 +20,19 @@ from ssl import (
 
 # Added in python 3.6
 try:
-    from ssl import AlertDescription, SSLErrorNumber, SSLSession, VerifyFlags, VerifyMode, Options
+    from ssl import AlertDescription, SSLErrorNumber, SSLSession, VerifyFlags, VerifyMode, Options  # noqa
 except ImportError:
     pass
 
 # Added in python 3.7
 try:
-    from ssl import SSLCertVerificationError, TLSVersion
+    from ssl import SSLCertVerificationError, TLSVersion  # noqa
 except ImportError:
     pass
 
 # Windows-only
 try:
-    from ssl import enum_certificates, enum_crls
+    from ssl import enum_certificates, enum_crls  # noqa
 except ImportError:
     pass
 

--- a/trio/_subprocess.py
+++ b/trio/_subprocess.py
@@ -1,8 +1,6 @@
-import math
 import os
 import select
 import subprocess
-import sys
 
 from ._abc import AsyncResource
 from ._highlevel_generic import StapledStream

--- a/trio/_subprocess_platform/__init__.py
+++ b/trio/_subprocess_platform/__init__.py
@@ -1,7 +1,6 @@
 # Platform-specific subprocess bits'n'pieces.
 
 import os
-import sys
 from typing import Tuple
 
 from .. import _core, _subprocess

--- a/trio/_sync.py
+++ b/trio/_sync.py
@@ -1,5 +1,3 @@
-import operator
-from collections import deque, OrderedDict
 import math
 
 import attr

--- a/trio/_timeouts.py
+++ b/trio/_timeouts.py
@@ -92,7 +92,6 @@ class TooSlowError(Exception):
     expires.
 
     """
-    pass
 
 
 @contextmanager

--- a/trio/_windows_pipes.py
+++ b/trio/_windows_pipes.py
@@ -1,6 +1,3 @@
-import os
-from typing import Tuple
-
 from . import _core
 from ._abc import SendStream, ReceiveStream
 from ._util import ConflictDetector
@@ -73,7 +70,6 @@ class PipeSendStream(SendStream):
                 raise _core.ClosedResourceError("This pipe is already closed")
 
             # not implemented yet, and probably not needed
-            pass
 
     async def aclose(self):
         await self._handle_holder.aclose()

--- a/trio/tests/test_deprecate.py
+++ b/trio/tests/test_deprecate.py
@@ -2,7 +2,6 @@ import pytest
 
 import inspect
 import warnings
-from types import ModuleType
 
 from .._deprecate import (
     TrioDeprecationWarning, warn_deprecated, deprecated, deprecated_alias

--- a/trio/tests/test_exports.py
+++ b/trio/tests/test_exports.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import importlib
 import types

--- a/trio/tests/test_file_io.py
+++ b/trio/tests/test_file_io.py
@@ -1,5 +1,4 @@
 import io
-import tempfile
 
 import pytest
 from unittest import mock

--- a/trio/tests/test_highlevel_open_unix_stream.py
+++ b/trio/tests/test_highlevel_open_unix_stream.py
@@ -9,9 +9,7 @@ from trio._highlevel_open_unix_stream import (
     close_on_error,
 )
 
-try:
-    from socket import AF_UNIX
-except ImportError:
+if not hasattr(socket, "AF_UNIX"):
     pytestmark = pytest.mark.skip("Needs unix socket support")
 
 

--- a/trio/tests/test_highlevel_serve_listeners.py
+++ b/trio/tests/test_highlevel_serve_listeners.py
@@ -2,7 +2,6 @@ import pytest
 
 from functools import partial
 import errno
-from collections import deque
 
 import attr
 

--- a/trio/tests/test_highlevel_serve_listeners.py
+++ b/trio/tests/test_highlevel_serve_listeners.py
@@ -45,7 +45,7 @@ async def test_serve_listeners_basic():
     def close_hook():
         # Make sure this is a forceful close
         assert trio.current_effective_deadline() == float("-inf")
-        record.append(("closed"))
+        record.append("closed")
 
     async def handler(stream):
         await stream.send_all(b"123")

--- a/trio/tests/test_subprocess.py
+++ b/trio/tests/test_subprocess.py
@@ -1,6 +1,4 @@
-import math
 import os
-import random
 import signal
 import subprocess
 import sys

--- a/trio/tests/test_threads.py
+++ b/trio/tests/test_threads.py
@@ -1,9 +1,6 @@
 import threading
 import queue as stdlib_queue
 import time
-import os
-import signal
-from functools import partial
 
 import pytest
 

--- a/trio/tests/test_util.py
+++ b/trio/tests/test_util.py
@@ -99,7 +99,7 @@ class ConcretePathLike(BaseKlass):
         return self.path
 
 
-class TestFspath(object):
+class TestFspath:
 
     # based on:
     # https://github.com/python/cpython/blob/da6c3da6c33c6bf794f741e348b9c6d86cc43ec5/Lib/test/test_os.py#L3527-L3571

--- a/trio/tests/test_wait_for_object.py
+++ b/trio/tests/test_wait_for_object.py
@@ -1,5 +1,4 @@
 import os
-import time
 
 import pytest
 
@@ -204,8 +203,6 @@ async def test_WaitForSingleObject_slow():
     print('test_WaitForSingleObject_slow set from task as int OK')
 
     # Test handle is CLOSED after 1 sec - NOPE see comment above
-
-    pass
 
     # Test cancellation
 


### PR DESCRIPTION
In the spirit of #220, here's some development tooling we've adopted in Hypothesis lately for your consideration.  I was going to write up an issue, but it seemed easier to explain by example 😉 

Both [`autoflake`](https://pypi.org/project/autoflake/) and [`pyupgrade`](https://pypi.org/project/pyupgrade/) aim to canonicalise source code; that is to ensure that equivalent constructs are represented in the same way wherever possible.  They also remove some redundancies!  For example, `autoflake` removes unused (standard library) imports and pointless `pass` statements; while `pyupgrade` standardizes set and dict comprehensions, string formatting, etc.

Personally, I've found the enforced consistency does make reading code somewhat easier!  If we want to take this further, `isort` and `black` would round it out, but IMO they deserve some discussion first.

Thoughts?