### PR TITLE
Test all constants reexported

### DIFF
--- a/trio/tests/test_socket.py
+++ b/trio/tests/test_socket.py
@@ -93,6 +93,15 @@ def test_socket_has_some_reexports():
     assert tsocket.ntohs == stdlib_socket.ntohs
 
 
+def test_all_constants_reexported():
+    trio_tsocket_exports = set(dir(tsocket))
+
+    for name in dir(stdlib_socket):
+        if name.isupper() and name[0] != "_":
+            stdlib_constant = name
+            assert stdlib_constant in trio_tsocket_exports
+
+
 ################################################################
 # name resolution
 ################################################################


### PR DESCRIPTION
The test actually fails because EAGAIN is not exported on my machine (which shows it may be a valuable test, but also means there's potentially work to do in the exporting magic, some of which goes above my head...).

```python3
Python 3.7.2 (tags/v3.7.2:9a3ffc0492, Dec 23 2018, 23:09:28) [MSC v.1916 64 bit (AMD64)] on win32
import socket
socket.EAGAIN
Out[3]: 11
from trio import socket as tsocket
tsocket.EAGAIN
Traceback (most recent call last):
  File "C:\Users\kiwini\PycharmProjects\trio\venv\lib\site-packages\IPython\core\interactiveshell.py", line 3326, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-5-14d153927893>", line 1, in <module>
    tsocket.EAGAIN
AttributeError: module 'trio.socket' has no attribute 'EAGAIN'
```

Guidance on where to head from here appreciated! (As I learned while making this PR, exports are platform dependent, is this test even going to be valuable on the CI machine or would it take a dev running windows like me to actually cause failures?)