### PR TITLE
docs: migrate to v2 Read the Docs format

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,10 +1,11 @@
-# https://docs.readthedocs.io/en/latest/yaml-config.html
+# https://docs.readthedocs.io/en/latest/config-file/index.html
+version: 2
+
 formats:
   - htmlzip
   - epub
 
-requirements_file: docs-requirements.txt
-
 python:
-  version: 3.5
-  pip_install: True
+  version: 3.7
+  install:
+    - requirements: docs-requirements.txt


### PR DESCRIPTION
Closes #1030

You can see the build here: https://readthedocs.org/projects/trio-pquentin/builds/9737603/result and the result here: https://trio-pquentin.readthedocs.io/en/rtd-v2-format/ (nothing changes!).