### PR TITLE
Fix Path's hash behavior to match `pathlib.Path`'s

### DIFF
--- a/newsfragments/1259.bugfix.rst
+++ b/newsfragments/1259.bugfix.rst
@@ -1,0 +1,1 @@
+Fix the hash behavior of `trio.Path` to mach `pathlib.Path`. Previously `trio.Path`'s hash was inhereted from `object` instead of from `pathlib.PurePath`. Thus, hashing two `trio.Path`'s or a `trio.Path` and a `pathlib.Path` with the same underlying path would yield different results.

--- a/trio/_path.py
+++ b/trio/_path.py
@@ -152,8 +152,16 @@ class Path(metaclass=AsyncAutoWrapperType):
     _wraps = pathlib.Path
     _forwards = pathlib.PurePath
     _forward_magic = [
-        '__str__', '__bytes__', '__truediv__', '__rtruediv__', '__eq__',
-        '__lt__', '__le__', '__gt__', '__ge__', '__hash__',
+        '__str__',
+        '__bytes__',
+        '__truediv__',
+        '__rtruediv__',
+        '__eq__',
+        '__lt__',
+        '__le__',
+        '__gt__',
+        '__ge__',
+        '__hash__',
     ]
     _wrap_iter = ['glob', 'rglob', 'iterdir']
 

--- a/trio/_path.py
+++ b/trio/_path.py
@@ -153,7 +153,7 @@ class Path(metaclass=AsyncAutoWrapperType):
     _forwards = pathlib.PurePath
     _forward_magic = [
         '__str__', '__bytes__', '__truediv__', '__rtruediv__', '__eq__',
-        '__lt__', '__le__', '__gt__', '__ge__'
+        '__lt__', '__le__', '__gt__', '__ge__', '__hash__',
     ]
     _wrap_iter = ['glob', 'rglob', 'iterdir']
 

--- a/trio/tests/test_path.py
+++ b/trio/tests/test_path.py
@@ -75,6 +75,15 @@ async def test_div_magic(cls_a, cls_b):
     assert str(result) == os.path.join('a', 'b')
 
 
+@pytest.mark.parametrize(
+    'cls_a,cls_b', [(trio.Path, pathlib.Path), (trio.Path, trio.Path)]
+)
+@pytest.mark.parametrize('path', ["foo", "foo/bar/baz", "./foo"])
+async def test_hash_magic(cls_a, cls_b, path):
+    a, b = cls_a(path), cls_b(path)
+    assert hash(a) == hash(b)
+
+
 async def test_forwarded_properties(path):
     # use `name` as a representative of forwarded properties
 


### PR DESCRIPTION
See https://github.com/python-trio/trio/issues/1259

New Behavior:
- `hash(Path("foo/bar/baz")) == hash(Path("foo/bar/baz"))`
- `hash(trio.Path("foo/bar/baz")) == hash(pathlib.Path("foo/bar/baz"))`