### PR TITLE
Don't crash when CancelScopes are nested *very* deeply

### DIFF
--- a/newsfragments/1235.bugfix.rst
+++ b/newsfragments/1235.bugfix.rst
@@ -1,0 +1,2 @@
+If you nest >1000 cancel scopes within each other, Trio now handles
+that gracefully instead of crashing with a ``RecursionError``.

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -253,17 +253,21 @@ class CancelStatus:
         )
 
     def recalculate(self):
-        new_state = (
-            self._scope.cancel_called
-            or self.parent_cancellation_is_visible_to_us
-        )
-        if new_state != self.effectively_cancelled:
-            self.effectively_cancelled = new_state
-            if new_state:
-                for task in self._tasks:
-                    task._attempt_delivery_of_any_pending_cancel()
-            for child in self._children:
-                child.recalculate()
+        # This is basically a recursive algorithm, but we do it iteratively to
+        # avoid any issues with stack overflow.
+        todo = [self]
+        while todo:
+            cs = todo.pop()
+            new_state = (
+                cs._scope.cancel_called
+                or cs.parent_cancellation_is_visible_to_us
+            )
+            if new_state != cs.effectively_cancelled:
+                cs.effectively_cancelled = new_state
+                if new_state:
+                    for task in cs._tasks:
+                        task._attempt_delivery_of_any_pending_cancel()
+                todo.extend(cs._children)
 
     def _mark_abandoned(self):
         self.abandoned_by_misnesting = True

--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -2427,3 +2427,13 @@ def test_async_function_implemented_in_C():
         assert start_soon_record == ["the generator ran"]
 
     _core.run(main)
+
+
+async def test_very_deep_cancel_scope_nesting():
+    # This used to crash with a RecursionError in CancelStatus.recalculate
+    with ExitStack() as exit_stack:
+        outermost_scope = _core.CancelScope()
+        exit_stack.enter_context(outermost_scope)
+        for _ in range(5000):
+            exit_stack.enter_context(_core.CancelScope())
+        outermost_scope.cancel()


### PR DESCRIPTION
This will probably never come up in real life, but I hit it while
messing around with some microbenchmarks, and the fix is easy.