### PR TITLE
Ensure MockClock autojump never feed jump with negative values

### DIFF
--- a/newsfragments/1190.bugfix.rst
+++ b/newsfragments/1190.bugfix.rst
@@ -1,0 +1,2 @@
+Fix a crash that could happen when using ``MockClock`` with autojump
+enabled and a non-zero rate.

--- a/trio/testing/_mock_clock.py
+++ b/trio/testing/_mock_clock.py
@@ -148,7 +148,7 @@ class MockClock(Clock):
                     )
                     statistics = _core.current_statistics()
                     jump = statistics.seconds_to_next_deadline
-                    if jump < inf:
+                    if 0 < jump < inf:
                         self.jump(jump)
                     else:
                         # There are no deadlines, nothing is going to happen


### PR DESCRIPTION
Fixes: #1190 