### PR TITLE
Prevent uncancelled scopes from catching Cancelled exceptions

### DIFF
--- a/newsfragments/1175.bugfix.rst
+++ b/newsfragments/1175.bugfix.rst
@@ -1,0 +1,4 @@
+It is no longer possible for a cancel scope that isn't cancelled to
+catch a propagating :exc:`trio.Cancelled` exception, even if you
+change shielding while a :exc:`trio.Cancelled` exception is propagating.
+(This fixes a regression introduced with the cancellation changes in 0.12.)

--- a/newsfragments/1175.bugfix.rst
+++ b/newsfragments/1175.bugfix.rst
@@ -1,4 +1,4 @@
-It is no longer possible for a cancel scope that isn't cancelled to
-catch a propagating :exc:`trio.Cancelled` exception, even if you
-change shielding while a :exc:`trio.Cancelled` exception is propagating.
-(This fixes a regression introduced with the cancellation changes in 0.12.)
+Fix regression introduced with cancellation changes in 0.12.0, where a
+`trio.CancelScope` which isn't cancelled could catch a propagating
+`trio.Cancelled` exception if shielding were changed while the
+cancellation was propagating.

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -426,7 +426,7 @@ class CancelScope(metaclass=Final):
         else:
             scope_task._activate_cancel_status(self._cancel_status.parent)
         if (
-            exc is not None
+            exc is not None and self._cancel_status.effectively_cancelled
             and not self._cancel_status.parent_cancellation_is_visible_to_us
         ):
             exc = MultiError.filter(self._exc_filter, exc)


### PR DESCRIPTION
This could happen in practice if a `finally:` block set an inner scope to be
shielded while a cancellation targeting the outer scope was propagating.
(Or if a user used private APIs to raise `Cancelled` directly themselves,
which is how it was first discovered.)

Fixes #1175.