### PR TITLE
Improve Wide Table Handling in Docs

### DIFF
--- a/docs/source/_static/hackrtd.css
+++ b/docs/source/_static/hackrtd.css
@@ -110,3 +110,27 @@ a.trio-help-hint, .trio-help-hint a:link, .trio-help-hint a:visited {
     text-decoration: none;
     border-bottom: 1px solid;
 }
+
+/* override table width restrictions */
+@media screen and (min-width: 767px) {
+
+   .wy-table-responsive table td {
+      /* !important prevents the common CSS stylesheets from overriding
+         this as on RTD they are loaded after this stylesheet */
+      white-space: normal !important;
+   }
+
+   .wy-table-responsive table th {
+      /* This is a trio specific override since we have long header names compared to other projects who've had issues
+         with wide tables (allowing wrapping just in the cells isn't enough to shrink tables meaningfully).
+         */
+      white-space: normal !important;
+   }
+
+   .wy-table-responsive {
+      /* This makes very wide tables look ugly and extend past their parent... Maybe allowing the scroll bar isn't so
+         bad in comparison (after the above 2 fixes).
+         */
+      overflow: visible !important;
+   }
+}


### PR DESCRIPTION
* Allows text to wrap in table rows
* Allows text to wrap in table headers
* Forces overflow to be visible (ugly, but at least the table is readable on large screens... Not sure if this makes things worse for small screens though)

https://github.com/python-trio/trio/issues/1210