### PR TITLE
Put BlockingTrioPortal back where it's supposed to be.

### DIFF
--- a/docs/source/history.rst
+++ b/docs/source/history.rst
@@ -21,6 +21,14 @@ Features
   `~trio.abc.ReceiveStream.receive_some`; you can ``await
   stream.receive_some()`` with no arguments, and the stream will
   automatically pick a reasonable size for you. (`#959 <https://github.com/python-trio/trio/issues/959>`__)
+- Threading interfaces have been reworked:
+  ``run_sync_in_worker_thread`` is now `trio.to_thread.run_sync`, and
+  instead of ``BlockingTrioPortal``, use `trio.from_thread.run` and
+  `trio.from_thread.run_sync`. What's neat about this is that these
+  cooperate, so if you're in a thread created by `to_thread.run_sync`,
+  it remembers which Trio created it, and you can call
+  ``trio.from_thread.*`` directly without having to pass around a
+  ``BlockingTrioPortal`` object everywhere. (`#810 <https://github.com/python-trio/trio/issues/810>`__)
 - We cleaned up the distinction between the "abstract channel interface"
   and the "memory channel" concrete implementation.
   `trio.abc.SendChannel` and `trio.abc.ReceiveChannel` have been slimmed
@@ -86,11 +94,15 @@ Deprecations and Removals
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - The ``clear`` method on `trio.Event` has been deprecated. (`#637 <https://github.com/python-trio/trio/issues/637>`__)
-- ``run_sync_in_worker_thread`` has become `trio.to_thread.run_sync`, in
-  order to make it shorter, and more consistent with the new
-  ``trio.from_thread``. And ``current_default_worker_thread_limiter`` is
-  now `trio.to_thread.current_default_thread_limiter`. (Of course the
-  old names still work with a deprecation warning, for now.) (`#810 <https://github.com/python-trio/trio/issues/810>`__)
+- ``BlockingTrioPortal`` has been deprecated in favor of the new
+  `trio.from_thread`.  (`#810
+  <https://github.com/python-trio/trio/issues/810>`__)
+- ``run_sync_in_worker_thread`` is deprecated in favor of
+  `trio.to_thread.run_sync`.  (`#810
+  <https://github.com/python-trio/trio/issues/810>`__)
+- ``current_default_worker_thread_limiter`` is deprecated in favor of
+  `trio.to_thread.current_default_thread_limiter`. (`#810
+  <https://github.com/python-trio/trio/issues/810>`__)
 - Give up on trying to have different low-level waiting APIs on Unix and
   Windows. All platforms now have `trio.hazmat.wait_readable`,
   `trio.hazmat.wait_writable`, and `trio.hazmat.notify_closing`. The old

--- a/newsfragments/1167.bugfix.rst
+++ b/newsfragments/1167.bugfix.rst
@@ -1,0 +1,3 @@
+In v0.12.0, we accidentally moved ``BlockingTrioPortal`` from ``trio``
+to ``trio.hazmat``. It's now been restored to its proper position.
+(It's still deprecated though, and will issue a warning if you use it.)

--- a/trio/__init__.py
+++ b/trio/__init__.py
@@ -115,6 +115,13 @@ __deprecated_attributes__ = {
             "0.12.0",
             issue=810,
         ),
+    "BlockingTrioPortal":
+        _deprecate.DeprecatedAttribute(
+            _BlockingTrioPortal,
+            "0.12.0",
+            issue=810,
+            instead=from_thread,
+        ),
 }
 
 _deprecate.enable_attribute_deprecations(hazmat.__name__)
@@ -142,13 +149,6 @@ hazmat.__deprecated_attributes__ = {
             hazmat.notify_closing,
             "0.12.0",
             issue=878,
-        ),
-    "BlockingTrioPortal":
-        _deprecate.DeprecatedAttribute(
-            _BlockingTrioPortal,
-            "0.12.0",
-            issue=810,
-            instead=from_thread,
         ),
 }
 

--- a/trio/tests/test_threads.py
+++ b/trio/tests/test_threads.py
@@ -560,3 +560,9 @@ async def test_BlockingTrioPortal_with_explicit_TrioToken():
 
     t = await to_thread_run_sync(worker_thread, token)
     assert t == threading.current_thread()
+
+
+def test_BlockingTrioPortal_deprecated_export(recwarn):
+    import trio
+    btp = trio.BlockingTrioPortal
+    assert btp is BlockingTrioPortal


### PR DESCRIPTION
When it was deprecated in gh-1122, it accidentally got moved into
trio.hazmat.

Fixes: gh-1167