### PR TITLE
Make send_eof a standard part of the Stream interface

### DIFF
--- a/docs/source/reference-io.rst
+++ b/docs/source/reference-io.rst
@@ -102,14 +102,9 @@ Abstract base classes
      - :class:`~trio.testing.MemoryReceiveStream`
    * - :class:`Stream`
      - :class:`SendStream`, :class:`ReceiveStream`
+     - `~Stream.send_eof`
      -
-     -
-     - :class:`~trio.SSLStream`
-   * - :class:`HalfCloseableStream`
-     - :class:`Stream`
-     - :meth:`~HalfCloseableStream.send_eof`
-     -
-     - :class:`~trio.SocketStream`, :class:`~trio.StapledStream`
+     - `~trio.SocketStream`, `~trio.StapledStream`, `~trio.SSLStream`
    * - :class:`Listener`
      - :class:`AsyncResource`
      - :meth:`~Listener.accept`
@@ -149,10 +144,6 @@ Abstract base classes
    :show-inheritance:
 
 .. autoclass:: trio.abc.Stream
-   :members:
-   :show-inheritance:
-
-.. autoclass:: trio.abc.HalfCloseableStream
    :members:
    :show-inheritance:
 

--- a/docs/source/reference-testing.rst
+++ b/docs/source/reference-testing.rst
@@ -164,8 +164,6 @@ implementations:
 
 .. autofunction:: check_two_way_stream
 
-.. autofunction:: check_half_closeable_stream
-
 
 .. _virtual-network-hooks:
 

--- a/newsfragments/1180.bugfix.rst
+++ b/newsfragments/1180.bugfix.rst
@@ -1,0 +1,5 @@
+Normally, if you try to call two stream send methods at the same time,
+then you're supposed to get a `BusyResourceError`. But
+`StapledStream.send_eof` had a subtle bug, where it could sometimes
+interrupt the other call to make it raise `ClosedResourceError`. This
+has now been fixed.

--- a/newsfragments/823.feature.rst
+++ b/newsfragments/823.feature.rst
@@ -1,0 +1,4 @@
+The `trio.abc.Stream` interface now includes
+`~trio.abc.Stream.send_eof` as a standard feature, rather than
+relegating it to the ``HalfCloseableStream`` sub-interface. And
+`trio.SSLStream` now supports ``send_eof`` on TLS 1.3 connections.

--- a/newsfragments/823.removal.rst
+++ b/newsfragments/823.removal.rst
@@ -1,0 +1,5 @@
+``trio.abc.HalfCloseableStream`` has been deprecated, since its
+functionality was merged into `trio.abc.Stream`. And
+``trio.testing.check_half_closeable_stream`` has been deprecated,
+since its functionality was merged into
+`trio.testing.check_two_way_stream`.

--- a/trio/__init__.py
+++ b/trio/__init__.py
@@ -152,6 +152,16 @@ hazmat.__deprecated_attributes__ = {
         ),
 }
 
+_deprecate.enable_attribute_deprecations(abc.__name__)
+abc.__deprecated_attributes__ = {
+    "HalfCloseableStream":
+        _deprecate.DeprecatedAttribute(
+            abc.Stream,
+            "0.13.0",
+            issue=823,
+        ),
+}
+
 # Having the public path in .__module__ attributes is important for:
 # - exception names in printed tracebacks
 # - sphinx :show-inheritance:

--- a/trio/_highlevel_socket.py
+++ b/trio/_highlevel_socket.py
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 import trio
 from . import socket as tsocket
 from ._util import ConflictDetector
-from .abc import HalfCloseableStream, Listener
+from .abc import Stream, Listener
 
 __all__ = ["SocketStream", "SocketListener"]
 
@@ -39,9 +39,9 @@ def _translate_socket_errors_to_stream_errors():
             ) from exc
 
 
-class SocketStream(HalfCloseableStream):
-    """An implementation of the :class:`trio.abc.HalfCloseableStream`
-    interface based on a raw network socket.
+class SocketStream(Stream):
+    """An implementation of the `trio.abc.Stream` interface based on a raw
+    network socket.
 
     Args:
       socket: The Trio socket object to wrap. Must have type ``SOCK_STREAM``,
@@ -53,9 +53,9 @@ class SocketStream(HalfCloseableStream):
     <https://github.com/python-trio/trio/issues/72>`__ for discussion. You can
     of course override these defaults by calling :meth:`setsockopt`.
 
-    Once a :class:`SocketStream` object is constructed, it implements the full
-    :class:`trio.abc.HalfCloseableStream` interface. In addition, it provides
-    a few extra features:
+    Once a `SocketStream` object is constructed, it implements the full
+    `trio.abc.Stream` interface. In addition, it provides a few extra
+    features:
 
     .. attribute:: socket
 
@@ -147,7 +147,7 @@ class SocketStream(HalfCloseableStream):
         self.socket.close()
         await trio.hazmat.checkpoint()
 
-    # __aenter__, __aexit__ inherited from HalfCloseableStream are OK
+    # __aenter__, __aexit__ inherited from Stream are OK
 
     def setsockopt(self, level, option, value):
         """Set an option on the underlying socket.

--- a/trio/_unix_pipes.py
+++ b/trio/_unix_pipes.py
@@ -99,6 +99,9 @@ class FdStream(Stream):
     `issue #174 <https://github.com/python-trio/trio/issues/174>`__ for a
     discussion of the challenges involved in relaxing this restriction.
 
+    The Unix file descriptor API does not provide any generic way to perform a
+    half-close, so ``FdStream.send_eof`` always raises `NotImplementedError`.
+
     Args:
       fd (int): The fd to be wrapped.
 
@@ -178,6 +181,9 @@ class FdStream(Stream):
                     break
 
             return data
+
+    async def send_eof(self):
+        raise NotImplementedError
 
     async def aclose(self):
         await self._fd_holder.aclose()

--- a/trio/abc.py
+++ b/trio/abc.py
@@ -6,6 +6,6 @@
 # here.
 from ._abc import (
     Clock, Instrument, AsyncResource, SendStream, ReceiveStream, Stream,
-    HalfCloseableStream, SocketFactory, HostnameResolver, Listener,
-    SendChannel, ReceiveChannel, Channel
+    SocketFactory, HostnameResolver, Listener, SendChannel, ReceiveChannel,
+    Channel
 )

--- a/trio/tests/test_highlevel_socket.py
+++ b/trio/tests/test_highlevel_socket.py
@@ -6,7 +6,7 @@ import errno
 
 from .. import _core
 from ..testing import (
-    check_half_closeable_stream, wait_all_tasks_blocked, assert_checkpoints
+    check_two_way_stream, wait_all_tasks_blocked, assert_checkpoints
 )
 from .._highlevel_socket import *
 from .. import socket as tsocket
@@ -130,7 +130,7 @@ async def test_SocketStream_generic():
         await fill_stream(right)
         return left, right
 
-    await check_half_closeable_stream(stream_maker, clogged_stream_maker)
+    await check_two_way_stream(stream_maker, clogged_stream_maker)
 
 
 async def test_SocketListener():

--- a/trio/tests/test_testing.py
+++ b/trio/tests/test_testing.py
@@ -782,10 +782,10 @@ async def test_memory_streams_with_generic_tests():
 
     await check_one_way_stream(one_way_stream_maker, None)
 
-    async def half_closeable_stream_maker():
+    async def two_way_stream_maker():
         return memory_stream_pair()
 
-    await check_half_closeable_stream(half_closeable_stream_maker, None)
+    await check_two_way_stream(two_way_stream_maker, None)
 
 
 async def test_lockstep_streams_with_generic_tests():


### PR DESCRIPTION
The only reason HalfCloseableStream existed as a separate interface
was because SSLStream couldn't support send_eof. But TLS 1.3 made it
possible to support send_eof! So now the static split doesn't make
sense. Instead, we move send_eof into the Stream interface (though it
can still fail at runtime with NotImplementedError), and get rid of
HalfCloseableStream. (Fixes: gh-823.)

This also includes a fix for StapledStream.send_eof, that was revealed
by the new enhanced check_two_way_stream. (Fixes: gh-1180).