### PR TITLE
Drop usage of SO_EXCLUSIVEADDRUSE on win32 (#928)

### DIFF
--- a/newsfragments/928.misc.rst
+++ b/newsfragments/928.misc.rst
@@ -1,0 +1,1 @@
+On win32 we no longer set SO_EXCLUSIVEADDRUSE when binding a socket in :exc:`trio.open_tcp_listeners`.

--- a/trio/_highlevel_open_tcp_listeners.py
+++ b/trio/_highlevel_open_tcp_listeners.py
@@ -120,11 +120,7 @@ async def open_tcp_listeners(port, *, host=None, backlog=None):
                     raise
             try:
                 # See https://github.com/python-trio/trio/issues/39
-                if sys.platform == "win32":
-                    sock.setsockopt(
-                        tsocket.SOL_SOCKET, tsocket.SO_EXCLUSIVEADDRUSE, 1
-                    )
-                else:
+                if sys.platform != "win32":
                     sock.setsockopt(
                         tsocket.SOL_SOCKET, tsocket.SO_REUSEADDR, 1
                     )

--- a/trio/tests/test_highlevel_open_tcp_listeners.py
+++ b/trio/tests/test_highlevel_open_tcp_listeners.py
@@ -122,7 +122,7 @@ async def test_open_tcp_listeners_rebind():
     sockaddr1 = l1.socket.getsockname()
 
     # Plain old rebinding while it's still there should fail, even if we have
-    # SO_REUSEADDR set (requires SO_EXCLUSIVEADDRUSE on Windows)
+    # SO_REUSEADDR set
     probe = stdlib_socket.socket()
     probe.setsockopt(stdlib_socket.SOL_SOCKET, stdlib_socket.SO_REUSEADDR, 1)
     with pytest.raises(OSError):


### PR DESCRIPTION
Tiny change to stop setting SO_EXCLUSIVEADDRUSE on sockets before binding them in trio.open_tcp_listeners when on win32, per all the messy details in issues 39, 72 and 928.