### PR TITLE
Use finally instead of reraising the exception.

### DIFF
--- a/trio/_threads.py
+++ b/trio/_threads.py
@@ -296,9 +296,8 @@ async def to_thread_run_sync(sync_fn, *args, cancellable=False, limiter=None):
             daemon=True
         )
         thread.start()
-    except:
+    finally:
         limiter.release_on_behalf_of(placeholder)
-        raise
 
     def abort(_):
         if cancellable:


### PR DESCRIPTION
If an exception was raised during the initialization of the thread we don't have to reraise it.
We just have to cleanup afterwards.
The exception will be raised anyway.