### PR TITLE
Fix __name__ and __qualname__ of trio.to_thread.run_sync

### DIFF
--- a/newsfragments/810.bugfix.rst
+++ b/newsfragments/810.bugfix.rst
@@ -1,0 +1,3 @@
+In 0.12.0 we deprecated ``trio.run_sync_in_worker_thread`` in favor of
+`trio.to_thread.run_sync`. But, the deprecation message listed the
+wrong name for the replacement. The message now gives the correct name.

--- a/trio/tests/test_util.py
+++ b/trio/tests/test_util.py
@@ -81,6 +81,7 @@ def test_module_metadata_is_fixed_up():
     assert trio.to_thread.run_sync.__name__ == "run_sync"
     assert trio.to_thread.run_sync.__qualname__ == "run_sync"
 
+
 # define a concrete class implementing the PathLike protocol
 # Since we want to have compatibility with Python 3.5 we need
 # to define the base class on runtime.

--- a/trio/tests/test_util.py
+++ b/trio/tests/test_util.py
@@ -72,6 +72,14 @@ def test_module_metadata_is_fixed_up():
     assert trio.hazmat.ParkingLot.__init__.__module__ == "trio.hazmat"
     assert trio.abc.Stream.send_all.__module__ == "trio.abc"
 
+    # And names
+    assert trio.Cancelled.__name__ == "Cancelled"
+    assert trio.Cancelled.__qualname__ == "Cancelled"
+    assert trio.abc.SendStream.send_all.__name__ == "send_all"
+    assert trio.abc.SendStream.send_all.__qualname__ == "SendStream.send_all"
+    assert trio.to_thread.__name__ == "trio.to_thread"
+    assert trio.to_thread.run_sync.__name__ == "run_sync"
+    assert trio.to_thread.run_sync.__qualname__ == "run_sync"
 
 # define a concrete class implementing the PathLike protocol
 # Since we want to have compatibility with Python 3.5 we need


### PR DESCRIPTION
In particular, this fixes the deprecation warning for
trio.run_sync_in_worker_thread.