### PR TITLE
Move set_wakeup_fd into common code, used on all platforms

### DIFF
--- a/newsfragments/109.bugfix.rst
+++ b/newsfragments/109.bugfix.rst
@@ -1,0 +1,4 @@
+Trio now uses `signal.set_wakeup_fd` on all platforms. This is mostly
+an internal refactoring with no user-visible effect, but in theory it
+should fix a few extremely-rare race conditions on Unix that could
+have caused signal delivery to be delayed.

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -1783,9 +1783,11 @@ def run(
         ):
             try:
                 with closing(runner):
-                    # The main reason this is split off into its own function
-                    # is just to get rid of this extra indentation.
-                    run_impl(runner, async_fn, args)
+                    with runner.entry_queue.wakeup.wakeup_on_signals():
+                        # The main reason this is split off into its own
+                        # function is just to get rid of this extra
+                        # indentation.
+                        run_impl(runner, async_fn, args)
             except TrioInternalError:
                 raise
             except BaseException as exc:

--- a/trio/_core/tests/test_ki.py
+++ b/trio/_core/tests/test_ki.py
@@ -480,10 +480,6 @@ def test_ki_with_broken_threads():
 # For details on why this test is non-trivial, see:
 #   https://github.com/python-trio/trio/issues/42
 #   https://github.com/python-trio/trio/issues/109
-# To make it an even better test, we should try doing
-#   pthread_kill(pthread_self, SIGINT)
-# in the child thread, to make sure signals in non-main threads also wake up
-# the main loop... but currently that test would fail (see gh-109 again).
 @slow
 def test_ki_wakes_us_up():
     assert is_main_thread()
@@ -515,10 +511,9 @@ def test_ki_wakes_us_up():
     #
     # PyPy was never affected.
     #
-    # The problem technically occurs on Unix as well, if a signal is delivered
-    # to a non-main thread, and if we were relying on the wakeup fd to wake
-    # us. Currently we don't use the wakeup fd on Unix anyway, though (see
-    # gh-109).
+    # The problem technically can occur on Unix as well, if a signal is
+    # delivered to a non-main thread, though we haven't observed this in
+    # practice.
     #
     # There's also this theoretical problem, but hopefully it won't actually
     # bite us in practice:
@@ -526,8 +521,8 @@ def test_ki_wakes_us_up():
     #   https://bitbucket.org/pypy/pypy/issues/2623
     import platform
     buggy_wakeup_fd = (
-        os.name == "nt" and platform.python_implementation() == "CPython"
-        and sys.version_info < (3, 6, 2)
+        platform.python_implementation() == "CPython" and sys.version_info <
+        (3, 6, 2)
     )
 
     # lock is only needed to avoid an annoying race condition where the

--- a/trio/_util.py
+++ b/trio/_util.py
@@ -7,6 +7,7 @@ import sys
 import pathlib
 from functools import wraps, update_wrapper
 import typing as t
+import threading
 
 import async_generator
 
@@ -64,7 +65,7 @@ if os.name == "nt":
 else:
 
     def signal_raise(signum):
-        os.kill(os.getpid(), signum)
+        signal.pthread_kill(threading.get_ident(), signum)
 
 
 # Decorator to handle the change to __aiter__ in 3.5.2


### PR DESCRIPTION
Also switched signal_raise to always run the C-level signal handler in
the current thread, which gives us more control over signal delivery
and lets us test the new behavior.

Fixes gh-109