### PR TITLE
Update link in timeout note (docs)

### DIFF
--- a/docs/source/reference-core.rst
+++ b/docs/source/reference-core.rst
@@ -269,7 +269,7 @@ finished`` message.
    the ``with`` statement. This is different from what you might have
    seen with other Python libraries, where timeouts often refer to
    something `more complicated
-   <http://docs.python-requests.org/en/master/user/quickstart/#timeouts>`__. We
+   <https://requests.kennethreitz.org//en/master/user/quickstart/#timeouts>`__. We
    think this way is easier to reason about.
 
 How does this work? There's no magic here: Trio is built using

--- a/docs/source/reference-core.rst
+++ b/docs/source/reference-core.rst
@@ -269,7 +269,7 @@ finished`` message.
    the ``with`` statement. This is different from what you might have
    seen with other Python libraries, where timeouts often refer to
    something `more complicated
-   <https://requests.kennethreitz.org//en/master/user/quickstart/#timeouts>`__. We
+   <https://requests.kennethreitz.org/en/master/user/quickstart/#timeouts>`__. We
    think this way is easier to reason about.
 
 How does this work? There's no magic here: Trio is built using


### PR DESCRIPTION
The link at line 272 was dead, I've updated it.