### PR TITLE
Add new trio.to_thread module for running worker threads

### DIFF
--- a/docs/source/history.rst
+++ b/docs/source/history.rst
@@ -655,7 +655,7 @@ CPython, or PyPy3 5.9+.
 Other changes
 ~~~~~~~~~~~~~
 
-* :func:`run_sync_in_thread` now has a :ref:`robust mechanism
+* ``run_sync_in_worker_thread`` now has a :ref:`robust mechanism
   for applying capacity limits to the number of concurrent threads
   <worker-thread-limiting>` (`#10
   <https://github.com/python-trio/trio/issues/170>`__, `#57

--- a/docs/source/reference-core/from-thread-example.py
+++ b/docs/source/reference-core/from-thread-example.py
@@ -23,7 +23,7 @@ async def main():
         # In a background thread, run:
         #   thread_fn(portal, receive_from_trio, send_to_trio)
         nursery.start_soon(
-            trio.run_sync_in_thread, thread_fn, receive_from_trio, send_to_trio
+            trio.to_thread.run_sync, thread_fn, receive_from_trio, send_to_trio
         )
 
         # prints "1"

--- a/docs/source/reference-hazmat.rst
+++ b/docs/source/reference-hazmat.rst
@@ -403,8 +403,8 @@ This logic is a bit convoluted, but accomplishes all of the following:
   loop outside of the ``except BlockingIOError:`` block.
 
 These functions can also be useful in other situations. For example,
-when :func:`trio.run_sync_in_thread` schedules some work to run
-in a worker thread, it blocks until the work is finished (so it's a
+when :func:`trio.to_thread.run_sync` schedules some work to run in a
+worker thread, it blocks until the work is finished (so it's a
 schedule point), but by default it doesn't allow cancellation. So to
 make sure that the call always acts as a checkpoint, it calls
 :func:`checkpoint_if_cancelled` before starting the thread.

--- a/docs/source/reference-io.rst
+++ b/docs/source/reference-io.rst
@@ -492,7 +492,7 @@ To understand why, you need to know two things.
 First, right now no mainstream operating system offers a generic,
 reliable, native API for async file or filesystem operations, so we
 have to fake it by using threads (specifically,
-:func:`run_sync_in_thread`). This is cheap but isn't free: on a
+:func:`trio.to_thread.run_sync`). This is cheap but isn't free: on a
 typical PC, dispatching to a worker thread adds something like ~100 µs
 of overhead to each operation. ("µs" is pronounced "microseconds", and
 there are 1,000,000 µs in a second. Note that all the numbers here are

--- a/newsfragments/810.removal.rst
+++ b/newsfragments/810.removal.rst
@@ -1,5 +1,5 @@
-``run_sync_in_worker_thread`` was too much of a mouthful – now it's
-just called `run_sync_in_thread` (though the old name still works with
-a deprecation warning, for now). Similarly,
-``current_default_worker_thread_limiter`` is becoming
-`current_default_thread_limiter`.
+``run_sync_in_worker_thread`` has become `trio.in_thread.run_sync`, in
+order to make it shorter, and more consistent with the new
+``trio.from_thread``. And ``current_default_worker_thread_limiter`` is
+now `trio.to_thread.current_default_thread_limiter`. (Of course the
+old names still work with a deprecation warning, for now.)

--- a/newsfragments/810.removal.rst
+++ b/newsfragments/810.removal.rst
@@ -1,4 +1,4 @@
-``run_sync_in_worker_thread`` has become `trio.in_thread.run_sync`, in
+``run_sync_in_worker_thread`` has become `trio.to_thread.run_sync`, in
 order to make it shorter, and more consistent with the new
 ``trio.from_thread``. And ``current_default_worker_thread_limiter`` is
 now `trio.to_thread.current_default_thread_limiter`. (Of course the

--- a/notes-to-self/blocking-read-hack.py
+++ b/notes-to-self/blocking-read-hack.py
@@ -29,7 +29,7 @@ async def blocking_read_with_timeout(fd, count, timeout):
         async with trio.open_nursery() as nursery:
             nursery.start_soon(kill_it_after_timeout, new_fd)
             try:
-                data = await trio.run_sync_in_thread(os.read, new_fd, count)
+                data = await trio.to_thread.run_sync(os.read, new_fd, count)
             except OSError as exc:
                 if cancel_requested and exc.errno == errno.ENOTCONN:
                     # Call was successfully cancelled. In a real version we'd

--- a/notes-to-self/thread-dispatch-bench.py
+++ b/notes-to-self/thread-dispatch-bench.py
@@ -2,7 +2,7 @@
 # minimal a fashion as possible.
 #
 # This is useful to get a sense of the *lower-bound* cost of
-# run_sync_in_thread
+# trio.to_thread.run_sync
 
 import threading
 from queue import Queue

--- a/trio/__init__.py
+++ b/trio/__init__.py
@@ -32,7 +32,6 @@ from ._sync import (
     Event, CapacityLimiter, Semaphore, Lock, StrictFIFOLock, Condition
 )
 
-from ._threads import (run_sync_in_thread, current_default_thread_limiter)
 from ._threads import BlockingTrioPortal as _BlockingTrioPortal
 
 from ._highlevel_generic import aclose_forcefully, StapledStream
@@ -67,12 +66,14 @@ from ._highlevel_ssl_helpers import (
 
 from ._deprecate import TrioDeprecationWarning
 
-# Imported by default
+# Submodules imported by default
 from . import hazmat
 from . import socket
 from . import abc
 from . import from_thread
-# Not imported by default: testing
+from . import to_thread
+# Not imported by default, but mentioned here so static analysis tools like
+# pylint will know that it exists.
 if False:
     from . import testing
 
@@ -104,13 +105,13 @@ __deprecated_attributes__ = {
         ),
     "run_sync_in_worker_thread":
         _deprecate.DeprecatedAttribute(
-            run_sync_in_thread,
+            to_thread.run_sync,
             "0.12.0",
             issue=810,
         ),
     "current_default_worker_thread_limiter":
         _deprecate.DeprecatedAttribute(
-            current_default_thread_limiter,
+            to_thread.current_default_thread_limiter,
             "0.12.0",
             issue=810,
         ),
@@ -163,6 +164,7 @@ fixup_module_metadata(hazmat.__name__, hazmat.__dict__)
 fixup_module_metadata(socket.__name__, socket.__dict__)
 fixup_module_metadata(abc.__name__, abc.__dict__)
 fixup_module_metadata(from_thread.__name__, from_thread.__dict__)
+fixup_module_metadata(to_thread.__name__, to_thread.__dict__)
 fixup_module_metadata(__name__ + ".ssl", _deprecated_ssl_reexports.__dict__)
 fixup_module_metadata(
     __name__ + ".subprocess", _deprecated_subprocess_reexports.__dict__

--- a/trio/_core/_entry_queue.py
+++ b/trio/_core/_entry_queue.py
@@ -131,10 +131,10 @@ class TrioToken:
     This object has two uses:
 
     1. It lets you re-enter the Trio run loop from external threads or signal
-       handlers. This is the low-level primitive that
-       :func:`trio.run_sync_in_thread` uses to receive results from
-       worker threads, that :func:`trio.open_signal_receiver` uses to receive
-       notifications about signals, and so forth.
+       handlers. This is the low-level primitive that :func:`trio.to_thread`
+       and `trio.from_thread` use to communicate with worker threads, that
+       `trio.open_signal_receiver` uses to receive notifications about
+       signals, and so forth.
 
     2. Each call to :func:`trio.run` has exactly one associated
        :class:`TrioToken` object, so you can use it to identify a particular

--- a/trio/_core/_traps.py
+++ b/trio/_core/_traps.py
@@ -111,7 +111,7 @@ async def wait_task_rescheduled(abort_func):
        At that point there are again two possibilities. You can simply ignore
        the cancellation altogether: wait for the operation to complete and
        then reschedule and continue as normal. (For example, this is what
-       :func:`trio.run_sync_in_thread` does if cancellation is disabled.)
+       :func:`trio.to_thread.run_sync` does if cancellation is disabled.)
        The other possibility is that the ``abort_func`` does succeed in
        cancelling the operation, but for some reason isn't able to report that
        right away. (Example: on Windows, it's possible to request that an

--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -17,7 +17,7 @@ from async_generator import async_generator
 
 from .tutil import check_sequence_matches, gc_collect_harder
 from ... import _core
-from ..._threads import run_sync_in_thread
+from ..._threads import to_thread_run_sync
 from ..._timeouts import sleep, fail_after
 from ..._util import aiter_compat
 from ...testing import (
@@ -552,7 +552,7 @@ async def test_cancel_scope_repr(mock_clock):
         scope.deadline = _core.current_time() + 10
         assert "deadline is 10.00 seconds from now" in repr(scope)
         # when not in async context, can't get the current time
-        assert "deadline" not in await run_sync_in_thread(repr, scope)
+        assert "deadline" not in await to_thread_run_sync(repr, scope)
         scope.cancel()
         assert "cancelled" in repr(scope)
     assert "exited" in repr(scope)

--- a/trio/_path.py
+++ b/trio/_path.py
@@ -58,7 +58,7 @@ def iter_wrapper_factory(cls, meth_name):
     async def wrapper(self, *args, **kwargs):
         meth = getattr(self._wrapped, meth_name)
         func = partial(meth, *args, **kwargs)
-        items = await trio.run_sync_in_thread(func)
+        items = await trio.to_thread.run_sync(func)
         return (rewrap_path(item) for item in items)
 
     return wrapper
@@ -70,7 +70,7 @@ def thread_wrapper_factory(cls, meth_name):
         args = unwrap_paths(args)
         meth = getattr(self._wrapped, meth_name)
         func = partial(meth, *args, **kwargs)
-        value = await trio.run_sync_in_thread(func)
+        value = await trio.to_thread.run_sync(func)
         return rewrap_path(value)
 
     return wrapper
@@ -83,7 +83,7 @@ def classmethod_wrapper_factory(cls, meth_name):
         args = unwrap_paths(args)
         meth = getattr(cls._wraps, meth_name)
         func = partial(meth, *args, **kwargs)
-        value = await trio.run_sync_in_thread(func)
+        value = await trio.to_thread.run_sync(func)
         return rewrap_path(value)
 
     return wrapper
@@ -145,7 +145,7 @@ class AsyncAutoWrapperType(type):
 
 class Path(metaclass=AsyncAutoWrapperType):
     """A :class:`pathlib.Path` wrapper that executes blocking methods in
-    :meth:`trio.run_sync_in_thread`.
+    :meth:`trio.to_thread.run_sync`.
 
     """
 
@@ -185,7 +185,7 @@ class Path(metaclass=AsyncAutoWrapperType):
         """
 
         func = partial(self._wrapped.open, *args, **kwargs)
-        value = await trio.run_sync_in_thread(func)
+        value = await trio.to_thread.run_sync(func)
         return trio.wrap_file(value)
 
 

--- a/trio/_socket.py
+++ b/trio/_socket.py
@@ -7,7 +7,6 @@ from functools import wraps as _wraps
 import idna as _idna
 
 import trio
-from ._threads import run_sync_in_thread
 from ._util import fspath
 from . import _core
 
@@ -179,7 +178,7 @@ async def getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
     if hr is not None:
         return await hr.getaddrinfo(host, port, family, type, proto, flags)
     else:
-        return await run_sync_in_thread(
+        return await trio.to_thread.run_sync(
             _stdlib_socket.getaddrinfo,
             host,
             port,
@@ -205,7 +204,7 @@ async def getnameinfo(sockaddr, flags):
     if hr is not None:
         return await hr.getnameinfo(sockaddr, flags)
     else:
-        return await run_sync_in_thread(
+        return await trio.to_thread.run_sync(
             _stdlib_socket.getnameinfo, sockaddr, flags, cancellable=True
         )
 
@@ -216,7 +215,7 @@ async def getprotobyname(name):
     Like :func:`socket.getprotobyname`, but async.
 
     """
-    return await run_sync_in_thread(
+    return await trio.to_thread.run_sync(
         _stdlib_socket.getprotobyname, name, cancellable=True
     )
 
@@ -464,7 +463,7 @@ class _SocketType(SocketType):
         ):
             # Use a thread for the filesystem traversal (unless it's an
             # abstract domain socket)
-            return await run_sync_in_thread(self._sock.bind, address)
+            return await trio.to_thread.run_sync(self._sock.bind, address)
         else:
             # POSIX actually says that bind can return EWOULDBLOCK and
             # complete asynchronously, like connect. But in practice AFAICT

--- a/trio/_subprocess_platform/waitid.py
+++ b/trio/_subprocess_platform/waitid.py
@@ -5,7 +5,7 @@ import sys
 
 from .. import _core, _subprocess
 from .._sync import CapacityLimiter, Event
-from .._threads import run_sync_in_thread
+from .._threads import to_thread_run_sync
 
 try:
     from os import waitid
@@ -74,7 +74,7 @@ async def _waitid_system_task(pid: int, event: Event) -> None:
     # call to trio.run is shutting down.
 
     try:
-        await run_sync_in_thread(
+        await to_thread_run_sync(
             sync_wait_reapable,
             pid,
             cancellable=True,

--- a/trio/_sync.py
+++ b/trio/_sync.py
@@ -153,9 +153,9 @@ class CapacityLimiter:
     fixed number of seats, and if they're all taken then you have to wait for
     someone to get up before you can sit down.
 
-    By default, :func:`run_sync_in_thread` uses a
+    By default, :func:`trio.to_thread.run_sync` uses a
     :class:`CapacityLimiter` to limit the number of threads running at once;
-    see :func:`current_default_thread_limiter` for details.
+    see `trio.to_thread.current_default_thread_limiter` for details.
 
     If you're familiar with semaphores, then you can think of this as a
     restricted semaphore that's specialized for one common use case, with
@@ -256,7 +256,7 @@ class CapacityLimiter:
         Args:
           borrower: A :class:`trio.hazmat.Task` or arbitrary opaque object
              used to record who is borrowing this token. This is used by
-             :func:`run_sync_in_thread` to allow threads to "hold
+             :func:`trio.to_thread.run_sync` to allow threads to "hold
              tokens", with the intention in the future of using it to `allow
              deadlock detection and other useful things
              <https://github.com/python-trio/trio/issues/182>`__

--- a/trio/_wait_for_object.py
+++ b/trio/_wait_for_object.py
@@ -32,7 +32,7 @@ async def WaitForSingleObject(obj):
     # that we can use to cancel the thread.
     cancel_handle = kernel32.CreateEventA(ffi.NULL, True, False, ffi.NULL)
     try:
-        await trio.run_sync_in_thread(
+        await trio.to_thread.run_sync(
             WaitForMultipleObjects_sync,
             handle,
             cancel_handle,

--- a/trio/from_thread.py
+++ b/trio/from_thread.py
@@ -3,4 +3,5 @@ This namespace represents special functions that can call back into Trio from
 an external thread by means of a Trio Token present in Thread Local Storage
 """
 
-from ._threads import (run_sync, run)
+from ._threads import from_thread_run as run
+from ._threads import from_thread_run_sync as run_sync

--- a/trio/tests/test_signals.py
+++ b/trio/tests/test_signals.py
@@ -55,7 +55,7 @@ async def test_catch_signals_wrong_thread():
             pass  # pragma: no cover
 
     with pytest.raises(RuntimeError):
-        await trio.run_sync_in_thread(trio.run, naughty)
+        await trio.to_thread.run_sync(trio.run, naughty)
 
 
 async def test_open_signal_receiver_conflict():

--- a/trio/tests/test_ssl.py
+++ b/trio/tests/test_ssl.py
@@ -114,7 +114,7 @@ async def ssl_echo_server_raw(**kwargs):
         # nursery context manager to exit too.
         with a, b:
             nursery.start_soon(
-                trio.run_sync_in_thread,
+                trio.to_thread.run_sync,
                 partial(ssl_echo_serve_sync, b, **kwargs)
             )
 

--- a/trio/tests/test_threads.py
+++ b/trio/tests/test_threads.py
@@ -54,7 +54,9 @@ async def test_do_in_trio_thread():
         record.append(("f", threading.current_thread()))
         raise ValueError
 
-    await check_case(from_thread_run_sync, f, ("error", ValueError), trio_token=token)
+    await check_case(
+        from_thread_run_sync, f, ("error", ValueError), trio_token=token
+    )
 
     async def f(record):
         assert not _core.currently_ki_protected()
@@ -503,7 +505,9 @@ async def test_trio_from_thread_token_kwarg():
     # Test that to_thread_run_sync and spawned trio.from_thread.run_sync() can
     # use an explicitly defined token
     def thread_fn(token):
-        callee_token = from_thread_run_sync(_core.current_trio_token, trio_token=token)
+        callee_token = from_thread_run_sync(
+            _core.current_trio_token, trio_token=token
+        )
         return callee_token
 
     caller_token = _core.current_trio_token()
@@ -521,7 +525,9 @@ async def test_from_thread_no_token():
 
 def test_run_fn_as_system_task_catched_badly_typed_token():
     with pytest.raises(RuntimeError):
-        from_thread_run_sync(_core.current_time, trio_token="Not TrioTokentype")
+        from_thread_run_sync(
+            _core.current_time, trio_token="Not TrioTokentype"
+        )
 
 
 async def test_do_in_trio_thread_from_trio_thread_legacy():

--- a/trio/tests/test_threads.py
+++ b/trio/tests/test_threads.py
@@ -7,8 +7,10 @@ import pytest
 from .. import _core
 from .. import Event, CapacityLimiter, sleep
 from ..testing import wait_all_tasks_blocked
-from .._threads import *
-from .._threads import run, run_sync  # Not in __all__, must import explicitly
+from .._threads import (
+    to_thread_run_sync, current_default_thread_limiter, from_thread_run,
+    from_thread_run_sync, BlockingTrioPortal
+)
 
 from .._core.tests.test_ki import ki_self
 from .._core.tests.tutil import slow
@@ -45,14 +47,14 @@ async def test_do_in_trio_thread():
         record.append(("f", threading.current_thread()))
         return 2
 
-    await check_case(run_sync, f, ("got", 2), trio_token=token)
+    await check_case(from_thread_run_sync, f, ("got", 2), trio_token=token)
 
     def f(record):
         assert not _core.currently_ki_protected()
         record.append(("f", threading.current_thread()))
         raise ValueError
 
-    await check_case(run_sync, f, ("error", ValueError), trio_token=token)
+    await check_case(from_thread_run_sync, f, ("error", ValueError), trio_token=token)
 
     async def f(record):
         assert not _core.currently_ki_protected()
@@ -60,7 +62,7 @@ async def test_do_in_trio_thread():
         record.append(("f", threading.current_thread()))
         return 3
 
-    await check_case(run, f, ("got", 3), trio_token=token)
+    await check_case(from_thread_run, f, ("got", 3), trio_token=token)
 
     async def f(record):
         assert not _core.currently_ki_protected()
@@ -68,18 +70,18 @@ async def test_do_in_trio_thread():
         record.append(("f", threading.current_thread()))
         raise KeyError
 
-    await check_case(run, f, ("error", KeyError), trio_token=token)
+    await check_case(from_thread_run, f, ("error", KeyError), trio_token=token)
 
 
 async def test_do_in_trio_thread_from_trio_thread():
     with pytest.raises(RuntimeError):
-        run_sync(lambda: None)  # pragma: no branch
+        from_thread_run_sync(lambda: None)  # pragma: no branch
 
     async def foo():  # pragma: no cover
         pass
 
     with pytest.raises(RuntimeError):
-        run(foo)
+        from_thread_run(foo)
 
 
 def test_run_in_trio_thread_ki():
@@ -106,12 +108,12 @@ def test_run_in_trio_thread_ki():
         def external_thread_fn():
             try:
                 print("running")
-                run_sync(trio_thread_fn, trio_token=token)
+                from_thread_run_sync(trio_thread_fn, trio_token=token)
             except KeyboardInterrupt:
                 print("ok1")
                 record.add("ok1")
             try:
-                run(trio_thread_afn, trio_token=token)
+                from_thread_run(trio_thread_afn, trio_token=token)
             except KeyboardInterrupt:
                 print("ok2")
                 record.add("ok2")
@@ -140,7 +142,7 @@ def test_await_in_trio_thread_while_main_exits():
 
     def thread_fn(token):
         try:
-            run(trio_fn, trio_token=token)
+            from_thread_run(trio_fn, trio_token=token)
         except _core.Cancelled:
             record.append("cancelled")
 
@@ -163,7 +165,7 @@ async def test_run_in_worker_thread():
     def f(x):
         return (x, threading.current_thread())
 
-    x, child_thread = await run_sync_in_thread(f, 1)
+    x, child_thread = await to_thread_run_sync(f, 1)
     assert x == 1
     assert child_thread != trio_thread
 
@@ -171,7 +173,7 @@ async def test_run_in_worker_thread():
         raise ValueError(threading.current_thread())
 
     with pytest.raises(ValueError) as excinfo:
-        await run_sync_in_thread(g)
+        await to_thread_run_sync(g)
     print(excinfo.value.args)
     assert excinfo.value.args[0] != trio_thread
 
@@ -188,7 +190,7 @@ async def test_run_in_worker_thread_cancellation():
     async def child(q, cancellable):
         record.append("start")
         try:
-            return await run_sync_in_thread(f, q, cancellable=cancellable)
+            return await to_thread_run_sync(f, q, cancellable=cancellable)
         finally:
             record.append("exit")
 
@@ -197,7 +199,7 @@ async def test_run_in_worker_thread_cancellation():
     async with _core.open_nursery() as nursery:
         nursery.start_soon(child, q, True)
         # Give it a chance to get started. (This is important because
-        # run_sync_in_thread does a checkpoint_if_cancelled before
+        # to_thread_run_sync does a checkpoint_if_cancelled before
         # blocking on the thread, and we don't want to trigger this.)
         await wait_all_tasks_blocked()
         assert record == ["start"]
@@ -246,7 +248,7 @@ def test_run_in_worker_thread_abandoned(capfd):
 
     async def main():
         async def child():
-            await run_sync_in_thread(thread_fn, cancellable=True)
+            await to_thread_run_sync(thread_fn, cancellable=True)
 
         async with _core.open_nursery() as nursery:
             nursery.start_soon(child)
@@ -275,7 +277,7 @@ async def test_run_in_worker_thread_limiter(MAX, cancel, use_default_limiter):
     # This test is a bit tricky. The goal is to make sure that if we set
     # limiter=CapacityLimiter(MAX), then in fact only MAX threads are ever
     # running at a time, even if there are more concurrent calls to
-    # run_sync_in_thread, and even if some of those are cancelled. And
+    # to_thread_run_sync, and even if some of those are cancelled. And
     # also to make sure that the default limiter actually limits.
     COUNT = 2 * MAX
     gate = threading.Event()
@@ -312,7 +314,7 @@ async def test_run_in_worker_thread_limiter(MAX, cancel, use_default_limiter):
 
         def thread_fn(cancel_scope):
             print("thread_fn start")
-            run_sync(cancel_scope.cancel, trio_token=token)
+            from_thread_run_sync(cancel_scope.cancel, trio_token=token)
             with lock:
                 state.ran += 1
                 state.running += 1
@@ -328,7 +330,7 @@ async def test_run_in_worker_thread_limiter(MAX, cancel, use_default_limiter):
 
         async def run_thread(event):
             with _core.CancelScope() as cancel_scope:
-                await run_sync_in_thread(
+                await to_thread_run_sync(
                     thread_fn,
                     cancel_scope,
                     limiter=limiter_arg,
@@ -395,7 +397,7 @@ async def test_run_in_worker_thread_custom_limiter():
             record.append("release")
             assert borrower == self._borrower
 
-    await run_sync_in_thread(lambda: None, limiter=CustomLimiter())
+    await to_thread_run_sync(lambda: None, limiter=CustomLimiter())
     assert record == ["acquire", "release"]
 
 
@@ -413,7 +415,7 @@ async def test_run_in_worker_thread_limiter_error():
     bs = BadCapacityLimiter()
 
     with pytest.raises(ValueError) as excinfo:
-        await run_sync_in_thread(lambda: None, limiter=bs)
+        await to_thread_run_sync(lambda: None, limiter=bs)
     assert excinfo.value.__context__ is None
     assert record == ["acquire", "release"]
     record = []
@@ -422,7 +424,7 @@ async def test_run_in_worker_thread_limiter_error():
     # chains with it
     d = {}
     with pytest.raises(ValueError) as excinfo:
-        await run_sync_in_thread(lambda: d["x"], limiter=bs)
+        await to_thread_run_sync(lambda: d["x"], limiter=bs)
     assert isinstance(excinfo.value.__context__, KeyError)
     assert record == ["acquire", "release"]
 
@@ -439,37 +441,37 @@ async def test_run_in_worker_thread_fail_to_spawn(monkeypatch):
 
     # We get an appropriate error, and the limiter is cleanly released
     with pytest.raises(RuntimeError) as excinfo:
-        await run_sync_in_thread(lambda: None)  # pragma: no cover
+        await to_thread_run_sync(lambda: None)  # pragma: no cover
     assert "engines" in str(excinfo.value)
 
     assert limiter.borrowed_tokens == 0
 
 
-async def test_trio_run_sync_in_thread_token():
-    # Test that run_sync_in_thread automatically injects the current trio token
+async def test_trio_to_thread_run_sync_token():
+    # Test that to_thread_run_sync automatically injects the current trio token
     # into a spawned thread
     def thread_fn():
-        callee_token = run_sync(_core.current_trio_token)
+        callee_token = from_thread_run_sync(_core.current_trio_token)
         return callee_token
 
     caller_token = _core.current_trio_token()
-    callee_token = await run_sync_in_thread(thread_fn)
+    callee_token = await to_thread_run_sync(thread_fn)
     assert callee_token == caller_token
 
 
 async def test_trio_from_thread_run_sync():
-    # Test that run_sync_in_thread correctly "hands off" the trio token to
+    # Test that to_thread_run_sync correctly "hands off" the trio token to
     # trio.from_thread.run_sync()
     def thread_fn():
-        trio_time = run_sync(_core.current_time)
+        trio_time = from_thread_run_sync(_core.current_time)
         return trio_time
 
-    trio_time = await run_sync_in_thread(thread_fn)
+    trio_time = await to_thread_run_sync(thread_fn)
     assert isinstance(trio_time, float)
 
 
 async def test_trio_from_thread_run():
-    # Test that run_sync_in_thread correctly "hands off" the trio token to
+    # Test that to_thread_run_sync correctly "hands off" the trio token to
     # trio.from_thread.run()
     record = []
 
@@ -479,33 +481,33 @@ async def test_trio_from_thread_run():
 
     def thread_fn():
         record.append("in thread")
-        run(back_in_trio_fn)
+        from_thread_run(back_in_trio_fn)
 
-    await run_sync_in_thread(thread_fn)
+    await to_thread_run_sync(thread_fn)
     assert record == ["in thread", "back in trio"]
 
 
 async def test_trio_from_thread_token():
-    # Test that run_sync_in_thread and spawned trio.from_thread.run_sync()
+    # Test that to_thread_run_sync and spawned trio.from_thread.run_sync()
     # share the same Trio token
     def thread_fn():
-        callee_token = run_sync(_core.current_trio_token)
+        callee_token = from_thread_run_sync(_core.current_trio_token)
         return callee_token
 
     caller_token = _core.current_trio_token()
-    callee_token = await run_sync_in_thread(thread_fn)
+    callee_token = await to_thread_run_sync(thread_fn)
     assert callee_token == caller_token
 
 
 async def test_trio_from_thread_token_kwarg():
-    # Test that run_sync_in_thread and spawned trio.from_thread.run_sync() can
+    # Test that to_thread_run_sync and spawned trio.from_thread.run_sync() can
     # use an explicitly defined token
     def thread_fn(token):
-        callee_token = run_sync(_core.current_trio_token, trio_token=token)
+        callee_token = from_thread_run_sync(_core.current_trio_token, trio_token=token)
         return callee_token
 
     caller_token = _core.current_trio_token()
-    callee_token = await run_sync_in_thread(thread_fn, caller_token)
+    callee_token = await to_thread_run_sync(thread_fn, caller_token)
     assert callee_token == caller_token
 
 
@@ -514,12 +516,12 @@ async def test_from_thread_no_token():
     # has been provided
 
     with pytest.raises(RuntimeError):
-        run_sync(_core.current_time)
+        from_thread_run_sync(_core.current_time)
 
 
 def test_run_fn_as_system_task_catched_badly_typed_token():
     with pytest.raises(RuntimeError):
-        run_sync(_core.current_time, trio_token="Not TrioTokentype")
+        from_thread_run_sync(_core.current_time, trio_token="Not TrioTokentype")
 
 
 async def test_do_in_trio_thread_from_trio_thread_legacy():
@@ -550,5 +552,5 @@ async def test_BlockingTrioPortal_with_explicit_TrioToken():
         portal = BlockingTrioPortal(token)
         return portal.run_sync(threading.current_thread)
 
-    t = await run_sync_in_thread(worker_thread, token)
+    t = await to_thread_run_sync(worker_thread, token)
     assert t == threading.current_thread()

--- a/trio/tests/test_util.py
+++ b/trio/tests/test_util.py
@@ -5,8 +5,8 @@ import sys
 
 import pytest
 
+import trio
 from .. import _core
-from trio import run_sync_in_thread
 from .._util import (
     signal_raise, ConflictDetector, fspath, is_main_thread, generic_function,
     Final, NoPublicConstructor
@@ -160,7 +160,7 @@ async def test_is_main_thread():
     def not_main_thread():
         assert not is_main_thread()
 
-    await run_sync_in_thread(not_main_thread)
+    await trio.to_thread.run_sync(not_main_thread)
 
 
 def test_generic_function():

--- a/trio/tests/test_wait_for_object.py
+++ b/trio/tests/test_wait_for_object.py
@@ -97,7 +97,8 @@ async def test_WaitForMultipleObjects_sync_slow():
     t0 = _core.current_time()
     async with _core.open_nursery() as nursery:
         nursery.start_soon(
-            trio.to_thread.run_sync, WaitForMultipleObjects_sync, handle1, handle2
+            trio.to_thread.run_sync, WaitForMultipleObjects_sync, handle1,
+            handle2
         )
         await _timeouts.sleep(TIMEOUT)
         kernel32.SetEvent(handle1)
@@ -113,7 +114,8 @@ async def test_WaitForMultipleObjects_sync_slow():
     t0 = _core.current_time()
     async with _core.open_nursery() as nursery:
         nursery.start_soon(
-            trio.to_thread.run_sync, WaitForMultipleObjects_sync, handle1, handle2
+            trio.to_thread.run_sync, WaitForMultipleObjects_sync, handle1,
+            handle2
         )
         await _timeouts.sleep(TIMEOUT)
         kernel32.SetEvent(handle2)

--- a/trio/tests/test_wait_for_object.py
+++ b/trio/tests/test_wait_for_object.py
@@ -7,12 +7,12 @@ on_windows = (os.name == "nt")
 pytestmark = pytest.mark.skipif(not on_windows, reason="windows only")
 
 from .._core.tests.tutil import slow
+import trio
 from .. import _core
 from .. import _timeouts
 if on_windows:
     from .._core._windows_cffi import ffi, kernel32
     from .._wait_for_object import WaitForSingleObject, WaitForMultipleObjects_sync
-    from trio import run_sync_in_thread
 
 
 async def test_WaitForMultipleObjects_sync():
@@ -80,7 +80,7 @@ async def test_WaitForMultipleObjects_sync_slow():
     t0 = _core.current_time()
     async with _core.open_nursery() as nursery:
         nursery.start_soon(
-            run_sync_in_thread, WaitForMultipleObjects_sync, handle1
+            trio.to_thread.run_sync, WaitForMultipleObjects_sync, handle1
         )
         await _timeouts.sleep(TIMEOUT)
         # If we would comment the line below, the above thread will be stuck,
@@ -97,7 +97,7 @@ async def test_WaitForMultipleObjects_sync_slow():
     t0 = _core.current_time()
     async with _core.open_nursery() as nursery:
         nursery.start_soon(
-            run_sync_in_thread, WaitForMultipleObjects_sync, handle1, handle2
+            trio.to_thread.run_sync, WaitForMultipleObjects_sync, handle1, handle2
         )
         await _timeouts.sleep(TIMEOUT)
         kernel32.SetEvent(handle1)
@@ -113,7 +113,7 @@ async def test_WaitForMultipleObjects_sync_slow():
     t0 = _core.current_time()
     async with _core.open_nursery() as nursery:
         nursery.start_soon(
-            run_sync_in_thread, WaitForMultipleObjects_sync, handle1, handle2
+            trio.to_thread.run_sync, WaitForMultipleObjects_sync, handle1, handle2
         )
         await _timeouts.sleep(TIMEOUT)
         kernel32.SetEvent(handle2)

--- a/trio/to_thread.py
+++ b/trio/to_thread.py
@@ -1,0 +1,2 @@
+from ._threads import to_thread_run_sync as run_sync
+from ._threads import current_default_thread_limiter


### PR DESCRIPTION
For consistency with trio.from_thread, and to give us a place for
future extensions, like utilities for pushing context managers into
threads.

See gh-810.