### PR TITLE
[RFC] Deadline setting performance

### DIFF
--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -1854,7 +1854,7 @@ def run_impl(runner, async_fn, args):
 
         # Process cancellations due to deadline expiry
         now = runner.clock.current_time()
-        while runner.scheduling_deadline < now:
+        while runner.scheduling_deadline <= now:
             runner.scheduling_deadline = inf
             expired = []
             for cancel_scope in runner.deadlines:


### PR DESCRIPTION
Experimenting with optimised deadline setting. Initial commit increased HTTP server performance from 7700 req/s to 8800 req/s, but is also likely to break something and may cause latencies elsewhere.

The approach taken is to no longer keep deadlines in a sorted dict, but to only track the earliest deadline. The earliest deadline is recalculated by traversing all deadlined cancel scopes whenever the old deadline expires, which usually also involves cancelling a scope.

Not ready for merging, I intend to keep working on this. Posted here for comments.
