### PR TITLE
add a new is_readable method to SocketType (fix #760)

### DIFF
--- a/docs/source/reference-io.rst
+++ b/docs/source/reference-io.rst
@@ -403,6 +403,10 @@ Socket objects
          left in an unknown state – possibly open, and possibly
          closed. The only reasonable thing to do is to close it.
 
+   .. method:: is_readable
+
+      Check whether the socket is readable or not.
+
    .. method:: sendfile
 
       `Not implemented yet! <https://github.com/python-trio/trio/issues/45>`__

--- a/newsfragments/760.feature.rst
+++ b/newsfragments/760.feature.rst
@@ -1,3 +1,2 @@
-We added a new ``is_readable`` method to the ``trio.socket.SocketType``
-object that allows you to check whether a socket is ready to be read
-or not.
+Trio sockets have a new method `~trio.socket.SocketType.is_readable` that allows
+you to check whether a socket is readable. This is useful for HTTP/1.1 clients.

--- a/newsfragments/760.feature.rst
+++ b/newsfragments/760.feature.rst
@@ -1,0 +1,3 @@
+We added a new ``is_readable`` method to the ``trio.socket.SocketType``
+object that allows you to check whether a socket is ready to be read
+or not.

--- a/trio/tests/test_socket.py
+++ b/trio/tests/test_socket.py
@@ -404,21 +404,15 @@ async def test_SocketType_simple_server(address, socket_type):
             assert await client.recv(1) == b"x"
 
 
-async def test_SocketTupe_is_readable():
-    listener = tsocket.socket(tsocket.AF_INET)
-    client = tsocket.socket(tsocket.AF_INET)
-    with listener, client:
-        await listener.bind(('127.0.0.1', 0))
-        listener.listen(20)
-        addr = listener.getsockname()[:2]
-        async with _core.open_nursery() as nursery:
-            nursery.start_soon(client.connect, addr)
-            server, client_addr = await listener.accept()
-        with server:
-            assert not client.is_readable()
-            await server.send(b"x")
-            assert client.is_readable()
-            assert await client.recv(1) == b"x"
+async def test_SocketType_is_readable():
+    a, b = tsocket.socketpair()
+    with a, b:
+        assert not a.is_readable()
+        await b.send(b"x")
+        await _core.wait_readable(a)
+        assert a.is_readable()
+        assert await a.recv(1) == b"x"
+        assert not a.is_readable()
 
 
 # On some macOS systems, getaddrinfo likes to return V4-mapped addresses even

--- a/trio/tests/test_socket.py
+++ b/trio/tests/test_socket.py
@@ -404,6 +404,23 @@ async def test_SocketType_simple_server(address, socket_type):
             assert await client.recv(1) == b"x"
 
 
+async def test_SocketTupe_is_readable():
+    listener = tsocket.socket(tsocket.AF_INET)
+    client = tsocket.socket(tsocket.AF_INET)
+    with listener, client:
+        await listener.bind(('127.0.0.1', 0))
+        listener.listen(20)
+        addr = listener.getsockname()[:2]
+        async with _core.open_nursery() as nursery:
+            nursery.start_soon(client.connect, addr)
+            server, client_addr = await listener.accept()
+        with server:
+            assert not client.is_readable()
+            await server.send(b"x")
+            assert client.is_readable()
+            assert await client.recv(1) == b"x"
+
+
 # On some macOS systems, getaddrinfo likes to return V4-mapped addresses even
 # when we *don't* pass AI_V4MAPPED.
 # https://github.com/python-trio/trio/issues/580


### PR DESCRIPTION
As explained in #760, this PR adds a new `is_readable` method to `trio.socket.SocketType` object.