### PR TITLE
Make Trio more robust to fds/handles being closed behind our back

### DIFF
--- a/newsfragments/1272.feature.rst
+++ b/newsfragments/1272.feature.rst
@@ -1,7 +1,7 @@
 If you're using Trio's low-level interfaces like
 `trio.hazmat.wait_readable` or similar, and then you close a socket or
 file descriptor, you're supposed to call `trio.hazmat.notify_closing`
-first so Trio can clean up properly. But what if you forgot? In the
+first so Trio can clean up properly. But what if you forget? In the
 past, Trio would tend to either deadlock or explode spectacularly.
 Now, it's much more robust to this situation, and should generally
 survive. (But note that "survive" is not the same as "give you the

--- a/newsfragments/1272.feature.rst
+++ b/newsfragments/1272.feature.rst
@@ -1,0 +1,16 @@
+If you're using Trio's low-level interfaces like
+`trio.hazmat.wait_readable` or similar, and then you close a socket or
+file descriptor, you're supposed to call `trio.hazmat.notify_closing`
+first so Trio can clean up properly. But what if you forgot? In the
+past, Trio would tend to either deadlock or explode spectacularly.
+Now, it's much more robust to this situation, and should generally
+survive. (But note that "survive" is not the same as "give you the
+results you were expecting", so you should still call
+`~trio.hazmat.notify_closing` when appropriate. This is about harm
+reduction and making it easier to debug this kind of mistake, not
+something you should rely on.)
+
+If you're using higher-level interfaces outside of the `trio.hazmat`
+module, then you don't need to worry about any of this; those
+intefaces already take care of calling `~trio.hazmat.notify_closing`
+for you.

--- a/trio/_core/_io_common.py
+++ b/trio/_core/_io_common.py
@@ -1,0 +1,22 @@
+import copy
+import outcome
+from .. import _core
+
+
+# Utility function shared between _io_epoll and _io_windows
+def wake_all(waiters, exc):
+    try:
+        current_task = _core.current_task()
+    except RuntimeError:
+        current_task = None
+    raise_at_end = False
+    for attr_name in ["read_task", "write_task"]:
+        task = getattr(waiters, attr_name)
+        if task is not None:
+            if task is current_task:
+                raise_at_end = True
+            else:
+                _core.reschedule(task, outcome.Error(copy.copy(exc)))
+            setattr(waiters, attr_name, None)
+    if raise_at_end:
+        raise exc

--- a/trio/_core/_io_epoll.py
+++ b/trio/_core/_io_epoll.py
@@ -28,38 +28,41 @@ class _EpollStatistics:
 # has some subtle consequences.
 #
 # In general, file objects inside the kernel are reference counted. Each entry
-# in a process's fd table holds a reference to the file objects, and most
-# operations that use file objects take a temporary reference while they're
-# working. So when you call close() on an fd, that might or might not cause
-# the file object to be deallocated -- it depends on whether there are any
-# other fds referring to that file object. Some common ways this can happen:
+# in a process's fd table holds a strong reference to the corresponding file
+# object, and most operations that use file objects take a temporary strong
+# reference while they're working. So when you call close() on an fd, that
+# might or might not cause the file object to be deallocated -- it depends on
+# whether there are any other references to that file object. Some common ways
+# this can happen:
 #
 # - after calling dup(), you have two fds in the same process referring to the
-#   same file object. Even if you close one, the file object will be kept
-#   alive by the other.
+#   same file object. Even if you close one fd (= remove that entry from the
+#   fd table), the file object will be kept alive by the other fd.
 # - when calling fork(), the child inherits a copy of the parent's fd table,
 #   so all the file objects get another reference. (But if the fork() is
 #   followed by exec(), then all of the child's fds that have the CLOEXEC flag
 #   set will be closed at that point.)
-# - most syscalls that work on fds take a reference to the underlying file
-#   object while they're running. So e.g. if there's a thread blocked in
-#   read(fd), and then another thread calls close(fd), the underlying file
-#   object won't actually be closed until after read() returns.
+# - most syscalls that work on fds take a strong reference to the underlying
+#   file object while they're using it. So there's one thread blocked in
+#   read(fd), and then another thread calls close() on the last fd referring
+#   to that object, the underlying file won't actually be closed until
+#   after read() returns.
 #
-# However, epoll does *not* take a reference to the file objects in its set
-# (that's what makes it similar to a WeakKeyDictionary). File objects inside
-# an epoll interest set will be deallocated if all *other* references to them
-# are closed, and then the epoll object will automatically deregister that
-# file object and stop reporting events on it. So that's quite handy.
+# However, epoll does *not* take a reference to any of the file objects in its
+# interest set (that's what makes it similar to a WeakKeyDictionary). File
+# objects inside an epoll interest set will be deallocated if all *other*
+# references to them are closed. And when that happens, the epoll object will
+# automatically deregister that file object and stop reporting events on it.
+# So that's quite handy.
 #
-# But, what happens if we do:
+# But, what happens if we do this?
 #
 #   fd1 = open(...)
 #   epoll_ctl(EPOLL_CTL_ADD, fd1, ...)
 #   fd2 = dup(fd1)
 #   close(fd1)
 #
-# ? In this case, the dup() keeps the underlying file object alive, so it
+# In this case, the dup() keeps the underlying file object alive, so it
 # remains registered in the epoll object's interest set, as the tuple (fd1,
 # file object). But, fd1 no longer refers to this file object! You might think
 # there was some magic to handle this, but unfortunately no; the consequences
@@ -68,98 +71,103 @@ class _EpollStatistics:
 # If any events occur on the file object, then epoll will report them as
 # happening on fd1, even though that doesn't make sense.
 #
-# So perhaps we would like to deregister fd1 to stop getting events. But how?
-# When we call epoll_ctl, we have to pass an fd number, which will get
-# expanded to an (fd number, file object) tuple. We can't pass fd1, because
-# when epoll_ctl tries to look it up, it won't find our file object. And we
-# can't pass fd2, because that will get expanded to (fd2, file object), which
-# is a different lookup key. In fact, in this case it is *impossible* to
-# de-register this fd!
+# Perhaps we would like to deregister fd1 to stop getting nonsensical events.
+# But how? When we call epoll_ctl, we have to pass an fd number, which will
+# get expanded to an (fd number, file object) tuple. We can't pass fd1,
+# because when epoll_ctl tries to look it up, it won't find our file object.
+# And we can't pass fd2, because that will get expanded to (fd2, file object),
+# which is a different lookup key. In fact, it's *impossible* to de-register
+# this fd!
 #
-# It is even possible that fd1 will get assigned to another file object, and
-# then we can have multiple keys registered simultaneously using the same fd
-# number, like: (fd1, file object 1), (fd1, file object 2)
-# epoll will happily report events on either file object as having happened on
+# We could even have fd1 get assigned to another file object, and then we can
+# have multiple keys registered simultaneously using the same fd number, like:
+# (fd1, file object 1), (fd1, file object 2). And if events happen on either
+# file object, then epoll will happily report that something happened to
 # "fd1".
 #
-# And what makes this particularly nasty is that suppose the old file object
+# Now here's what makes this especially nasty: suppose the old file object
 # becomes, say, readable. That means that every time we call epoll_wait, it
 # will return immediately to tell us that "fd1" is readable. Normally, we
-# would handle this by de-registering fd1, waking up wait_readable, then the
-# user will call read() or recv() or something, etc., so it's fine. But if
-# this happens on a stale fd where we can't remove the registration, then we
-# might get stuck in a state where epoll_ctl *always* returns immediately, so
-# our event loop becomes unable to sleep, and now our program is burning 100%
-# of the CPU doing nothing.
+# would handle this by de-registering fd1, waking up the corresponding call to
+# wait_readable, then the user will call read() or recv() or something, and
+# we're fine. But if this happens on a stale fd where we can't remove the
+# registration, then we might get stuck in a state where epoll_wait *always*
+# returns immediately, so our event loop becomes unable to sleep, and now our
+# program is burning 100% of the CPU doing nothing, with no way out.
 #
 #
 # What does this mean for Trio?
 # -----------------------------
 #
 # Since we don't control the user's code, we have no way to guarantee that we
-# don't get stuck in the pathological situation described above. For example,
-# a user could call wait_readable(fd) in one task, and then while that's
+# don't get stuck with stale fd's in our epoll interest set. For example, a
+# user could call wait_readable(fd) in one task, and then while that's
 # running, they might close(fd) from another task. In this situation, they're
 # *supposed* to call notify_closing(fd) to let us know what's happening, so we
 # can interrupt the wait_readable() call and avoid getting into this mess. And
 # that's the only thing that can possibly work correctly in all cases. But
-# sometimes code has bugs. So we would like to be able to at least survive
-# this without corrupting Trio's internal state or otherwise causing the whole
-# program to explode messily.
+# sometimes user code has bugs. So if this does happen, we'd like to degrade
+# gracefully, and survive without corrupting Trio's internal state or
+# otherwise causing the whole program to explode messily.
 #
-# Our solution: we always use EPOLLONESHOT when registering an fd with epoll.
-# This way, we might get *one* spurious event on a stale fd, but then epoll
-# will automatically quiet it until we explicitly say that we want more
-# events... which on a stale fd we can't do, so that will never happen, and we
-# avoid getting stuck in a busy-loop. And this might even cause some wait_*
-# function to return before it should have... but in general, the wait_*
-# functions are allowed to have some spurious wakeups; the user code will just
-# attempt the operation, get EWOULDBLOCK, and call wait_* again.
+# Our solution: we always use EPOLLONESHOT. This way, we might get *one*
+# spurious event on a stale fd, but then epoll will automatically silence it
+# until we explicitly say that we want more events... and if we have a stale
+# fd, then we actually can't re-enable it! So we can't get stuck in an
+# infinite busy-loop. If there's a stale fd hanging around, then it might
+# cause a spurious `BusyResourceError`, or cause one wait_* call to return
+# before it should have... but in general, the wait_* functions are allowed to
+# have some spurious wakeups; the user code will just attempt the operation,
+# get EWOULDBLOCK, and call wait_* again. And the program as a whole will
+# survive, any exceptions will propagate, etc.
 #
-# (We could also get a spurious BusyResourceError, but at least that doesn't
-# corrupt the whole program.)
+# As a bonus, EPOLLONESHOT also saves us having to explicitly deregister fds
+# on the normal wakeup path, so it's a bit more efficient in general.
 #
-# As a bonus, EPOLLONESHOT also saves us having to explicitly deregister fds,
-# so it's a bit more efficient in the normal case too.
-#
-# However, EPOLLONESHOT has a few trade-offs:
+# However, EPOLLONESHOT has a few trade-offs to consider:
 #
 # First, you can't combine EPOLLONESHOT with EPOLLEXCLUSIVE. This is a bit sad
 # in one somewhat rare case: if you have a multi-process server where a group
 # of processes all share the same listening socket, then EPOLLEXCLUSIVE can be
 # used to avoid "thundering herd" problems when a new connection comes in. But
-# this isn't too bad. It's not clear if EPOLLEXCLUSIVE even works here anyway:
+# this isn't too bad. It's not clear if EPOLLEXCLUSIVE even works for us
+# anyway:
 #
 #   https://stackoverflow.com/questions/41582560/how-does-epolls-epollexclusive-mode-interact-with-level-triggering
 #
-# And if we really need to support this, we could always add support through
-# some specialized API in the future.
+# And it's not clear that EPOLLEXCLUSIVE is a great approach either:
+#
+#   https://blog.cloudflare.com/the-sad-state-of-linux-socket-balancing/
+#
+# And if we do need to support this, we could always add support through some
+# more-specialized API in the future. So this isn't a blocker to using
+# EPOLLONESHOT.
 #
 # Second, EPOLLONESHOT does not actually *deregister* the fd after delivering
 # an event (EPOLL_CTL_DEL). Instead, it keeps the fd registered, but
 # effectively does an EPOLL_CTL_MOD to set the fd's interest flags to
-# all-zeros.
+# all-zeros. So we could still end up with an fd hanging around in the
+# interest set for a long time, even if we're not using it.
 #
-# So one possible problem would be that the epoll object will end up keeping
-# the underlying file object alive. Fortunately, that doesn't happen, as
-# described above – if we have a stale fd that's been silenced by
-# EPOLLONESHOT, then I guess it wastes a bit of kernel memory remembering this
-# fd that can never be revived, but when the underlying file object is
-# eventually closed, that memory will be reclaimed. So that's OK.
+# Fortunately, this isn't a problem, because it's only a weak reference – if
+# we have a stale fd that's been silenced by EPOLLONESHOT, then it wastes a
+# tiny bit of kernel memory remembering this fd that can never be revived, but
+# when the underlying file object is eventually closed, that memory will be
+# reclaimed. So that's OK.
 #
-# The other issue is that when someon calls wait_*, using EPOLLONESHOT means
+# The other issue is that when someone calls wait_*, using EPOLLONESHOT means
 # that if we have ever waited for this fd before, we have to use EPOLL_CTL_MOD
 # to re-enable it; but if it's a new fd, we have to use EPOLL_CTL_ADD. How do
-# we know which to use? There's no reasonable way to track which fds are
+# we know which one to use? There's no reasonable way to track which fds are
 # currently registered -- remember, we're assuming the user might have gone
 # and rearranged their fds without telling us!
 #
-# Fortunately, this also has a simple solution: usually, if we wait on a
-# socket or other fd once, we will probably wait lots of times. And the epoll
+# Fortunately, this also has a simple solution: if we wait on a socket or
+# other fd once, then we'll probably wait on it lots of times. And the epoll
 # object itself knows which fds it already has registered. So when an fd comes
 # in, we optimistically assume that it's been waited on before, and try doing
-# EPOLL_CTL_MOD. If that failed with an ENOENT error, then we try again with
-# EPOLL_CTL_ADD.
+# EPOLL_CTL_MOD. And if that fails with an ENOENT error, then we try again
+# with EPOLL_CTL_ADD.
 #
 # So that's why this code is the way it is. And now you know more than you
 # wanted to about how epoll works.
@@ -218,7 +226,7 @@ class EpollIOManager:
         events = self._epoll.poll(timeout, max_events)
         for fd, flags in events:
             waiters = self._registered[fd]
-            # EPOLLONESHOT always clears the flags
+            # EPOLLONESHOT always clears the flags when an event is delivered
             waiters.current_flags = 0
             # Clever hack stolen from selectors.EpollSelector: an event
             # with EPOLLHUP or EPOLLERR flags wakes both readers and

--- a/trio/_core/_io_epoll.py
+++ b/trio/_core/_io_epoll.py
@@ -14,6 +14,7 @@ class _EpollStatistics:
     tasks_waiting_write = attr.ib()
     backend = attr.ib(default="epoll")
 
+
 # Some facts about epoll
 # ----------------------
 #
@@ -244,7 +245,9 @@ class EpollIOManager:
                     self._epoll.modify(fd, wanted_flags | select.EPOLLONESHOT)
                 except OSError:
                     # If that fails, it might be a new fd; try EPOLL_CTL_ADD
-                    self._epoll.register(fd, wanted_flags | select.EPOLLONESHOT)
+                    self._epoll.register(
+                        fd, wanted_flags | select.EPOLLONESHOT
+                    )
                 waiters.current_flags = wanted_flags
             except OSError as exc:
                 # If everything fails, probably it's a bad fd, e.g. because

--- a/trio/_core/_io_epoll.py
+++ b/trio/_core/_io_epoll.py
@@ -1,6 +1,8 @@
 import select
 import attr
 import outcome
+import copy
+from collections import defaultdict
 
 from .. import _core
 from ._run import _public
@@ -12,39 +14,185 @@ class _EpollStatistics:
     tasks_waiting_write = attr.ib()
     backend = attr.ib(default="epoll")
 
+# Some facts about epoll
+# ----------------------
+#
+# Internally, an epoll object is sort of like a WeakKeyDictionary where the
+# keys are tuples of (fd number, file object). When you call epoll_ctl, you
+# pass in an fd; that gets converted to an (fd number, file object) tuple by
+# looking up the fd in the process's fd table at the time of the call. When an
+# event happens on the file object, epoll_wait drops the file object part, and
+# just returns the fd number in its event. So from the outside it looks like
+# it's keeping a table of fds, but really it's a bit more complicated. This
+# has some subtle consequences.
+#
+# In general, file objects inside the kernel are reference counted. Each entry
+# in a process's fd table holds a reference to the file objects, and most
+# operations that use file objects take a temporary reference while they're
+# working. So when you call close() on an fd, that might or might not cause
+# the file object to be deallocated -- it depends on whether there are any
+# other fds referring to that file object. Some common ways this can happen:
+#
+# - after calling dup(), you have two fds in the same process referring to the
+#   same file object. Even if you close one, the file object will be kept
+#   alive by the other.
+# - when calling fork(), the child inherits a copy of the parent's fd table,
+#   so all the file objects get another reference. (But if the fork() is
+#   followed by exec(), then all of the child's fds that have the CLOEXEC flag
+#   set will be closed at that point.)
+# - most syscalls that work on fds take a reference to the underlying file
+#   object while they're running. So e.g. if there's a thread blocked in
+#   read(fd), and then another thread calls close(fd), the underlying file
+#   object won't actually be closed until after read() returns.
+#
+# However, epoll does *not* take a reference to the file objects in its set
+# (that's what makes it similar to a WeakKeyDictionary). File objects inside
+# an epoll interest set will be deallocated if all *other* references to them
+# are closed, and then the epoll object will automatically deregister that
+# file object and stop reporting events on it. So that's quite handy.
+#
+# But, what happens if we do:
+#
+#   fd1 = open(...)
+#   epoll_ctl(EPOLL_CTL_ADD, fd1, ...)
+#   fd2 = dup(fd1)
+#   close(fd1)
+#
+# ? In this case, the dup() keeps the underlying file object alive, so it
+# remains registered in the epoll object's interest set, as the tuple (fd1,
+# file object). But, fd1 no longer refers to this file object! You might think
+# there was some magic to handle this, but unfortunately no; the consequences
+# are totally predictable from what I said above:
+#
+# If any events occur on the file object, then epoll will report them as
+# happening on fd1, even though that doesn't make sense.
+#
+# So perhaps we would like to deregister fd1 to stop getting events. But how?
+# When we call epoll_ctl, we have to pass an fd number, which will get
+# expanded to an (fd number, file object) tuple. We can't pass fd1, because
+# when epoll_ctl tries to look it up, it won't find our file object. And we
+# can't pass fd2, because that will get expanded to (fd2, file object), which
+# is a different lookup key. In fact, in this case it is *impossible* to
+# de-register this fd!
+#
+# It is even possible that fd1 will get assigned to another file object, and
+# then we can have multiple keys registered simultaneously using the same fd
+# number, like: (fd1, file object 1), (fd1, file object 2)
+# epoll will happily report events on either file object as having happened on
+# "fd1".
+#
+# And what makes this particularly nasty is that suppose the old file object
+# becomes, say, readable. That means that every time we call epoll_wait, it
+# will return immediately to tell us that "fd1" is readable. Normally, we
+# would handle this by de-registering fd1, waking up wait_readable, then the
+# user will call read() or recv() or something, etc., so it's fine. But if
+# this happens on a stale fd where we can't remove the registration, then we
+# might get stuck in a state where epoll_ctl *always* returns immediately, so
+# our event loop becomes unable to sleep, and now our program is burning 100%
+# of the CPU doing nothing.
+#
+#
+# What does this mean for Trio?
+# -----------------------------
+#
+# Since we don't control the user's code, we have no way to guarantee that we
+# don't get stuck in the pathological situation described above. For example,
+# a user could call wait_readable(fd) in one task, and then while that's
+# running, they might close(fd) from another task. In this situation, they're
+# *supposed* to call notify_closing(fd) to let us know what's happening, so we
+# can interrupt the wait_readable() call and avoid getting into this mess. And
+# that's the only thing that can possibly work correctly in all cases. But
+# sometimes code has bugs. So we would like to be able to at least survive
+# this without corrupting Trio's internal state or otherwise causing the whole
+# program to explode messily.
+#
+# Our solution: we always use EPOLLONESHOT when registering an fd with epoll.
+# This way, we might get *one* spurious event on a stale fd, but then epoll
+# will automatically quiet it until we explicitly say that we want more
+# events... which on a stale fd we can't do, so that will never happen, and we
+# avoid getting stuck in a busy-loop. And this might even cause some wait_*
+# function to return before it should have... but in general, the wait_*
+# functions are allowed to have some spurious wakeups; the user code will just
+# attempt the operation, get EWOULDBLOCK, and call wait_* again.
+#
+# (We could also get a spurious BusyResourceError, but at least that doesn't
+# corrupt the whole program.)
+#
+# As a bonus, EPOLLONESHOT also saves us having to explicitly deregister fds,
+# so it's a bit more efficient in the normal case too.
+#
+# However, EPOLLONESHOT has a few trade-offs:
+#
+# First, you can't combine EPOLLONESHOT with EPOLLEXCLUSIVE. This is a bit sad
+# in one somewhat rare case: if you have a multi-process server where a group
+# of processes all share the same listening socket, then EPOLLEXCLUSIVE can be
+# used to avoid "thundering herd" problems when a new connection comes in. But
+# this isn't too bad. It's not clear if EPOLLEXCLUSIVE even works here anyway:
+#
+#   https://stackoverflow.com/questions/41582560/how-does-epolls-epollexclusive-mode-interact-with-level-triggering
+#
+# And if we really need to support this, we could always add support through
+# some specialized API in the future.
+#
+# Second, EPOLLONESHOT does not actually *deregister* the fd after delivering
+# an event (EPOLL_CTL_DEL). Instead, it keeps the fd registered, but
+# effectively does an EPOLL_CTL_MOD to set the fd's interest flags to
+# all-zeros.
+#
+# So one possible problem would be that the epoll object will end up keeping
+# the underlying file object alive. Fortunately, that doesn't happen, as
+# described above – if we have a stale fd that's been silenced by
+# EPOLLONESHOT, then I guess it wastes a bit of kernel memory remembering this
+# fd that can never be revived, but when the underlying file object is
+# eventually closed, that memory will be reclaimed. So that's OK.
+#
+# The other issue is that when someon calls wait_*, using EPOLLONESHOT means
+# that if we have ever waited for this fd before, we have to use EPOLL_CTL_MOD
+# to re-enable it; but if it's a new fd, we have to use EPOLL_CTL_ADD. How do
+# we know which to use? There's no reasonable way to track which fds are
+# currently registered -- remember, we're assuming the user might have gone
+# and rearranged their fds without telling us!
+#
+# Fortunately, this also has a simple solution: usually, if we wait on a
+# socket or other fd once, we will probably wait lots of times. And the epoll
+# object itself knows which fds it already has registered. So when an fd comes
+# in, we optimistically assume that it's been waited on before, and try doing
+# EPOLL_CTL_MOD. If that failed with an ENOENT error, then we try again with
+# EPOLL_CTL_ADD.
+#
+# So that's why this code is the way it is. And now you know more than you
+# wanted to about how epoll works.
+
 
 @attr.s(slots=True, eq=False)
 class EpollWaiters:
     read_task = attr.ib(default=None)
     write_task = attr.ib(default=None)
+    current_flags = attr.ib(default=0)
 
-    def flags(self):
-        flags = 0
-        if self.read_task is not None:
-            flags |= select.EPOLLIN
-        if self.write_task is not None:
-            flags |= select.EPOLLOUT
-        if not flags:
-            return None
-        # XX not sure if EPOLLEXCLUSIVE is actually safe... I think
-        # probably we should use it here unconditionally, but:
-        # https://stackoverflow.com/questions/41582560/how-does-epolls-epollexclusive-mode-interact-with-level-triggering
-
-        # flags |= select.EPOLLEXCLUSIVE
-        # We used to use ONESHOT here also, but it turns out that it's
-        # confusing/complicated: you can't use ONESHOT+EPOLLEXCLUSIVE
-        # together, you ONESHOT doesn't delete the registration but just
-        # "disables" it so you re-enable with CTL rather than ADD (or
-        # something?)...
-        # https://lkml.org/lkml/2016/2/4/541
-        return flags
+    def wake_all(self, exc):
+        try:
+            current_task = _core.current_task()
+        except RuntimeError:
+            current_task = None
+        raise_at_end = False
+        for attr_name in ["read_task", "write_task"]:
+            task = getattr(self, attr_name)
+            if task is not None:
+                if task is current_task:
+                    raise_at_end = True
+                else:
+                    _core.reschedule(task, outcome.Error(copy.copy(exc)))
+                setattr(self, attr_name, None)
+        if raise_at_end:
+            raise exc
 
 
 @attr.s(slots=True, eq=False, hash=False)
 class EpollIOManager:
     _epoll = attr.ib(factory=select.epoll)
     # {fd: EpollWaiters}
-    _registered = attr.ib(factory=dict)
+    _registered = attr.ib(factory=lambda: defaultdict(EpollWaiters))
 
     def statistics(self):
         tasks_waiting_read = 0
@@ -69,6 +217,8 @@ class EpollIOManager:
         events = self._epoll.poll(timeout, max_events)
         for fd, flags in events:
             waiters = self._registered[fd]
+            # EPOLLONESHOT always clears the flags
+            waiters.current_flags = 0
             # Clever hack stolen from selectors.EpollSelector: an event
             # with EPOLLHUP or EPOLLERR flags wakes both readers and
             # writers.
@@ -78,40 +228,51 @@ class EpollIOManager:
             if flags & ~select.EPOLLOUT and waiters.read_task is not None:
                 _core.reschedule(waiters.read_task)
                 waiters.read_task = None
-            self._update_registrations(fd, True)
+            self._update_registrations(fd)
 
-    def _update_registrations(self, fd, currently_registered):
+    def _update_registrations(self, fd):
         waiters = self._registered[fd]
-        flags = waiters.flags()
-        if flags is None:
-            assert currently_registered
+        wanted_flags = 0
+        if waiters.read_task is not None:
+            wanted_flags |= select.EPOLLIN
+        if waiters.write_task is not None:
+            wanted_flags |= select.EPOLLOUT
+        if wanted_flags != waiters.current_flags:
+            try:
+                try:
+                    # First try EPOLL_CTL_MOD
+                    self._epoll.modify(fd, wanted_flags | select.EPOLLONESHOT)
+                except OSError:
+                    # If that fails, it might be a new fd; try EPOLL_CTL_ADD
+                    self._epoll.register(fd, wanted_flags | select.EPOLLONESHOT)
+                waiters.current_flags = wanted_flags
+            except OSError as exc:
+                # If everything fails, probably it's a bad fd, e.g. because
+                # the fd was closed behind our back. In this case we don't
+                # want to try to unregister the fd, because that will probably
+                # fail too. Just clear our state and wake everyone up.
+                del self._registered[fd]
+                # This could raise (in case we're calling this inside one of
+                # the to-be-woken tasks), so we have to do it last.
+                waiters.wake_all(exc)
+                return
+        if not wanted_flags:
             del self._registered[fd]
-            self._epoll.unregister(fd)
-        else:
-            if currently_registered:
-                self._epoll.modify(fd, flags)
-            else:
-                self._epoll.register(fd, flags)
-
-    # Public (hazmat) API:
 
     async def _epoll_wait(self, fd, attr_name):
         if not isinstance(fd, int):
             fd = fd.fileno()
-        currently_registered = (fd in self._registered)
-        if not currently_registered:
-            self._registered[fd] = EpollWaiters()
         waiters = self._registered[fd]
         if getattr(waiters, attr_name) is not None:
             raise _core.BusyResourceError(
                 "another task is already reading / writing this fd"
             )
         setattr(waiters, attr_name, _core.current_task())
-        self._update_registrations(fd, currently_registered)
+        self._update_registrations(fd)
 
         def abort(_):
-            setattr(self._registered[fd], attr_name, None)
-            self._update_registrations(fd, True)
+            setattr(waiters, attr_name, None)
+            self._update_registrations(fd)
             return _core.Abort.SUCCEEDED
 
         await _core.wait_task_rescheduled(abort)
@@ -128,21 +289,11 @@ class EpollIOManager:
     def notify_closing(self, fd):
         if not isinstance(fd, int):
             fd = fd.fileno()
-        if fd not in self._registered:
-            return
-
-        waiters = self._registered[fd]
-
-        def interrupt(task):
-            exc = _core.ClosedResourceError("another task closed this fd")
-            _core.reschedule(task, outcome.Error(exc))
-
-        if waiters.write_task is not None:
-            interrupt(waiters.write_task)
-            waiters.write_task = None
-
-        if waiters.read_task is not None:
-            interrupt(waiters.read_task)
-            waiters.read_task = None
-
-        self._update_registrations(fd, True)
+        self._registered[fd].wake_all(
+            _core.ClosedResourceError("another task closed this fd")
+        )
+        del self._registered[fd]
+        try:
+            self._epoll.unregister(fd)
+        except (OSError, ValueError):
+            pass

--- a/trio/_core/_io_kqueue.py
+++ b/trio/_core/_io_kqueue.py
@@ -125,11 +125,12 @@ class KqueueIOManager:
             except FileNotFoundError:
                 # kqueue tracks individual fds (*not* the underlying file
                 # object, see _io_epoll.py for a long discussion of why this
-                # matters), and automatically deregisters an event if the fd
-                # is closed. So if kqueue.control says that it doesn't know
-                # about this event, then probably it's because the fd was
-                # closed behind our backs. (Too bad it doesn't tell us that
-                # this happened... oh well, you can't have everything.)
+                # distinction matters), and automatically deregisters an event
+                # if the fd is closed. So if kqueue.control says that it
+                # doesn't know about this event, then probably it's because
+                # the fd was closed behind our backs. (Too bad it doesn't tell
+                # us that this happened... oh well, you can't have
+                # everything.)
                 pass
             return _core.Abort.SUCCEEDED
 

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -856,7 +856,7 @@ class Nursery(metaclass=NoPublicConstructor):
             return MultiError(self._pending_excs)
 
     def start_soon(self, async_fn, *args, name=None):
-        """ Creates a child task, scheduling ``await async_fn(*args)``.
+        """Creates a child task, scheduling ``await async_fn(*args)``.
 
         This and :meth:`start` are the two fundamental methods for
         creating concurrent tasks in Trio.

--- a/trio/_core/tests/test_io.py
+++ b/trio/_core/tests/test_io.py
@@ -418,6 +418,7 @@ async def test_can_survive_unnotified_close():
         b.setblocking(False)
         fill_socket(a)
         e = trio.Event()
+
         async def wait_readable_then_set():
             await trio.hazmat.wait_readable(a)
             e.set()

--- a/trio/_core/tests/test_io.py
+++ b/trio/_core/tests/test_io.py
@@ -438,7 +438,7 @@ async def test_can_survive_unnotified_close():
         async with trio.open_nursery() as nursery:
             nursery.start_soon(allow_OSError, trio.hazmat.wait_readable, a)
             nursery.start_soon(allow_OSError, trio.hazmat.wait_writable, a)
-            nursery.start_soon(allow_OSError, wait_readable_a2_then_set)
+            nursery.start_soon(wait_readable_a2_then_set)
             await wait_all_tasks_blocked()
             a.close()
             b.send(b"x")

--- a/trio/_core/tests/test_io.py
+++ b/trio/_core/tests/test_io.py
@@ -381,7 +381,7 @@ async def test_can_survive_unnotified_close():
     # handle to the object (which produces a LOCAL_CLOSE notification and
     # wakes up wait_readable), or only close one of the handles (which leaves
     # wait_readable pending until cancelled).
-    with stdlib_socket.socket() as s, s.dup() as s2:
+    with stdlib_socket.socket() as s, s.dup() as s2:  # noqa: F841
         async with trio.open_nursery() as nursery:
             nursery.start_soon(allow_OSError, trio.hazmat.wait_readable, s)
             await wait_all_tasks_blocked()
@@ -397,7 +397,7 @@ async def test_can_survive_unnotified_close():
     # do that has been pulled out from under our feet... so test that we can
     # survive this.
     a, b = stdlib_socket.socketpair()
-    with a, b, a.dup() as a2:
+    with a, b, a.dup() as a2:  # noqa: F841
         a.setblocking(False)
         b.setblocking(False)
         fill_socket(a)
@@ -412,7 +412,7 @@ async def test_can_survive_unnotified_close():
     # arriving, not a cancellation, so the operation gets re-issued from
     # handle_io context rather than abort context.
     a, b = stdlib_socket.socketpair()
-    with a, b, a.dup() as a2:
+    with a, b, a.dup() as a2:  # noqa: F841
         print("a={}, b={}, a2={}".format(a.fileno(), b.fileno(), a2.fileno()))
         a.setblocking(False)
         b.setblocking(False)

--- a/trio/_core/tests/test_io.py
+++ b/trio/_core/tests/test_io.py
@@ -413,7 +413,7 @@ async def test_can_survive_unnotified_close():
     # handle_io context rather than abort context.
     a, b = stdlib_socket.socketpair()
     with a, b, a.dup() as a2:
-        print(f"a={a.fileno()}, b={b.fileno()}, a2={a2.fileno()}")
+        print("a={}, b={}, a2={}".format(a.fileno(), b.fileno(), a2.fileno()))
         a.setblocking(False)
         b.setblocking(False)
         fill_socket(a)

--- a/trio/_core/tests/test_io.py
+++ b/trio/_core/tests/test_io.py
@@ -354,9 +354,12 @@ async def test_io_manager_statistics():
 
 
 async def test_can_survive_unnotified_close():
-    # This should never happen -- users should call notify_closing when they
-    # close things. But, just in case they don't, we would still like to avoid
-    # exploding. Acceptable behaviors:
+    # An "unnotified" close is when the user closes an fd/socket/handle
+    # directly, without calling notify_closing first. This should never happen
+    # -- users should call notify_closing before closing things. But, just in
+    # case they don't, we would still like to avoid exploding.
+    #
+    # Acceptable behaviors:
     # - wait_* never return, but can be cancelled cleanly
     # - wait_* exit cleanly
     # - wait_* raise an OSError
@@ -364,6 +367,9 @@ async def test_can_survive_unnotified_close():
     # Not acceptable:
     # - getting stuck in an uncancellable state
     # - TrioInternalError blowing up the whole run
+    #
+    # This test exercises some tricky "unnotified close" scenarios, to make
+    # sure we get the "acceptable" behaviors.
 
     async def allow_OSError(async_func, *args):
         with suppress(OSError):


### PR DESCRIPTION
Fixes #1272

Todo:

- [x] Windows coverage is a bit wonky -- there's code in `wake_all` to handle the case where `_refresh_afd` failed inside an issuing task, but in fact that never happens in our tests, because in the cases where it would happen `_get_base_handle` crashes first. So this code seems to be unreachable. Should we remove it? Keep it but mark it `no cover`? Not sure. [Edit: better idea – the `wake_all` code was identical between `_io_windows.py` and `_io_epoll.py`, so I just factored it out into a shared file, and now they share testing.]

- [x] Newsfragment

- [x] See what happens on macOS – hopefully nothing because kqueue is simple and friendly, but we'll see what the CI says! [Edit: ok it wasn't quite that simple, but it's working now]