### PR TITLE
Update pypy versions in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,7 @@ matrix:
     - python: 3.6
       env: CHECK_FORMATTING=1
     # The pypy tests are slow, so we list them first
-    - python: pypy3.5
-    - language: generic
-      env: PYPY_NIGHTLY_BRANCH=py3.5
+    - python: pypy3
     - language: generic
       env: PYPY_NIGHTLY_BRANCH=py3.6
     # 3.5.0 and 3.5.1 have different __aiter__ semantics than all


### PR DESCRIPTION
The "pypy3.5" tag points to pypy3.5 v5.10, while we actually want to
test against the latest pypy3 release, which is pypy3.6 v7.1. For now
at least the "pypy3" tag seems to be up to date, so let's use that and
cross our fingers that it stays that way.

We were also still testing against the pypy3.5 branch nightlies, even
though that branch is now abandoned in favor of the pypy3.6 branch. We
were already testing against pypy3.6 nightlies, so we can just drop
the pypy3.5 nightlies.