### PR TITLE
add MultiError.__init__ to avoid linter confusion

### DIFF
--- a/newsfragments/1066.feature.rst
+++ b/newsfragments/1066.feature.rst
@@ -1,0 +1,2 @@
+MultiError now defines its ``exceptions`` attribute in ``__init__()``
+to better support linters and code autocompletion.

--- a/trio/_core/tests/test_multierror.py
+++ b/trio/_core/tests/test_multierror.py
@@ -112,6 +112,16 @@ def test_MultiError():
         MultiError([KeyError(), ValueError])
 
 
+def test_MultiErrorOfSingleMultiError():
+    # For MultiError([MultiError]), ensure there is no bad recursion by the
+    # constructor where __init__ is called if __new__ returns a bare MultiError.
+    exceptions = [KeyError(), ValueError()]
+    a = MultiError(exceptions)
+    b = MultiError([a])
+    assert b == a
+    assert b.exceptions == exceptions
+
+
 async def test_MultiErrorNotHashable():
     exc1 = NotHashableException(42)
     exc2 = NotHashableException(4242)


### PR DESCRIPTION
Fixes #1066 