### PR TITLE
Make testing instructions less generic

### DIFF
--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -184,10 +184,11 @@ Tests
 We use `pytest <https://pytest.org/>`__ for testing. To run the tests
 locally, you should run:
 
-* ``cd path/to/project/checkout/``
-* ``pip install -r test-requirements.txt`` (possibly using a
-  virtualenv)
-* ``pytest <projectname>``
+.. code-block:: shell
+
+   cd path/to/trio/checkout/
+   pip install -r test-requirements.txt  # possibly using a virtualenv
+   pytest trio
 
 This doesn't try to be completely exhaustive – it only checks that
 things work on your machine, and it may skip some slow tests. But it's


### PR DESCRIPTION
In `contributing.rst`, the instructions for running tests locally appear to have been cut-and-pasted from the pytest manual, or something like that, and it's not clear exactly what to type.  Replacing "project" with "trio" in two places fixes this.  In particular, I have verified that `pytest trio` is the correct command to run the test suite once everything is set up.

Also use a code-block instead of a bulleted list of verbatim strings.