### PR TITLE
[WIP] pyOpenSSL-backed TLS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ __pycache__/
 .installed.cfg
 *.egg
 /.pybuild
+pip-wheel-metadata
 
 # Installer logs
 pip-log.txt

--- a/trio/_openssl.py
+++ b/trio/_openssl.py
@@ -1,0 +1,880 @@
+# General theory of operation:
+#
+# We implement an API that closely mirrors the stdlib ssl module's blocking
+# API, and we do it using the stdlib ssl module's non-blocking in-memory API.
+# The stdlib non-blocking in-memory API is barely documented, and acts as a
+# thin wrapper around openssl, whose documentation also leaves something to be
+# desired. So here's the main things you need to know to understand the code
+# in this file:
+#
+# We use an ssl.SSLObject, which exposes the four main I/O operations:
+#
+# - do_handshake: performs the initial handshake. Must be called once at the
+#   beginning of each connection; is a no-op once it's completed once.
+#
+# - write: takes some unencrypted data and attempts to send it to the remote
+#   peer.
+
+# - read: attempts to decrypt and return some data from the remote peer.
+#
+# - unwrap: this is weirdly named; maybe it helps to realize that the thing it
+#   wraps is called SSL_shutdown. It sends a cryptographically signed message
+#   saying "I'm closing this connection now", and then waits to receive the
+#   same from the remote peer (unless we already received one, in which case
+#   it returns immediately).
+#
+# All of these operations read and write from some in-memory buffers called
+# "BIOs", which are an opaque OpenSSL-specific object that's basically
+# semantically equivalent to a Python bytearray. When they want to send some
+# bytes to the remote peer, they append them to the outgoing BIO, and when
+# they want to receive some bytes from the remote peer, they try to pull them
+# out of the incoming BIO. "Sending" always succeeds, because the outgoing BIO
+# can always be extended to hold more data. "Receiving" acts sort of like a
+# non-blocking socket: it might manage to get some data immediately, or it
+# might fail and need to be tried again later. We can also directly add or
+# remove data from the BIOs whenever we want.
+#
+# Now the problem is that while these I/O operations are opaque atomic
+# operations from the point of view of us calling them, under the hood they
+# might require some arbitrary sequence of sends and receives from the remote
+# peer. This is particularly true for do_handshake, which generally requires a
+# few round trips, but it's also true for write and read, due to an evil thing
+# called "renegotiation".
+#
+# Renegotiation is the process by which one of the peers might arbitrarily
+# decide to redo the handshake at any time. Did I mention it's evil? It's
+# pretty evil, and almost universally hated. The HTTP/2 spec forbids the use
+# of TLS renegotiation for HTTP/2 connections. TLS 1.3 removes it from the
+# protocol entirely. It's impossible to trigger a renegotiation if using
+# Python's ssl module. OpenSSL's renegotiation support is pretty buggy [1].
+# Nonetheless, it does get used in real life, mostly in two cases:
+#
+# 1) Normally in TLS 1.2 and below, when the client side of a connection wants
+# to present a certificate to prove their identity, that certificate gets sent
+# in plaintext. This is bad, because it means that anyone eavesdropping can
+# see who's connecting – it's like sending your username in plain text. Not as
+# bad as sending your password in plain text, but still, pretty bad. However,
+# renegotiations *are* encrypted. So as a workaround, it's not uncommon for
+# systems that want to use client certificates to first do an anonymous
+# handshake, and then to turn around and do a second handshake (=
+# renegotiation) and this time ask for a client cert. Or sometimes this is
+# done on a case-by-case basis, e.g. a web server might accept a connection,
+# read the request, and then once it sees the page you're asking for it might
+# stop and ask you for a certificate.
+#
+# 2) In principle the same TLS connection can be used for an arbitrarily long
+# time, and might transmit arbitrarily large amounts of data. But this creates
+# a cryptographic problem: an attacker who has access to arbitrarily large
+# amounts of data that's all encrypted using the same key may eventually be
+# able to use this to figure out the key. Is this a real practical problem? I
+# have no idea, I'm not a cryptographer. In any case, some people worry that
+# it's a problem, so their TLS libraries are designed to automatically trigger
+# a renegotation every once in a while on some sort of timer.
+#
+# The end result is that you might be going along, minding your own business,
+# and then *bam*! a wild renegotiation appears! And you just have to cope.
+#
+# The reason that coping with renegotiations is difficult is that some
+# unassuming "read" or "write" call might find itself unable to progress until
+# it does a handshake, which remember is a process with multiple round
+# trips. So read might have to send data, and write might have to receive
+# data, and this might happen multiple times. And some of those attempts might
+# fail because there isn't any data yet, and need to be retried. Managing all
+# this is pretty complicated.
+#
+# Here's how openssl (and thus the stdlib ssl module) handle this. All of the
+# I/O operations above follow the same rules. When you call one of them:
+#
+# - it might write some data to the outgoing BIO
+# - it might read some data from the incoming BIO
+# - it might raise SSLWantReadError if it can't complete without reading more
+#   data from the incoming BIO. This is important: the "read" in ReadError
+#   refers to reading from the *underlying* stream.
+# - (and in principle it might raise SSLWantWriteError too, but that never
+#   happens when using memory BIOs, so never mind)
+#
+# If it doesn't raise an error, then the operation completed successfully
+# (though we still need to take any outgoing data out of the memory buffer and
+# put it onto the wire). If it *does* raise an error, then we need to retry
+# *exactly that method call* later – in particular, if a 'write' failed, we
+# need to try again later *with the same data*, because openssl might have
+# already committed some of the initial parts of our data to its output even
+# though it didn't tell us that, and has remembered that the next time we call
+# write it needs to skip the first 1024 bytes or whatever it is. (Well,
+# technically, we're actually allowed to call 'write' again with a data buffer
+# which is the same as our old one PLUS some extra stuff added onto the end,
+# but in Trio that never comes up so never mind.)
+#
+# There are some people online who claim that once you've gotten a Want*Error
+# then the *very next call* you make to openssl *must* be the same as the
+# previous one. I'm pretty sure those people are wrong. In particular, it's
+# okay to call write, get a WantReadError, and then call read a few times;
+# it's just that *the next time you call write*, it has to be with the same
+# data.
+#
+# One final wrinkle: we want our SSLStream to support full-duplex operation,
+# i.e. it should be possible for one task to be calling send_all while another
+# task is calling receive_some. But renegotiation makes this a big hassle, because
+# even if SSLStream's restricts themselves to one task calling send_all and one
+# task calling receive_some, those two tasks might end up both wanting to call
+# send_all, or both to call receive_some at the same time *on the underlying
+# stream*. So we have to do some careful locking to hide this problem from our
+# users.
+#
+# (Renegotiation is evil.)
+#
+# So our basic strategy is to define a single helper method called "_retry",
+# which has generic logic for dealing with SSLWantReadError, pushing data from
+# the outgoing BIO to the wire, reading data from the wire to the incoming
+# BIO, retrying an I/O call until it works, and synchronizing with other tasks
+# that might be calling _retry concurrently. Basically it takes an SSLObject
+# non-blocking in-memory method and converts it into a Trio async blocking
+# method. _retry is only about 30 lines of code, but all these cases
+# multiplied by concurrent calls make it extremely tricky, so there are lots
+# of comments down below on the details, and a really extensive test suite in
+# test_ssl.py. And now you know *why* it's so tricky, and can probably
+# understand how it works.
+#
+# [1] https://rt.openssl.org/Ticket/Display.html?id=3712
+
+# XX how closely should we match the stdlib API?
+# - maybe suppress_ragged_eofs=False is a better default?
+# - maybe check crypto folks for advice?
+# - this is also interesting: https://bugs.python.org/issue8108#msg102867
+
+# Definitely keep an eye on Cory's TLS API ideas on security-sig etc.
+
+# XX document behavior on cancellation/error (i.e.: all is lost abandon
+# stream)
+# docs will need to make very clear that this is different from all the other
+# cancellations in core Trio
+
+import operator as _operator
+import ssl as _stdlib_ssl
+from enum import Enum as _Enum
+
+import trio
+
+from .abc import Stream, Listener
+from ._highlevel_generic import aclose_forcefully
+from . import _sync
+from ._util import ConflictDetector
+
+################################################################
+# SSLStream
+################################################################
+
+
+class NeedHandshakeError(Exception):
+    """Some :class:`SSLStream` methods can't return any meaningful data until
+    after the handshake. If you call them before the handshake, they raise
+    this error.
+
+    """
+
+
+class _Once:
+    def __init__(self, afn, *args):
+        self._afn = afn
+        self._args = args
+        self.started = False
+        self._done = _sync.Event()
+
+    async def ensure(self, *, checkpoint):
+        if not self.started:
+            self.started = True
+            await self._afn(*self._args)
+            self._done.set()
+        elif not checkpoint and self._done.is_set():
+            return
+        else:
+            await self._done.wait()
+
+    @property
+    def done(self):
+        return self._done.is_set()
+
+
+_State = _Enum("_State", ["OK", "BROKEN", "CLOSED"])
+
+_default_max_refill_bytes = 32 * 1024
+
+
+class SSLStream(Stream):
+    r"""Encrypted communication using SSL/TLS.
+
+    :class:`SSLStream` wraps an arbitrary :class:`~trio.abc.Stream`, and
+    allows you to perform encrypted communication over it using the usual
+    :class:`~trio.abc.Stream` interface. You pass regular data to
+    :meth:`send_all`, then it encrypts it and sends the encrypted data on the
+    underlying :class:`~trio.abc.Stream`; :meth:`receive_some` takes encrypted
+    data out of the underlying :class:`~trio.abc.Stream` and decrypts it
+    before returning it.
+
+    You should read the standard library's :mod:`ssl` documentation carefully
+    before attempting to use this class, and probably other general
+    documentation on SSL/TLS as well. SSL/TLS is subtle and quick to
+    anger. Really. I'm not kidding.
+
+    Args:
+      transport_stream (~trio.abc.Stream): The stream used to transport
+          encrypted data. Required.
+
+      ssl_context (~ssl.SSLContext): The :class:`~ssl.SSLContext` used for
+          this connection. Required. Usually created by calling
+          :func:`ssl.create_default_context`.
+
+      server_hostname (str or None): The name of the server being connected
+          to. Used for `SNI
+          <https://en.wikipedia.org/wiki/Server_Name_Indication>`__ and for
+          validating the server's certificate (if hostname checking is
+          enabled). This is effectively mandatory for clients, and actually
+          mandatory if ``ssl_context.check_hostname`` is ``True``.
+
+      server_side (bool): Whether this stream is acting as a client or
+          server. Defaults to False, i.e. client mode.
+
+      https_compatible (bool): There are two versions of SSL/TLS commonly
+          encountered in the wild: the standard version, and the version used
+          for HTTPS (HTTP-over-SSL/TLS).
+
+          Standard-compliant SSL/TLS implementations always send a
+          cryptographically signed ``close_notify`` message before closing the
+          connection. This is important because if the underlying transport
+          were simply closed, then there wouldn't be any way for the other
+          side to know whether the connection was intentionally closed by the
+          peer that they negotiated a cryptographic connection to, or by some
+          `man-in-the-middle
+          <https://en.wikipedia.org/wiki/Man-in-the-middle_attack>`__ attacker
+          who can't manipulate the cryptographic stream, but can manipulate
+          the transport layer (a so-called "truncation attack").
+
+          However, this part of the standard is widely ignored by real-world
+          HTTPS implementations, which means that if you want to interoperate
+          with them, then you NEED to ignore it too.
+
+          Fortunately this isn't as bad as it sounds, because the HTTP
+          protocol already includes its own equivalent of ``close_notify``, so
+          doing this again at the SSL/TLS level is redundant. But not all
+          protocols do! Therefore, by default Trio implements the safer
+          standard-compliant version (``https_compatible=False``). But if
+          you're speaking HTTPS or some other protocol where
+          ``close_notify``\s are commonly skipped, then you should set
+          ``https_compatible=True``; with this setting, Trio will neither
+          expect nor send ``close_notify`` messages.
+
+          If you have code that was written to use :class:`ssl.SSLSocket` and
+          now you're porting it to Trio, then it may be useful to know that a
+          difference between :class:`SSLStream` and :class:`ssl.SSLSocket` is
+          that :class:`~ssl.SSLSocket` implements the
+          ``https_compatible=True`` behavior by default.
+
+      max_refill_bytes (int): :class:`~ssl.SSLSocket` maintains an internal
+          buffer of incoming data, and when it runs low then it calls
+          :meth:`receive_some` on the underlying transport stream to refill
+          it. This argument lets you set the ``max_bytes`` argument passed to
+          the *underlying* :meth:`receive_some` call. It doesn't affect calls
+          to *this* class's :meth:`receive_some`, or really anything else
+          user-observable except possibly performance. You probably don't need
+          to worry about this.
+
+    Attributes:
+      transport_stream (trio.abc.Stream): The underlying transport stream
+          that was passed to ``__init__``. An example of when this would be
+          useful is if you're using :class:`SSLStream` over a
+          :class:`~trio.SocketStream` and want to call the
+          :class:`~trio.SocketStream`'s :meth:`~trio.SocketStream.setsockopt`
+          method.
+
+    Internally, this class is implemented using an instance of
+    :class:`ssl.SSLObject`, and all of :class:`~ssl.SSLObject`'s methods and
+    attributes are re-exported as methods and attributes on this class.
+    However, there is one difference: :class:`~ssl.SSLObject` has several
+    methods that return information about the encrypted connection, like
+    :meth:`~ssl.SSLSocket.cipher` or
+    :meth:`~ssl.SSLSocket.selected_alpn_protocol`. If you call them before the
+    handshake, when they can't possibly return useful data, then
+    :class:`ssl.SSLObject` returns None, but :class:`trio.SSLStream`
+    raises :exc:`NeedHandshakeError`.
+
+    This also means that if you register a SNI callback using
+    `~ssl.SSLContext.sni_callback`, then the first argument your callback
+    receives will be a :class:`ssl.SSLObject`.
+
+    """
+
+    # Note: any new arguments here should likely also be added to
+    # SSLListener.__init__, and maybe the open_ssl_over_tcp_* helpers.
+    def __init__(
+        self,
+        transport_stream,
+        ssl_context,
+        *,
+        server_hostname=None,
+        server_side=False,
+        https_compatible=False,
+        max_refill_bytes=_default_max_refill_bytes
+    ):
+        self.transport_stream = transport_stream
+        self._state = _State.OK
+        self._max_refill_bytes = max_refill_bytes
+        self._https_compatible = https_compatible
+        self._outgoing = _stdlib_ssl.MemoryBIO()
+        self._incoming = _stdlib_ssl.MemoryBIO()
+        self._ssl_object = ssl_context.wrap_bio(
+            self._incoming,
+            self._outgoing,
+            server_side=server_side,
+            server_hostname=server_hostname
+        )
+        # Tracks whether we've already done the initial handshake
+        self._handshook = _Once(self._do_handshake)
+
+        # These are used to synchronize access to self.transport_stream
+        self._inner_send_lock = _sync.StrictFIFOLock()
+        self._inner_recv_count = 0
+        self._inner_recv_lock = _sync.Lock()
+
+        # These are used to make sure that our caller doesn't attempt to make
+        # multiple concurrent calls to send_all/wait_send_all_might_not_block
+        # or to receive_some.
+        self._outer_send_conflict_detector = ConflictDetector(
+            "another task is currently sending data on this SSLStream"
+        )
+        self._outer_recv_conflict_detector = ConflictDetector(
+            "another task is currently receiving data on this SSLStream"
+        )
+
+    _forwarded = {
+        "context",
+        "server_side",
+        "server_hostname",
+        "session",
+        "session_reused",
+        "getpeercert",
+        "selected_npn_protocol",
+        "cipher",
+        "shared_ciphers",
+        "compression",
+        "pending",
+        "get_channel_binding",
+        "selected_alpn_protocol",
+        "version",
+    }
+
+    _after_handshake = {
+        "session_reused",
+        "getpeercert",
+        "selected_npn_protocol",
+        "cipher",
+        "shared_ciphers",
+        "compression",
+        "get_channel_binding",
+        "selected_alpn_protocol",
+        "version",
+    }
+
+    def __getattr__(self, name):
+        if name in self._forwarded:
+            if name in self._after_handshake and not self._handshook.done:
+                raise NeedHandshakeError(
+                    "call do_handshake() before calling {!r}".format(name)
+                )
+
+            return getattr(self._ssl_object, name)
+        else:
+            raise AttributeError(name)
+
+    def __setattr__(self, name, value):
+        if name in self._forwarded:
+            setattr(self._ssl_object, name, value)
+        else:
+            super().__setattr__(name, value)
+
+    def __dir__(self):
+        return super().__dir__() + list(self._forwarded)
+
+    def _check_status(self):
+        if self._state is _State.OK:
+            return
+        elif self._state is _State.BROKEN:
+            raise trio.BrokenResourceError
+        elif self._state is _State.CLOSED:
+            raise trio.ClosedResourceError
+        else:  # pragma: no cover
+            assert False
+
+    # This is probably the single trickiest function in Trio. It has lots of
+    # comments, though, just make sure to think carefully if you ever have to
+    # touch it. The big comment at the top of this file will help explain
+    # too.
+    async def _retry(self, fn, *args, ignore_want_read=False):
+        await trio.hazmat.checkpoint_if_cancelled()
+        yielded = False
+        finished = False
+        while not finished:
+            # WARNING: this code needs to be very careful with when it
+            # calls 'await'! There might be multiple tasks calling this
+            # function at the same time trying to do different operations,
+            # so we need to be careful to:
+            #
+            # 1) interact with the SSLObject, then
+            # 2) await on exactly one thing that lets us make forward
+            # progress, then
+            # 3) loop or exit
+            #
+            # In particular we don't want to yield while interacting with
+            # the SSLObject (because it's shared state, so someone else
+            # might come in and mess with it while we're suspended), and
+            # we don't want to yield *before* starting the operation that
+            # will help us make progress, because then someone else might
+            # come in and leapfrog us.
+
+            # Call the SSLObject method, and get its result.
+            #
+            # NB: despite what the docs say, SSLWantWriteError can't
+            # happen – "Writes to memory BIOs will always succeed if
+            # memory is available: that is their size can grow
+            # indefinitely."
+            # https://wiki.openssl.org/index.php/Manual:BIO_s_mem(3)
+            want_read = False
+            ret = None
+            try:
+                ret = fn(*args)
+            except _stdlib_ssl.SSLWantReadError:
+                want_read = True
+            except (_stdlib_ssl.SSLError, _stdlib_ssl.CertificateError) as exc:
+                self._state = _State.BROKEN
+                raise trio.BrokenResourceError from exc
+            else:
+                finished = True
+            if ignore_want_read:
+                want_read = False
+                finished = True
+            to_send = self._outgoing.read()
+
+            # Outputs from the above code block are:
+            #
+            # - to_send: bytestring; if non-empty then we need to send
+            #   this data to make forward progress
+            #
+            # - want_read: True if we need to receive_some some data to make
+            #   forward progress
+            #
+            # - finished: False means that we need to retry the call to
+            #   fn(*args) again, after having pushed things forward. True
+            #   means we still need to do whatever was said (in particular
+            #   send any data in to_send), but once we do then we're
+            #   done.
+            #
+            # - ret: the operation's return value. (Meaningless unless
+            #   finished is True.)
+            #
+            # Invariant: want_read and finished can't both be True at the
+            # same time.
+            #
+            # Now we need to move things forward. There are two things we
+            # might have to do, and any given operation might require
+            # either, both, or neither to proceed:
+            #
+            # - send the data in to_send
+            #
+            # - receive_some some data and put it into the incoming BIO
+            #
+            # Our strategy is: if there's data to send, send it;
+            # *otherwise* if there's data to receive_some, receive_some it.
+            #
+            # If both need to happen, then we only send. Why? Well, we
+            # know that *right now* we have to both send and receive_some
+            # before the operation can complete. But as soon as we yield,
+            # that information becomes potentially stale – e.g. while
+            # we're sending, some other task might go and receive_some the
+            # data we need and put it into the incoming BIO. And if it
+            # does, then we *definitely don't* want to do a receive_some –
+            # there might not be any more data coming, and we'd deadlock!
+            # We could do something tricky to keep track of whether a
+            # receive_some happens while we're sending, but the case where
+            # we have to do both is very unusual (only during a
+            # renegotation), so it's better to keep things simple. So we
+            # do just one potentially-blocking operation, then check again
+            # for fresh information.
+            #
+            # And we prioritize sending over receiving because, if there
+            # are multiple tasks that want to receive_some, then it
+            # doesn't matter what order they go in. But if there are
+            # multiple tasks that want to send, then they each have
+            # different data, and the data needs to get put onto the wire
+            # in the same order that it was retrieved from the outgoing
+            # BIO. So if we have data to send, that *needs* to be the
+            # *very* *next* *thing* we do, to make sure no-one else sneaks
+            # in before us. Or if we can't send immediately because
+            # someone else is, then we at least need to get in line
+            # immediately.
+            if to_send:
+                # NOTE: This relies on the lock being strict FIFO fair!
+                async with self._inner_send_lock:
+                    yielded = True
+                    try:
+                        await self.transport_stream.send_all(to_send)
+                    except:
+                        # Some unknown amount of our data got sent, and we
+                        # don't know how much. This stream is doomed.
+                        self._state = _State.BROKEN
+                        raise
+            elif want_read:
+                # It's possible that someone else is already blocked in
+                # transport_stream.receive_some. If so then we want to
+                # wait for them to finish, but we don't want to call
+                # transport_stream.receive_some again ourselves; we just
+                # want to loop around and check if their contribution
+                # helped anything. So we make a note of how many times
+                # some task has been through here before taking the lock,
+                # and if it's changed by the time we get the lock, then we
+                # skip calling transport_stream.receive_some and loop
+                # around immediately.
+                recv_count = self._inner_recv_count
+                async with self._inner_recv_lock:
+                    yielded = True
+                    if recv_count == self._inner_recv_count:
+                        data = await self.transport_stream.receive_some(
+                            self._max_refill_bytes
+                        )
+                        if not data:
+                            self._incoming.write_eof()
+                        else:
+                            self._incoming.write(data)
+                        self._inner_recv_count += 1
+        if not yielded:
+            await trio.hazmat.cancel_shielded_checkpoint()
+        return ret
+
+    async def _do_handshake(self):
+        try:
+            await self._retry(self._ssl_object.do_handshake)
+        except:
+            self._state = _State.BROKEN
+            raise
+
+    async def do_handshake(self):
+        """Ensure that the initial handshake has completed.
+
+        The SSL protocol requires an initial handshake to exchange
+        certificates, select cryptographic keys, and so forth, before any
+        actual data can be sent or received. You don't have to call this
+        method; if you don't, then :class:`SSLStream` will automatically
+        peform the handshake as needed, the first time you try to send or
+        receive data. But if you want to trigger it manually – for example,
+        because you want to look at the peer's certificate before you start
+        talking to them – then you can call this method.
+
+        If the initial handshake is already in progress in another task, this
+        waits for it to complete and then returns.
+
+        If the initial handshake has already completed, this returns
+        immediately without doing anything (except executing a checkpoint).
+
+        .. warning:: If this method is cancelled, then it may leave the
+           :class:`SSLStream` in an unusable state. If this happens then any
+           future attempt to use the object will raise
+           :exc:`trio.BrokenResourceError`.
+
+        """
+        self._check_status()
+        await self._handshook.ensure(checkpoint=True)
+
+    # Most things work if we don't explicitly force do_handshake to be called
+    # before calling receive_some or send_all, because openssl will
+    # automatically perform the handshake on the first SSL_{read,write}
+    # call. BUT, allowing openssl to do this will disable Python's hostname
+    # checking!!! See:
+    #   https://bugs.python.org/issue30141
+    # So we *definitely* have to make sure that do_handshake is called
+    # before doing anything else.
+    async def receive_some(self, max_bytes):
+        """Read some data from the underlying transport, decrypt it, and
+        return it.
+
+        See :meth:`trio.abc.ReceiveStream.receive_some` for details.
+
+        .. warning:: If this method is cancelled while the initial handshake
+           or a renegotiation are in progress, then it may leave the
+           :class:`SSLStream` in an unusable state. If this happens then any
+           future attempt to use the object will raise
+           :exc:`trio.BrokenResourceError`.
+
+        """
+        with self._outer_recv_conflict_detector:
+            self._check_status()
+            try:
+                await self._handshook.ensure(checkpoint=False)
+            except trio.BrokenResourceError as exc:
+                # For some reason, EOF before handshake sometimes raises
+                # SSLSyscallError instead of SSLEOFError (e.g. on my linux
+                # laptop, but not on appveyor). Thanks openssl.
+                if (
+                    self._https_compatible and isinstance(
+                        exc.__cause__,
+                        (_stdlib_ssl.SSLEOFError, _stdlib_ssl.SSLSyscallError)
+                    )
+                ):
+                    await trio.hazmat.checkpoint()
+                    return b""
+                else:
+                    raise
+            max_bytes = _operator.index(max_bytes)
+            if max_bytes < 1:
+                raise ValueError("max_bytes must be >= 1")
+            try:
+                return await self._retry(self._ssl_object.read, max_bytes)
+            except trio.BrokenResourceError as exc:
+                # This isn't quite equivalent to just returning b"" in the
+                # first place, because we still end up with self._state set to
+                # BROKEN. But that's actually fine, because after getting an
+                # EOF on TLS then the only thing you can do is close the
+                # stream, and closing doesn't care about the state.
+                if (
+                    self._https_compatible
+                    and isinstance(exc.__cause__, _stdlib_ssl.SSLEOFError)
+                ):
+                    await trio.hazmat.checkpoint()
+                    return b""
+                else:
+                    raise
+
+    async def send_all(self, data):
+        """Encrypt some data and then send it on the underlying transport.
+
+        See :meth:`trio.abc.SendStream.send_all` for details.
+
+        .. warning:: If this method is cancelled, then it may leave the
+           :class:`SSLStream` in an unusable state. If this happens then any
+           attempt to use the object will raise
+           :exc:`trio.BrokenResourceError`.
+
+        """
+        with self._outer_send_conflict_detector:
+            self._check_status()
+            await self._handshook.ensure(checkpoint=False)
+            # SSLObject interprets write(b"") as an EOF for some reason, which
+            # is not what we want.
+            if not data:
+                await trio.hazmat.checkpoint()
+                return
+            await self._retry(self._ssl_object.write, data)
+
+    async def unwrap(self):
+        """Cleanly close down the SSL/TLS encryption layer, allowing the
+        underlying stream to be used for unencrypted communication.
+
+        You almost certainly don't need this.
+
+        Returns:
+          A pair ``(transport_stream, trailing_bytes)``, where
+          ``transport_stream`` is the underlying transport stream, and
+          ``trailing_bytes`` is a byte string. Since :class:`SSLStream`
+          doesn't necessarily know where the end of the encrypted data will
+          be, it can happen that it accidentally reads too much from the
+          underlying stream. ``trailing_bytes`` contains this extra data; you
+          should process it as if it was returned from a call to
+          ``transport_stream.receive_some(...)``.
+
+        """
+        with self._outer_recv_conflict_detector, \
+                self._outer_send_conflict_detector:
+            self._check_status()
+            await self._handshook.ensure(checkpoint=False)
+            await self._retry(self._ssl_object.unwrap)
+            transport_stream = self.transport_stream
+            self.transport_stream = None
+            self._state = _State.CLOSED
+            return (transport_stream, self._incoming.read())
+
+    async def aclose(self):
+        """Gracefully shut down this connection, and close the underlying
+        transport.
+
+        If ``https_compatible`` is False (the default), then this attempts to
+        first send a ``close_notify`` and then close the underlying stream by
+        calling its :meth:`~trio.abc.AsyncResource.aclose` method.
+
+        If ``https_compatible`` is set to True, then this simply closes the
+        underlying stream and marks this stream as closed.
+
+        """
+        if self._state is _State.CLOSED:
+            await trio.hazmat.checkpoint()
+            return
+        if self._state is _State.BROKEN or self._https_compatible:
+            self._state = _State.CLOSED
+            await self.transport_stream.aclose()
+            return
+        try:
+            # https_compatible=False, so we're in spec-compliant mode and have
+            # to send close_notify so that the other side gets a cryptographic
+            # assurance that we've called aclose. Of course, we can't do
+            # anything cryptographic until after we've completed the
+            # handshake:
+            await self._handshook.ensure(checkpoint=False)
+            # Then, we call SSL_shutdown *once*, because we want to send a
+            # close_notify but *not* wait for the other side to send back a
+            # response. In principle it would be more polite to wait for the
+            # other side to reply with their own close_notify. However, if
+            # they aren't paying attention (e.g., if they're just sending
+            # data and not receiving) then we will never notice our
+            # close_notify and we'll be waiting forever. Eventually we'll time
+            # out (hopefully), but it's still kind of nasty. And we can't
+            # require the other side to always be receiving, because (a)
+            # backpressure is kind of important, and (b) I bet there are
+            # broken TLS implementations out there that don't receive all the
+            # time. (Like e.g. anyone using Python ssl in synchronous mode.)
+            #
+            # The send-then-immediately-close behavior is explicitly allowed
+            # by the TLS specs, so we're ok on that.
+            #
+            # Subtlety: SSLObject.unwrap will immediately call it a second
+            # time, and the second time will raise SSLWantReadError because
+            # there hasn't been time for the other side to respond
+            # yet. (Unless they spontaneously sent a close_notify before we
+            # called this, and it's either already been processed or gets
+            # pulled out of the buffer by Python's second call.) So the way to
+            # do what we want is to ignore SSLWantReadError on this call.
+            #
+            # Also, because the other side might have already sent
+            # close_notify and closed their connection then it's possible that
+            # our attempt to send close_notify will raise
+            # BrokenResourceError. This is totally legal, and in fact can happen
+            # with two well-behaved Trio programs talking to each other, so we
+            # don't want to raise an error. So we suppress BrokenResourceError
+            # here. (This is safe, because literally the only thing this call
+            # to _retry will do is send the close_notify alert, so that's
+            # surely where the error comes from.)
+            #
+            # FYI in some cases this could also raise SSLSyscallError which I
+            # think is because SSL_shutdown is terrible. (Check out that note
+            # at the bottom of the man page saying that it sometimes gets
+            # raised spuriously.) I haven't seen this since we switched to
+            # immediately closing the socket, and I don't know exactly what
+            # conditions cause it and how to respond, so for now we're just
+            # letting that happen. But if you start seeing it, then hopefully
+            # this will give you a little head start on tracking it down,
+            # because whoa did this puzzle us at the 2017 PyCon sprints.
+            #
+            # Also, if someone else is blocked in send/receive, then we aren't
+            # going to be able to do a clean shutdown. If that happens, we'll
+            # just do an unclean shutdown.
+            try:
+                await self._retry(
+                    self._ssl_object.unwrap, ignore_want_read=True
+                )
+            except (trio.BrokenResourceError, trio.BusyResourceError):
+                pass
+        except:
+            # Failure! Kill the stream and move on.
+            await aclose_forcefully(self.transport_stream)
+            raise
+        else:
+            # Success! Gracefully close the underlying stream.
+            await self.transport_stream.aclose()
+        finally:
+            self._state = _State.CLOSED
+
+    async def wait_send_all_might_not_block(self):
+        """See :meth:`trio.abc.SendStream.wait_send_all_might_not_block`.
+
+        """
+        # This method's implementation is deceptively simple.
+        #
+        # First, we take the outer send lock, because of Trio's standard
+        # semantics that wait_send_all_might_not_block and send_all
+        # conflict.
+        with self._outer_send_conflict_detector:
+            self._check_status()
+            # Then we take the inner send lock. We know that no other tasks
+            # are calling self.send_all or self.wait_send_all_might_not_block,
+            # because we have the outer_send_lock. But! There might be another
+            # task calling self.receive_some -> transport_stream.send_all, in
+            # which case if we were to call
+            # transport_stream.wait_send_all_might_not_block directly we'd
+            # have two tasks doing write-related operations on
+            # transport_stream simultaneously, which is not allowed. We
+            # *don't* want to raise this conflict to our caller, because it's
+            # purely an internal affair – all they did was call
+            # wait_send_all_might_not_block and receive_some at the same time,
+            # which is totally valid. And waiting for the lock is OK, because
+            # a call to send_all certainly wouldn't complete while the other
+            # task holds the lock.
+            async with self._inner_send_lock:
+                # Now we have the lock, which creates another potential
+                # problem: what if a call to self.receive_some attempts to do
+                # transport_stream.send_all now? It'll have to wait for us to
+                # finish! But that's OK, because we release the lock as soon
+                # as the underlying stream becomes writable, and the
+                # self.receive_some call wasn't going to make any progress
+                # until then anyway.
+                #
+                # Of course, this does mean we might return *before* the
+                # stream is logically writable, because immediately after we
+                # return self.receive_some might write some data and make it
+                # non-writable again. But that's OK too,
+                # wait_send_all_might_not_block only guarantees that it
+                # doesn't return late.
+                await self.transport_stream.wait_send_all_might_not_block()
+
+
+class SSLListener(Listener[SSLStream]):
+    """A :class:`~trio.abc.Listener` for SSL/TLS-encrypted servers.
+
+    :class:`SSLListener` wraps around another Listener, and converts
+    all incoming connections to encrypted connections by wrapping them
+    in a :class:`SSLStream`.
+
+    Args:
+      transport_listener (~trio.abc.Listener): The listener whose incoming
+          connections will be wrapped in :class:`SSLStream`.
+
+      ssl_context (~ssl.SSLContext): The :class:`~ssl.SSLContext` that will be
+          used for incoming connections.
+
+      https_compatible (bool): Passed on to :class:`SSLStream`.
+
+      max_refill_bytes (int): Passed on to :class:`SSLStream`.
+
+    Attributes:
+      transport_listener (trio.abc.Listener): The underlying listener that was
+          passed to ``__init__``.
+
+    """
+
+    def __init__(
+        self,
+        transport_listener,
+        ssl_context,
+        *,
+        https_compatible=False,
+        max_refill_bytes=_default_max_refill_bytes
+    ):
+        self.transport_listener = transport_listener
+        self._ssl_context = ssl_context
+        self._https_compatible = https_compatible
+        self._max_refill_bytes = max_refill_bytes
+
+    async def accept(self):
+        """Accept the next connection and wrap it in an :class:`SSLStream`.
+
+        See :meth:`trio.abc.Listener.accept` for details.
+
+        """
+        transport_stream = await self.transport_listener.accept()
+        return SSLStream(
+            transport_stream,
+            self._ssl_context,
+            server_side=True,
+            https_compatible=self._https_compatible,
+            max_refill_bytes=self._max_refill_bytes,
+        )
+
+    async def aclose(self):
+        """Close the transport listener.
+
+        """
+        await self.transport_listener.aclose()

--- a/trio/tests/test_openssl.py
+++ b/trio/tests/test_openssl.py
@@ -1,0 +1,1248 @@
+import pytest
+
+import threading
+import socket as stdlib_socket
+import ssl
+from contextlib import contextmanager
+from functools import partial
+
+from OpenSSL import SSL
+import trustme
+from async_generator import async_generator, yield_, asynccontextmanager
+
+import trio
+from .. import _core
+from .._highlevel_socket import SocketStream, SocketListener
+from .._highlevel_generic import aclose_forcefully
+from .._core import ClosedResourceError, BrokenResourceError
+from .._highlevel_open_tcp_stream import open_tcp_stream
+from .. import socket as tsocket
+from .._ssl import SSLStream, SSLListener, NeedHandshakeError
+from .._util import ConflictDetector
+
+from .._core.tests.tutil import slow
+
+from ..testing import (
+    assert_checkpoints,
+    Sequencer,
+    memory_stream_pair,
+    lockstep_stream_pair,
+    check_two_way_stream,
+)
+
+# We have two different kinds of echo server fixtures we use for testing. The
+# first is a real server written using the stdlib ssl module and blocking
+# sockets. It runs in a thread and we talk to it over a real socketpair(), to
+# validate interoperability in a semi-realistic setting.
+#
+# The second is a very weird virtual echo server that lives inside a custom
+# Stream class. It lives entirely inside the Python object space; there are no
+# operating system calls in it at all. No threads, no I/O, nothing. It's
+# 'send_all' call takes encrypted data from a client and feeds it directly into
+# the server-side TLS state engine to decrypt, then takes that data, feeds it
+# back through to get the encrypted response, and returns it from 'receive_some'. This
+# gives us full control and reproducibility. This server is written using
+# PyOpenSSL, so that we can trigger renegotiations on demand. It also allows
+# us to insert random (virtual) delays, to really exercise all the weird paths
+# in SSLStream's state engine.
+#
+# Both present a certificate for "trio-test-1.example.org".
+
+TRIO_TEST_CA = trustme.CA()
+TRIO_TEST_1_CERT = TRIO_TEST_CA.issue_server_cert("trio-test-1.example.org")
+
+SERVER_CTX = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+TRIO_TEST_1_CERT.configure_cert(SERVER_CTX)
+
+CLIENT_CTX = ssl.create_default_context()
+TRIO_TEST_CA.configure_trust(CLIENT_CTX)
+
+# Temporarily disable TLSv1.3, until the issue with openssl's session
+# ticket handling is sorted out one way or another:
+#     https://github.com/python-trio/trio/issues/819
+#     https://github.com/openssl/openssl/issues/7948
+#     https://github.com/openssl/openssl/issues/7967
+if hasattr(ssl, "OP_NO_TLSv1_3"):
+    CLIENT_CTX.options |= ssl.OP_NO_TLSv1_3
+
+
+# The blocking socket server.
+def ssl_echo_serve_sync(sock, *, expect_fail=False):
+    try:
+        wrapped = SERVER_CTX.wrap_socket(
+            sock, server_side=True, suppress_ragged_eofs=False
+        )
+        wrapped.do_handshake()
+        while True:
+            data = wrapped.recv(4096)
+            if not data:
+                # other side has initiated a graceful shutdown; we try to
+                # respond in kind but it's legal for them to have already gone
+                # away.
+                exceptions = (BrokenPipeError, ssl.SSLZeroReturnError)
+                # Under unclear conditions, CPython sometimes raises
+                # SSLWantWriteError here. This is a bug (bpo-32219), but it's
+                # not our bug, so ignore it.
+                exceptions += (ssl.SSLWantWriteError,)
+                try:
+                    wrapped.unwrap()
+                except exceptions:
+                    pass
+                return
+            wrapped.sendall(data)
+    except Exception as exc:
+        if expect_fail:
+            print("ssl_echo_serve_sync got error as expected:", exc)
+        else:  # pragma: no cover
+            print("ssl_echo_serve_sync got unexpected error:", exc)
+            raise
+    else:
+        if expect_fail:  # pragma: no cover
+            raise RuntimeError("failed to fail?")
+
+
+# Fixture that gives a raw socket connected to a trio-test-1 echo server
+# (running in a thread). Useful for testing making connections with different
+# SSLContexts.
+@asynccontextmanager
+@async_generator
+async def ssl_echo_server_raw(**kwargs):
+    a, b = stdlib_socket.socketpair()
+    async with trio.open_nursery() as nursery:
+        # Exiting the 'with a, b' context manager closes the sockets, which
+        # causes the thread to exit (possibly with an error), which allows the
+        # nursery context manager to exit too.
+        with a, b:
+            nursery.start_soon(
+                trio.run_sync_in_thread,
+                partial(ssl_echo_serve_sync, b, **kwargs)
+            )
+
+            await yield_(SocketStream(tsocket.from_stdlib_socket(a)))
+
+
+# Fixture that gives a properly set up SSLStream connected to a trio-test-1
+# echo server (running in a thread)
+@asynccontextmanager
+@async_generator
+async def ssl_echo_server(**kwargs):
+    async with ssl_echo_server_raw(**kwargs) as sock:
+        await yield_(
+            SSLStream(
+                sock, CLIENT_CTX, server_hostname="trio-test-1.example.org"
+            )
+        )
+
+
+# The weird in-memory server ... thing.
+# Doesn't inherit from Stream because I left out the methods that we don't
+# actually need.
+class PyOpenSSLEchoStream:
+    def __init__(self, sleeper=None):
+        ctx = SSL.Context(SSL.SSLv23_METHOD)
+        # TLS 1.3 removes renegotiation support. Which is great for them, but
+        # we still have to support versions before that, and that means we
+        # need to test renegotation support, which means we need to force this
+        # to use a lower version where this test server can trigger
+        # renegotiations. Of course TLS 1.3 support isn't released yet, but
+        # I'm told that this will work once it is. (And once it is we can
+        # remove the pragma: no cover too.) Alternatively, once we drop
+        # support for CPython 3.5 on macOS, then we could switch to using
+        # TLSv1_2_METHOD.
+        #
+        # Discussion: https://github.com/pyca/pyopenssl/issues/624
+        if hasattr(SSL, "OP_NO_TLSv1_3"):
+            ctx.set_options(SSL.OP_NO_TLSv1_3)
+        # Unfortunately there's currently no way to say "use 1.3 or worse", we
+        # can only disable specific versions. And if the two sides start
+        # negotiating 1.4 at some point in the future, it *might* mean that
+        # our tests silently stop working properly. So the next line is a
+        # tripwire to remind us we need to revisit this stuff in 5 years or
+        # whatever when the next TLS version is released:
+        assert not hasattr(SSL, "OP_NO_TLSv1_4")
+        TRIO_TEST_1_CERT.configure_cert(ctx)
+        self._conn = SSL.Connection(ctx, None)
+        self._conn.set_accept_state()
+        self._lot = _core.ParkingLot()
+        self._pending_cleartext = bytearray()
+
+        self._send_all_conflict_detector = ConflictDetector(
+            "simultaneous calls to PyOpenSSLEchoStream.send_all"
+        )
+        self._receive_some_conflict_detector = ConflictDetector(
+            "simultaneous calls to PyOpenSSLEchoStream.receive_some"
+        )
+
+        if sleeper is None:
+
+            async def no_op_sleeper(_):
+                return
+
+            self.sleeper = no_op_sleeper
+        else:
+            self.sleeper = sleeper
+
+    async def aclose(self):
+        self._conn.bio_shutdown()
+
+    def renegotiate_pending(self):
+        return self._conn.renegotiate_pending()
+
+    def renegotiate(self):
+        # Returns false if a renegotation is already in progress, meaning
+        # nothing happens.
+        assert self._conn.renegotiate()
+
+    async def wait_send_all_might_not_block(self):
+        with self._send_all_conflict_detector:
+            await _core.checkpoint()
+            await _core.checkpoint()
+            await self.sleeper("wait_send_all_might_not_block")
+
+    async def send_all(self, data):
+        print("  --> transport_stream.send_all")
+        with self._send_all_conflict_detector:
+            await _core.checkpoint()
+            await _core.checkpoint()
+            await self.sleeper("send_all")
+            self._conn.bio_write(data)
+            while True:
+                await self.sleeper("send_all")
+                try:
+                    data = self._conn.recv(1)
+                except SSL.ZeroReturnError:
+                    self._conn.shutdown()
+                    print("renegotiations:", self._conn.total_renegotiations())
+                    break
+                except SSL.WantReadError:
+                    break
+                else:
+                    self._pending_cleartext += data
+            self._lot.unpark_all()
+            await self.sleeper("send_all")
+            print("  <-- transport_stream.send_all finished")
+
+    async def receive_some(self, nbytes):
+        print("  --> transport_stream.receive_some")
+        with self._receive_some_conflict_detector:
+            try:
+                await _core.checkpoint()
+                await _core.checkpoint()
+                while True:
+                    await self.sleeper("receive_some")
+                    try:
+                        return self._conn.bio_read(nbytes)
+                    except SSL.WantReadError:
+                        # No data in our ciphertext buffer; try to generate
+                        # some.
+                        if self._pending_cleartext:
+                            # We have some cleartext; maybe we can encrypt it
+                            # and then return it.
+                            print("    trying", self._pending_cleartext)
+                            try:
+                                # PyOpenSSL bug: doesn't accept bytearray
+                                # https://github.com/pyca/pyopenssl/issues/621
+                                next_byte = self._pending_cleartext[0:1]
+                                self._conn.send(bytes(next_byte))
+                            # Apparently this next bit never gets hit in the
+                            # test suite, but it's not an interesting omission
+                            # so let's pragma it.
+                            except SSL.WantReadError:  # pragma: no cover
+                                # We didn't manage to send the cleartext (and
+                                # in particular we better leave it there to
+                                # try again, due to openssl's retry
+                                # semantics), but it's possible we pushed a
+                                # renegotiation forward and *now* we have data
+                                # to send.
+                                try:
+                                    return self._conn.bio_read(nbytes)
+                                except SSL.WantReadError:
+                                    # Nope. We're just going to have to wait
+                                    # for someone to call send_all() to give
+                                    # use more data.
+                                    print("parking (a)")
+                                    await self._lot.park()
+                            else:
+                                # We successfully sent that byte, so we don't
+                                # have to again.
+                                del self._pending_cleartext[0:1]
+                        else:
+                            # no pending cleartext; nothing to do but wait for
+                            # someone to call send_all
+                            print("parking (b)")
+                            await self._lot.park()
+            finally:
+                await self.sleeper("receive_some")
+                print("  <-- transport_stream.receive_some finished")
+
+
+async def test_PyOpenSSLEchoStream_gives_resource_busy_errors():
+    # Make sure that PyOpenSSLEchoStream complains if two tasks call send_all
+    # at the same time, or ditto for receive_some. The tricky cases where SSLStream
+    # might accidentally do this are during renegotation, which we test using
+    # PyOpenSSLEchoStream, so this makes sure that if we do have a bug then
+    # PyOpenSSLEchoStream will notice and complain.
+
+    s = PyOpenSSLEchoStream()
+    with pytest.raises(_core.BusyResourceError) as excinfo:
+        async with _core.open_nursery() as nursery:
+            nursery.start_soon(s.send_all, b"x")
+            nursery.start_soon(s.send_all, b"x")
+    assert "simultaneous" in str(excinfo.value)
+
+    s = PyOpenSSLEchoStream()
+    with pytest.raises(_core.BusyResourceError) as excinfo:
+        async with _core.open_nursery() as nursery:
+            nursery.start_soon(s.send_all, b"x")
+            nursery.start_soon(s.wait_send_all_might_not_block)
+    assert "simultaneous" in str(excinfo.value)
+
+    s = PyOpenSSLEchoStream()
+    with pytest.raises(_core.BusyResourceError) as excinfo:
+        async with _core.open_nursery() as nursery:
+            nursery.start_soon(s.wait_send_all_might_not_block)
+            nursery.start_soon(s.wait_send_all_might_not_block)
+    assert "simultaneous" in str(excinfo.value)
+
+    s = PyOpenSSLEchoStream()
+    with pytest.raises(_core.BusyResourceError) as excinfo:
+        async with _core.open_nursery() as nursery:
+            nursery.start_soon(s.receive_some, 1)
+            nursery.start_soon(s.receive_some, 1)
+    assert "simultaneous" in str(excinfo.value)
+
+
+@contextmanager
+def virtual_ssl_echo_server(**kwargs):
+    fakesock = PyOpenSSLEchoStream(**kwargs)
+    yield SSLStream(
+        fakesock, CLIENT_CTX, server_hostname="trio-test-1.example.org"
+    )
+
+
+def ssl_wrap_pair(
+    client_transport, server_transport, *, client_kwargs={}, server_kwargs={}
+):
+    client_ssl = SSLStream(
+        client_transport,
+        CLIENT_CTX,
+        server_hostname="trio-test-1.example.org",
+        **client_kwargs
+    )
+    server_ssl = SSLStream(
+        server_transport, SERVER_CTX, server_side=True, **server_kwargs
+    )
+    return client_ssl, server_ssl
+
+
+def ssl_memory_stream_pair(**kwargs):
+    client_transport, server_transport = memory_stream_pair()
+    return ssl_wrap_pair(client_transport, server_transport, **kwargs)
+
+
+def ssl_lockstep_stream_pair(**kwargs):
+    client_transport, server_transport = lockstep_stream_pair()
+    return ssl_wrap_pair(client_transport, server_transport, **kwargs)
+
+
+# Simple smoke test for handshake/send/receive/shutdown talking to a
+# synchronous server, plus make sure that we do the bare minimum of
+# certificate checking (even though this is really Python's responsibility)
+async def test_ssl_client_basics():
+    # Everything OK
+    async with ssl_echo_server() as s:
+        assert not s.server_side
+        await s.send_all(b"x")
+        assert await s.receive_some(1) == b"x"
+        await s.aclose()
+
+    # Didn't configure the CA file, should fail
+    async with ssl_echo_server_raw(expect_fail=True) as sock:
+        client_ctx = ssl.create_default_context()
+        s = SSLStream(
+            sock, client_ctx, server_hostname="trio-test-1.example.org"
+        )
+        assert not s.server_side
+        with pytest.raises(BrokenResourceError) as excinfo:
+            await s.send_all(b"x")
+        assert isinstance(excinfo.value.__cause__, ssl.SSLError)
+
+    # Trusted CA, but wrong host name
+    async with ssl_echo_server_raw(expect_fail=True) as sock:
+        s = SSLStream(
+            sock, CLIENT_CTX, server_hostname="trio-test-2.example.org"
+        )
+        assert not s.server_side
+        with pytest.raises(BrokenResourceError) as excinfo:
+            await s.send_all(b"x")
+        assert isinstance(excinfo.value.__cause__, ssl.CertificateError)
+
+
+async def test_ssl_server_basics():
+    a, b = stdlib_socket.socketpair()
+    with a, b:
+        server_sock = tsocket.from_stdlib_socket(b)
+        server_transport = SSLStream(
+            SocketStream(server_sock), SERVER_CTX, server_side=True
+        )
+        assert server_transport.server_side
+
+        def client():
+            client_sock = CLIENT_CTX.wrap_socket(
+                a, server_hostname="trio-test-1.example.org"
+            )
+            client_sock.sendall(b"x")
+            assert client_sock.recv(1) == b"y"
+            client_sock.sendall(b"z")
+            client_sock.unwrap()
+
+        t = threading.Thread(target=client)
+        t.start()
+
+        assert await server_transport.receive_some(1) == b"x"
+        await server_transport.send_all(b"y")
+        assert await server_transport.receive_some(1) == b"z"
+        assert await server_transport.receive_some(1) == b""
+        await server_transport.aclose()
+
+        t.join()
+
+
+async def test_attributes():
+    async with ssl_echo_server_raw(expect_fail=True) as sock:
+        good_ctx = CLIENT_CTX
+        bad_ctx = ssl.create_default_context()
+        s = SSLStream(
+            sock, good_ctx, server_hostname="trio-test-1.example.org"
+        )
+
+        assert s.transport_stream is sock
+
+        # Forwarded attribute getting
+        assert s.context is good_ctx
+        assert s.server_side == False  # noqa
+        assert s.server_hostname == "trio-test-1.example.org"
+        with pytest.raises(AttributeError):
+            s.asfdasdfsa
+
+        # __dir__
+        assert "transport_stream" in dir(s)
+        assert "context" in dir(s)
+
+        # Setting the attribute goes through to the underlying object
+
+        # most attributes on SSLObject are read-only
+        with pytest.raises(AttributeError):
+            s.server_side = True
+        with pytest.raises(AttributeError):
+            s.server_hostname = "asdf"
+
+        # but .context is *not*. Check that we forward attribute setting by
+        # making sure that after we set the bad context our handshake indeed
+        # fails:
+        s.context = bad_ctx
+        assert s.context is bad_ctx
+        with pytest.raises(BrokenResourceError) as excinfo:
+            await s.do_handshake()
+        assert isinstance(excinfo.value.__cause__, ssl.SSLError)
+
+
+# Note: this test fails horribly if we force TLS 1.2 and trigger a
+# renegotiation at the beginning (e.g. by switching to the pyopenssl
+# server). Usually the client crashes in SSLObject.write with "UNEXPECTED
+# RECORD"; sometimes we get something more exotic like a SyscallError. This is
+# odd because openssl isn't doing any syscalls, but so it goes. After lots of
+# websearching I'm pretty sure this is due to a bug in OpenSSL, where it just
+# can't reliably handle full-duplex communication combined with
+# renegotiation. Nice, eh?
+#
+#   https://rt.openssl.org/Ticket/Display.html?id=3712
+#   https://rt.openssl.org/Ticket/Display.html?id=2481
+#   http://openssl.6102.n7.nabble.com/TLS-renegotiation-failure-on-receiving-application-data-during-handshake-td48127.html
+#   https://stackoverflow.com/questions/18728355/ssl-renegotiation-with-full-duplex-socket-communication
+#
+# In some variants of this test (maybe only against the java server?) I've
+# also seen cases where our send_all blocks waiting to write, and then our receive_some
+# also blocks waiting to write, and they never wake up again. It looks like
+# some kind of deadlock. I suspect there may be an issue where we've filled up
+# the send buffers, and the remote side is trying to handle the renegotiation
+# from inside a write() call, so it has a problem: there's all this application
+# data clogging up the pipe, but it can't process and return it to the
+# application because it's in write(), and it doesn't want to buffer infinite
+# amounts of data, and... actually I guess those are the only two choices.
+#
+# NSS even documents that you shouldn't try to do a renegotiation except when
+# the connection is idle:
+#
+#   https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/SSL_functions/sslfnc.html#1061582
+#
+# I begin to see why HTTP/2 forbids renegotiation and TLS 1.3 removes it...
+
+
+async def test_full_duplex_basics():
+    CHUNKS = 30
+    CHUNK_SIZE = 32768
+    EXPECTED = CHUNKS * CHUNK_SIZE
+
+    sent = bytearray()
+    received = bytearray()
+
+    async def sender(s):
+        nonlocal sent
+        for i in range(CHUNKS):
+            print(i)
+            chunk = bytes([i] * CHUNK_SIZE)
+            sent += chunk
+            await s.send_all(chunk)
+
+    async def receiver(s):
+        nonlocal received
+        while len(received) < EXPECTED:
+            chunk = await s.receive_some(CHUNK_SIZE // 2)
+            received += chunk
+
+    async with ssl_echo_server() as s:
+        async with _core.open_nursery() as nursery:
+            nursery.start_soon(sender, s)
+            nursery.start_soon(receiver, s)
+            # And let's have some doing handshakes too, everyone
+            # simultaneously
+            nursery.start_soon(s.do_handshake)
+            nursery.start_soon(s.do_handshake)
+
+        await s.aclose()
+
+    assert len(sent) == len(received) == EXPECTED
+    assert sent == received
+
+
+async def test_renegotiation_simple():
+    with virtual_ssl_echo_server() as s:
+        await s.do_handshake()
+
+        s.transport_stream.renegotiate()
+        await s.send_all(b"a")
+        assert await s.receive_some(1) == b"a"
+
+        # Have to send some more data back and forth to make sure the
+        # renegotiation is finished before shutting down the
+        # connection... otherwise openssl raises an error. I think this is a
+        # bug in openssl but what can ya do.
+        await s.send_all(b"b")
+        assert await s.receive_some(1) == b"b"
+
+        await s.aclose()
+
+
+@slow
+async def test_renegotiation_randomized(mock_clock):
+    # The only blocking things in this function are our random sleeps, so 0 is
+    # a good threshold.
+    mock_clock.autojump_threshold = 0
+
+    import random
+    r = random.Random(0)
+
+    async def sleeper(_):
+        await trio.sleep(r.uniform(0, 10))
+
+    async def clear():
+        while s.transport_stream.renegotiate_pending():
+            with assert_checkpoints():
+                await send(b"-")
+            with assert_checkpoints():
+                await expect(b"-")
+        print("-- clear --")
+
+    async def send(byte):
+        await s.transport_stream.sleeper("outer send")
+        print("calling SSLStream.send_all", byte)
+        with assert_checkpoints():
+            await s.send_all(byte)
+
+    async def expect(expected):
+        await s.transport_stream.sleeper("expect")
+        print("calling SSLStream.receive_some, expecting", expected)
+        assert len(expected) == 1
+        with assert_checkpoints():
+            assert await s.receive_some(1) == expected
+
+    with virtual_ssl_echo_server(sleeper=sleeper) as s:
+        await s.do_handshake()
+
+        await send(b"a")
+        s.transport_stream.renegotiate()
+        await expect(b"a")
+
+        await clear()
+
+        for i in range(100):
+            b1 = bytes([i % 0xff])
+            b2 = bytes([(2 * i) % 0xff])
+            s.transport_stream.renegotiate()
+            async with _core.open_nursery() as nursery:
+                nursery.start_soon(send, b1)
+                nursery.start_soon(expect, b1)
+            async with _core.open_nursery() as nursery:
+                nursery.start_soon(expect, b2)
+                nursery.start_soon(send, b2)
+            await clear()
+
+        for i in range(100):
+            b1 = bytes([i % 0xff])
+            b2 = bytes([(2 * i) % 0xff])
+            await send(b1)
+            s.transport_stream.renegotiate()
+            await expect(b1)
+            async with _core.open_nursery() as nursery:
+                nursery.start_soon(expect, b2)
+                nursery.start_soon(send, b2)
+            await clear()
+
+    # Checking that wait_send_all_might_not_block and receive_some don't
+    # conflict:
+
+    # 1) Set up a situation where expect (receive_some) is blocked sending,
+    # and wait_send_all_might_not_block comes in.
+
+    # Our receive_some() call will get stuck when it hits send_all
+    async def sleeper_with_slow_send_all(method):
+        if method == "send_all":
+            await trio.sleep(100000)
+
+    # And our wait_send_all_might_not_block call will give it time to get
+    # stuck, and then start
+    async def sleep_then_wait_writable():
+        await trio.sleep(1000)
+        await s.wait_send_all_might_not_block()
+
+    with virtual_ssl_echo_server(sleeper=sleeper_with_slow_send_all) as s:
+        await send(b"x")
+        s.transport_stream.renegotiate()
+        async with _core.open_nursery() as nursery:
+            nursery.start_soon(expect, b"x")
+            nursery.start_soon(sleep_then_wait_writable)
+
+        await clear()
+
+        await s.aclose()
+
+    # 2) Same, but now wait_send_all_might_not_block is stuck when
+    # receive_some tries to send.
+
+    async def sleeper_with_slow_wait_writable_and_expect(method):
+        if method == "wait_send_all_might_not_block":
+            await trio.sleep(100000)
+        elif method == "expect":
+            await trio.sleep(1000)
+
+    with virtual_ssl_echo_server(
+        sleeper=sleeper_with_slow_wait_writable_and_expect
+    ) as s:
+        await send(b"x")
+        s.transport_stream.renegotiate()
+        async with _core.open_nursery() as nursery:
+            nursery.start_soon(expect, b"x")
+            nursery.start_soon(s.wait_send_all_might_not_block)
+
+        await clear()
+
+        await s.aclose()
+
+
+async def test_resource_busy_errors():
+    async def do_send_all():
+        with assert_checkpoints():
+            await s.send_all(b"x")
+
+    async def do_receive_some():
+        with assert_checkpoints():
+            await s.receive_some(1)
+
+    async def do_wait_send_all_might_not_block():
+        with assert_checkpoints():
+            await s.wait_send_all_might_not_block()
+
+    s, _ = ssl_lockstep_stream_pair()
+    with pytest.raises(_core.BusyResourceError) as excinfo:
+        async with _core.open_nursery() as nursery:
+            nursery.start_soon(do_send_all)
+            nursery.start_soon(do_send_all)
+    assert "another task" in str(excinfo.value)
+
+    s, _ = ssl_lockstep_stream_pair()
+    with pytest.raises(_core.BusyResourceError) as excinfo:
+        async with _core.open_nursery() as nursery:
+            nursery.start_soon(do_receive_some)
+            nursery.start_soon(do_receive_some)
+    assert "another task" in str(excinfo.value)
+
+    s, _ = ssl_lockstep_stream_pair()
+    with pytest.raises(_core.BusyResourceError) as excinfo:
+        async with _core.open_nursery() as nursery:
+            nursery.start_soon(do_send_all)
+            nursery.start_soon(do_wait_send_all_might_not_block)
+    assert "another task" in str(excinfo.value)
+
+    s, _ = ssl_lockstep_stream_pair()
+    with pytest.raises(_core.BusyResourceError) as excinfo:
+        async with _core.open_nursery() as nursery:
+            nursery.start_soon(do_wait_send_all_might_not_block)
+            nursery.start_soon(do_wait_send_all_might_not_block)
+    assert "another task" in str(excinfo.value)
+
+
+async def test_wait_writable_calls_underlying_wait_writable():
+    record = []
+
+    class NotAStream:
+        async def wait_send_all_might_not_block(self):
+            record.append("ok")
+
+    ctx = ssl.create_default_context()
+    s = SSLStream(NotAStream(), ctx, server_hostname="x")
+    await s.wait_send_all_might_not_block()
+    assert record == ["ok"]
+
+
+async def test_checkpoints():
+    async with ssl_echo_server() as s:
+        with assert_checkpoints():
+            await s.do_handshake()
+        with assert_checkpoints():
+            await s.do_handshake()
+        with assert_checkpoints():
+            await s.wait_send_all_might_not_block()
+        with assert_checkpoints():
+            await s.send_all(b"xxx")
+        with assert_checkpoints():
+            await s.receive_some(1)
+        # These receive_some's in theory could return immediately, because the
+        # "xxx" was sent in a single record and after the first
+        # receive_some(1) the rest are sitting inside the SSLObject's internal
+        # buffers.
+        with assert_checkpoints():
+            await s.receive_some(1)
+        with assert_checkpoints():
+            await s.receive_some(1)
+        with assert_checkpoints():
+            await s.unwrap()
+
+    async with ssl_echo_server() as s:
+        await s.do_handshake()
+        with assert_checkpoints():
+            await s.aclose()
+
+
+async def test_send_all_empty_string():
+    async with ssl_echo_server() as s:
+        await s.do_handshake()
+
+        # underlying SSLObject interprets writing b"" as indicating an EOF,
+        # for some reason. Make sure we don't inherit this.
+        with assert_checkpoints():
+            await s.send_all(b"")
+        with assert_checkpoints():
+            await s.send_all(b"")
+        await s.send_all(b"x")
+        assert await s.receive_some(1) == b"x"
+
+        await s.aclose()
+
+
+@pytest.mark.parametrize("https_compatible", [False, True])
+async def test_SSLStream_generic(https_compatible):
+    async def stream_maker():
+        return ssl_memory_stream_pair(
+            client_kwargs={"https_compatible": https_compatible},
+            server_kwargs={"https_compatible": https_compatible},
+        )
+
+    async def clogged_stream_maker():
+        client, server = ssl_lockstep_stream_pair()
+        # If we don't do handshakes up front, then we run into a problem in
+        # the following situation:
+        # - server does wait_send_all_might_not_block
+        # - client does receive_some to unclog it
+        # Then the client's receive_some will actually send some data to start
+        # the handshake, and itself get stuck.
+        async with _core.open_nursery() as nursery:
+            nursery.start_soon(client.do_handshake)
+            nursery.start_soon(server.do_handshake)
+        return client, server
+
+    await check_two_way_stream(stream_maker, clogged_stream_maker)
+
+
+async def test_unwrap():
+    client_ssl, server_ssl = ssl_memory_stream_pair()
+    client_transport = client_ssl.transport_stream
+    server_transport = server_ssl.transport_stream
+
+    seq = Sequencer()
+
+    async def client():
+        await client_ssl.do_handshake()
+        await client_ssl.send_all(b"x")
+        assert await client_ssl.receive_some(1) == b"y"
+        await client_ssl.send_all(b"z")
+
+        # After sending that, disable outgoing data from our end, to make
+        # sure the server doesn't see our EOF until after we've sent some
+        # trailing data
+        async with seq(0):
+            send_all_hook = client_transport.send_stream.send_all_hook
+            client_transport.send_stream.send_all_hook = None
+
+        assert await client_ssl.receive_some(1) == b""
+        assert client_ssl.transport_stream is client_transport
+        # We just received EOF. Unwrap the connection and send some more.
+        raw, trailing = await client_ssl.unwrap()
+        assert raw is client_transport
+        assert trailing == b""
+        assert client_ssl.transport_stream is None
+        await raw.send_all(b"trailing")
+
+        # Reconnect the streams. Now the server will receive both our shutdown
+        # acknowledgement + the trailing data in a single lump.
+        client_transport.send_stream.send_all_hook = send_all_hook
+        await client_transport.send_stream.send_all_hook()
+
+    async def server():
+        await server_ssl.do_handshake()
+        assert await server_ssl.receive_some(1) == b"x"
+        await server_ssl.send_all(b"y")
+        assert await server_ssl.receive_some(1) == b"z"
+        # Now client is blocked waiting for us to send something, but
+        # instead we close the TLS connection (with sequencer to make sure
+        # that the client won't see and automatically respond before we've had
+        # a chance to disable the client->server transport)
+        async with seq(1):
+            raw, trailing = await server_ssl.unwrap()
+        assert raw is server_transport
+        assert trailing == b"trailing"
+        assert server_ssl.transport_stream is None
+
+    async with _core.open_nursery() as nursery:
+        nursery.start_soon(client)
+        nursery.start_soon(server)
+
+
+async def test_closing_nice_case():
+    # the nice case: graceful closes all around
+
+    client_ssl, server_ssl = ssl_memory_stream_pair()
+    client_transport = client_ssl.transport_stream
+
+    # Both the handshake and the close require back-and-forth discussion, so
+    # we need to run them concurrently
+    async def client_closer():
+        with assert_checkpoints():
+            await client_ssl.aclose()
+
+    async def server_closer():
+        assert await server_ssl.receive_some(10) == b""
+        assert await server_ssl.receive_some(10) == b""
+        with assert_checkpoints():
+            await server_ssl.aclose()
+
+    async with _core.open_nursery() as nursery:
+        nursery.start_soon(client_closer)
+        nursery.start_soon(server_closer)
+
+    # closing the SSLStream also closes its transport
+    with pytest.raises(ClosedResourceError):
+        await client_transport.send_all(b"123")
+
+    # once closed, it's OK to close again
+    with assert_checkpoints():
+        await client_ssl.aclose()
+    with assert_checkpoints():
+        await client_ssl.aclose()
+
+    # Trying to send more data does not work
+    with pytest.raises(ClosedResourceError):
+        await server_ssl.send_all(b"123")
+
+    # And once the connection is has been closed *locally*, then instead of
+    # getting empty bytestrings we get a proper error
+    with pytest.raises(ClosedResourceError):
+        await client_ssl.receive_some(10) == b""
+
+    with pytest.raises(ClosedResourceError):
+        await client_ssl.unwrap()
+
+    with pytest.raises(ClosedResourceError):
+        await client_ssl.do_handshake()
+
+    # Check that a graceful close *before* handshaking gives a clean EOF on
+    # the other side
+    client_ssl, server_ssl = ssl_memory_stream_pair()
+
+    async def expect_eof_server():
+        with assert_checkpoints():
+            assert await server_ssl.receive_some(10) == b""
+        with assert_checkpoints():
+            await server_ssl.aclose()
+
+    async with _core.open_nursery() as nursery:
+        nursery.start_soon(client_ssl.aclose)
+        nursery.start_soon(expect_eof_server)
+
+
+async def test_send_all_fails_in_the_middle():
+    client, server = ssl_memory_stream_pair()
+
+    async with _core.open_nursery() as nursery:
+        nursery.start_soon(client.do_handshake)
+        nursery.start_soon(server.do_handshake)
+
+    async def bad_hook():
+        raise KeyError
+
+    client.transport_stream.send_stream.send_all_hook = bad_hook
+
+    with pytest.raises(KeyError):
+        await client.send_all(b"x")
+
+    with pytest.raises(BrokenResourceError):
+        await client.wait_send_all_might_not_block()
+
+    closed = 0
+
+    def close_hook():
+        nonlocal closed
+        closed += 1
+
+    client.transport_stream.send_stream.close_hook = close_hook
+    client.transport_stream.receive_stream.close_hook = close_hook
+    await client.aclose()
+
+    assert closed == 2
+
+
+async def test_ssl_over_ssl():
+    client_0, server_0 = memory_stream_pair()
+
+    client_1 = SSLStream(
+        client_0, CLIENT_CTX, server_hostname="trio-test-1.example.org"
+    )
+    server_1 = SSLStream(server_0, SERVER_CTX, server_side=True)
+
+    client_2 = SSLStream(
+        client_1, CLIENT_CTX, server_hostname="trio-test-1.example.org"
+    )
+    server_2 = SSLStream(server_1, SERVER_CTX, server_side=True)
+
+    async def client():
+        await client_2.send_all(b"hi")
+        assert await client_2.receive_some(10) == b"bye"
+
+    async def server():
+        assert await server_2.receive_some(10) == b"hi"
+        await server_2.send_all(b"bye")
+
+    async with _core.open_nursery() as nursery:
+        nursery.start_soon(client)
+        nursery.start_soon(server)
+
+
+async def test_ssl_bad_shutdown():
+    client, server = ssl_memory_stream_pair()
+
+    async with _core.open_nursery() as nursery:
+        nursery.start_soon(client.do_handshake)
+        nursery.start_soon(server.do_handshake)
+
+    await trio.aclose_forcefully(client)
+    # now the server sees a broken stream
+    with pytest.raises(BrokenResourceError):
+        await server.receive_some(10)
+    with pytest.raises(BrokenResourceError):
+        await server.send_all(b"x" * 10)
+
+    await server.aclose()
+
+
+async def test_ssl_bad_shutdown_but_its_ok():
+    client, server = ssl_memory_stream_pair(
+        server_kwargs={"https_compatible": True},
+        client_kwargs={"https_compatible": True}
+    )
+
+    async with _core.open_nursery() as nursery:
+        nursery.start_soon(client.do_handshake)
+        nursery.start_soon(server.do_handshake)
+
+    await trio.aclose_forcefully(client)
+    # the server sees that as a clean shutdown
+    assert await server.receive_some(10) == b""
+    with pytest.raises(BrokenResourceError):
+        await server.send_all(b"x" * 10)
+
+    await server.aclose()
+
+
+async def test_ssl_handshake_failure_during_aclose():
+    # Weird scenario: aclose() triggers an automatic handshake, and this
+    # fails. This also exercises a bit of code in aclose() that was otherwise
+    # uncovered, for re-raising exceptions after calling aclose_forcefully on
+    # the underlying transport.
+    async with ssl_echo_server_raw(expect_fail=True) as sock:
+        # Don't configure trust correctly
+        client_ctx = ssl.create_default_context()
+        s = SSLStream(
+            sock, client_ctx, server_hostname="trio-test-1.example.org"
+        )
+        # It's a little unclear here whether aclose should swallow the error
+        # or let it escape. We *do* swallow the error if it arrives when we're
+        # sending close_notify, because both sides closing the connection
+        # simultaneously is allowed. But I guess when https_compatible=False
+        # then it's bad if we can get through a whole connection with a peer
+        # that has no valid certificate, and never raise an error.
+        with pytest.raises(BrokenResourceError):
+            await s.aclose()
+
+
+async def test_ssl_only_closes_stream_once():
+    # We used to have a bug where if transport_stream.aclose() raised an
+    # error, we would call it again. This checks that that's fixed.
+    client, server = ssl_memory_stream_pair()
+
+    async with _core.open_nursery() as nursery:
+        nursery.start_soon(client.do_handshake)
+        nursery.start_soon(server.do_handshake)
+
+    client_orig_close_hook = client.transport_stream.send_stream.close_hook
+    transport_close_count = 0
+
+    def close_hook():
+        nonlocal transport_close_count
+        client_orig_close_hook()
+        transport_close_count += 1
+        raise KeyError
+
+    client.transport_stream.send_stream.close_hook = close_hook
+
+    with pytest.raises(KeyError):
+        await client.aclose()
+    assert transport_close_count == 1
+
+
+async def test_ssl_https_compatibility_disagreement():
+    client, server = ssl_memory_stream_pair(
+        server_kwargs={"https_compatible": False},
+        client_kwargs={"https_compatible": True}
+    )
+
+    async with _core.open_nursery() as nursery:
+        nursery.start_soon(client.do_handshake)
+        nursery.start_soon(server.do_handshake)
+
+    # client is in HTTPS-mode, server is not
+    # so client doing graceful_shutdown causes an error on server
+    async def receive_and_expect_error():
+        with pytest.raises(BrokenResourceError) as excinfo:
+            await server.receive_some(10)
+        assert isinstance(excinfo.value.__cause__, ssl.SSLEOFError)
+
+    async with _core.open_nursery() as nursery:
+        nursery.start_soon(client.aclose)
+        nursery.start_soon(receive_and_expect_error)
+
+
+async def test_https_mode_eof_before_handshake():
+    client, server = ssl_memory_stream_pair(
+        server_kwargs={"https_compatible": True},
+        client_kwargs={"https_compatible": True}
+    )
+
+    async def server_expect_clean_eof():
+        assert await server.receive_some(10) == b""
+
+    async with _core.open_nursery() as nursery:
+        nursery.start_soon(client.aclose)
+        nursery.start_soon(server_expect_clean_eof)
+
+
+async def test_send_error_during_handshake():
+    client, server = ssl_memory_stream_pair()
+
+    async def bad_hook():
+        raise KeyError
+
+    client.transport_stream.send_stream.send_all_hook = bad_hook
+
+    with pytest.raises(KeyError):
+        with assert_checkpoints():
+            await client.do_handshake()
+
+    with pytest.raises(BrokenResourceError):
+        with assert_checkpoints():
+            await client.do_handshake()
+
+
+async def test_receive_error_during_handshake():
+    client, server = ssl_memory_stream_pair()
+
+    async def bad_hook():
+        raise KeyError
+
+    client.transport_stream.receive_stream.receive_some_hook = bad_hook
+
+    async def client_side(cancel_scope):
+        with pytest.raises(KeyError):
+            with assert_checkpoints():
+                await client.do_handshake()
+        cancel_scope.cancel()
+
+    async with _core.open_nursery() as nursery:
+        nursery.start_soon(client_side, nursery.cancel_scope)
+        nursery.start_soon(server.do_handshake)
+
+    with pytest.raises(BrokenResourceError):
+        with assert_checkpoints():
+            await client.do_handshake()
+
+
+async def test_selected_alpn_protocol_before_handshake():
+    client, server = ssl_memory_stream_pair()
+
+    with pytest.raises(NeedHandshakeError):
+        client.selected_alpn_protocol()
+
+    with pytest.raises(NeedHandshakeError):
+        server.selected_alpn_protocol()
+
+
+async def test_selected_alpn_protocol_when_not_set():
+    # ALPN protocol still returns None when it's not ser,
+    # instead of raising an exception
+    client, server = ssl_memory_stream_pair()
+
+    async with _core.open_nursery() as nursery:
+        nursery.start_soon(client.do_handshake)
+        nursery.start_soon(server.do_handshake)
+
+    assert client.selected_alpn_protocol() is None
+    assert server.selected_alpn_protocol() is None
+
+    assert client.selected_alpn_protocol() == \
+        server.selected_alpn_protocol()
+
+
+async def test_selected_npn_protocol_before_handshake():
+    client, server = ssl_memory_stream_pair()
+
+    with pytest.raises(NeedHandshakeError):
+        client.selected_npn_protocol()
+
+    with pytest.raises(NeedHandshakeError):
+        server.selected_npn_protocol()
+
+
+async def test_selected_npn_protocol_when_not_set():
+    # NPN protocol still returns None when it's not ser,
+    # instead of raising an exception
+    client, server = ssl_memory_stream_pair()
+
+    async with _core.open_nursery() as nursery:
+        nursery.start_soon(client.do_handshake)
+        nursery.start_soon(server.do_handshake)
+
+    assert client.selected_npn_protocol() is None
+    assert server.selected_npn_protocol() is None
+
+    assert client.selected_npn_protocol() == \
+        server.selected_npn_protocol()
+
+
+async def test_get_channel_binding_before_handshake():
+    client, server = ssl_memory_stream_pair()
+
+    with pytest.raises(NeedHandshakeError):
+        client.get_channel_binding()
+
+    with pytest.raises(NeedHandshakeError):
+        server.get_channel_binding()
+
+
+async def test_get_channel_binding_after_handshake():
+    client, server = ssl_memory_stream_pair()
+
+    async with _core.open_nursery() as nursery:
+        nursery.start_soon(client.do_handshake)
+        nursery.start_soon(server.do_handshake)
+
+    assert client.get_channel_binding() is not None
+    assert server.get_channel_binding() is not None
+
+    assert client.get_channel_binding() == \
+        server.get_channel_binding()
+
+
+async def test_getpeercert():
+    # Make sure we're not affected by https://bugs.python.org/issue29334
+    client, server = ssl_memory_stream_pair()
+
+    async with _core.open_nursery() as nursery:
+        nursery.start_soon(client.do_handshake)
+        nursery.start_soon(server.do_handshake)
+
+    assert server.getpeercert() is None
+    print(client.getpeercert())
+    assert (
+        ("DNS",
+         "trio-test-1.example.org") in client.getpeercert()["subjectAltName"]
+    )
+
+
+async def test_SSLListener():
+    async def setup(**kwargs):
+        listen_sock = tsocket.socket()
+        await listen_sock.bind(("127.0.0.1", 0))
+        listen_sock.listen(1)
+        socket_listener = SocketListener(listen_sock)
+        ssl_listener = SSLListener(socket_listener, SERVER_CTX, **kwargs)
+
+        transport_client = await open_tcp_stream(*listen_sock.getsockname())
+        ssl_client = SSLStream(
+            transport_client,
+            CLIENT_CTX,
+            server_hostname="trio-test-1.example.org"
+        )
+        return listen_sock, ssl_listener, ssl_client
+
+    listen_sock, ssl_listener, ssl_client = await setup()
+
+    async with ssl_client:
+        ssl_server = await ssl_listener.accept()
+
+        async with ssl_server:
+            assert not ssl_server._https_compatible
+
+            # Make sure the connection works
+            async with _core.open_nursery() as nursery:
+                nursery.start_soon(ssl_client.do_handshake)
+                nursery.start_soon(ssl_server.do_handshake)
+
+        # Test SSLListener.aclose
+        await ssl_listener.aclose()
+        assert listen_sock.fileno() == -1
+
+    ################
+
+    # Test https_compatible and max_refill_bytes
+    _, ssl_listener, ssl_client = await setup(
+        https_compatible=True,
+        max_refill_bytes=100,
+    )
+
+    ssl_server = await ssl_listener.accept()
+
+    assert ssl_server._https_compatible
+    assert ssl_server._max_refill_bytes == 100
+
+    await aclose_forcefully(ssl_listener)
+    await aclose_forcefully(ssl_client)
+    await aclose_forcefully(ssl_server)

--- a/trio/tests/test_openssl.py
+++ b/trio/tests/test_openssl.py
@@ -417,7 +417,7 @@ async def test_ssl_server_basics():
 async def test_attributes():
     async with ssl_echo_server_raw(expect_fail=True) as sock:
         good_ctx = CLIENT_CTX
-        bad_ctx = ssl.create_default_context()
+        bad_ctx = SSL.Context(SSL.TLSv1_2_METHOD)
         s = SSLStream(
             sock, good_ctx, server_hostname="trio-test-1.example.org"
         )
@@ -426,8 +426,8 @@ async def test_attributes():
 
         # Forwarded attribute getting
         assert s.context is good_ctx
-        assert s.server_side == False  # noqa
-        assert s.server_hostname == "trio-test-1.example.org"
+        # assert s.server_side == False  # noqa
+        assert s.server_hostname == b"trio-test-1.example.org"
         with pytest.raises(AttributeError):
             s.asfdasdfsa
 
@@ -438,10 +438,11 @@ async def test_attributes():
         # Setting the attribute goes through to the underlying object
 
         # most attributes on SSLObject are read-only
-        with pytest.raises(AttributeError):
-            s.server_side = True
-        with pytest.raises(AttributeError):
-            s.server_hostname = "asdf"
+        # Not on SSL.Connection()
+        # with pytest.raises(AttributeError):
+        #     s.server_side = True
+        # with pytest.raises(AttributeError):
+        #     s.server_hostname = "asdf"
 
         # but .context is *not*. Check that we forward attribute setting by
         # making sure that after we set the bad context our handshake indeed
@@ -1195,11 +1196,11 @@ async def test_getpeercert():
         nursery.start_soon(client.do_handshake)
         nursery.start_soon(server.do_handshake)
 
-    assert server.getpeercert() is None
-    print(client.getpeercert())
+    assert server.get_peer_certificate() is None
+    print(client.get_peer_certificate())
     assert (
         ("DNS",
-         "trio-test-1.example.org") in client.getpeercert()["subjectAltName"]
+         "trio-test-1.example.org") in client.get_peer_certificate()["subjectAltName"]
     )
 
 

--- a/trio/tests/test_openssl.py
+++ b/trio/tests/test_openssl.py
@@ -1208,11 +1208,10 @@ async def test_getpeercert():
         nursery.start_soon(client.do_handshake)
         nursery.start_soon(server.do_handshake)
 
-    assert server.get_peer_certificate() is None
-    print(client.get_peer_certificate())
+    assert server.getpeercert() is None
     assert (
         ("DNS",
-         "trio-test-1.example.org") in client.get_peer_certificate()["subjectAltName"]
+         "trio-test-1.example.org") in client.getpeercert()["subjectAltName"]
     )
 
 


### PR DESCRIPTION
I would like to be able to do OCSP stapling and other SSL tricks. Tried doing a ssl -> OpenSSL.SSL replace for `asyncio` https://bitbucket.org/dholth/bioopenssl/src/default/ , am now trying the same thing for `trio`. Amazed at how much easier to read `trio` is, but haven't gotten very far with this particular change.

OpenSSL.SSL is completely low level and seems to have no examples outside of the tests. Here are some examples I found: 

- https://github.com/urllib3/urllib3/blob/master/src/urllib3/contrib/pyopenssl.py
- https://github.com/twisted/twisted/blob/twisted-16.4.1/twisted/internet/_sslverify.py#L1341