### PR TITLE
[wip] [ci] Run tests in a full-fledged ubuntu 19.10 VM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-dist: bionic
+dist: trusty
 
 matrix:
   include:
@@ -18,6 +18,9 @@ matrix:
     # early warning of any issues that might happen in the next Ubuntu
     # LTS.
     - language: generic
+      # We use bionic for the host, b/c rumor says that Travis's
+      # 'bionic' systems have nested KVM enabled.
+      dist: bionic
       env:
         - "JOB_NAME=Ubuntu 19.10, full VM"
         - "VM_IMAGE=https://cloud-images.ubuntu.com/eoan/current/eoan-server-cloudimg-amd64.img"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-dist: xenial
+dist: bionic
 
 matrix:
   include:
@@ -11,9 +11,20 @@ matrix:
     - python: pypy3
     - language: generic
       env: PYPY_NIGHTLY_BRANCH=py3.6
+    # Qemu tests are also slow
+    # The unique thing this provides is testing on the given distro's
+    # kernel, which is important when we use new kernel features. This
+    # is also good for testing the latest openssl etc., and getting
+    # early warning of any issues that might happen in the next Ubuntu
+    # LTS.
+    - language: generic
+      env:
+        - "JOB_NAME=Ubuntu 19.10, full VM"
+        - "VM_IMAGE=https://cloud-images.ubuntu.com/eoan/current/eoan-server-cloudimg-amd64.img"
     # 3.5.0 and 3.5.1 have different __aiter__ semantics than all
     # other versions, so we need to test them specially. Travis's
-    # xenial dist only provides 3.5.2+.
+    # newer images only provide 3.5.2+, so we have to request the old
+    # 'trusty' images.
     - python: 3.5.0
       dist: trusty
     - python: 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
       # 'bionic' systems have nested KVM enabled.
       dist: bionic
       env:
-        - "JOB_NAME=Ubuntu 19.10, full VM"
+        - "JOB_NAME='Ubuntu 19.10, full VM'"
         - "VM_IMAGE=https://cloud-images.ubuntu.com/eoan/current/eoan-server-cloudimg-amd64.img"
     # 3.5.0 and 3.5.1 have different __aiter__ semantics than all
     # other versions, so we need to test them specially. Travis's

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-dist: trusty
+dist: xenial
 
 matrix:
   include:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,36 +6,6 @@ trigger:
 
 jobs:
 
-# Special job that uses a container to check we work on the latest
-# tippy-tip ubuntu. The main thing this adds is openssl 1.1.1/TLS 1.3.
-#
-# Azure has fancy stuff to let you run directly inside a container:
-#
-#   https://docs.microsoft.com/en-us/azure/devops/pipelines/process/container-phases
-#
-# Unfortunately it's useless for us. Azure carefully sets everything
-# up so that you run as a non-root user, but can sudo to get root. But
-# the standard images that docker maintains like 'ubuntu' or 'debian'
-# don't have sudo installed, which means that if you use 'container:
-# ubuntu:rolling' then you simply cannot get root. And it's definitely
-# not worth maintaining our own container image just so we can
-# preinstall sudo:
-#
-#   https://github.com/MicrosoftDocs/vsts-docs/issues/2939
-- job: "py37_latest_ubuntu"
-  pool:
-    vmImage: "ubuntu-16.04"
-  timeoutInMinutes: 10
-  steps:
-    # This actually reveals the CODECOV_TOKEN in the logs, but
-    # AFAICT the only thing the token lets you do is upload coverage
-    # reports, which doesn't seem like a very tempting target for
-    # malicious hackers.
-    - bash: |
-        set -ex
-        env | sort
-        sudo docker run -e SYSTEM_JOBIDENTIFIER="$SYSTEM_JOBIDENTIFIER" -e CODECOV_TOKEN="$CODECOV_TOKEN" -v "$PWD:/t" ubuntu:rolling /bin/bash -c "set -ex; cd /t; apt update; apt install -y python3.7-dev python3-virtualenv git build-essential curl; python3.7 -m virtualenv -p python3.7 venv; source venv/bin/activate; source ci.sh"
-
 - job: 'Windows'
   pool:
     vmImage: 'vs2017-win2016'

--- a/ci.sh
+++ b/ci.sh
@@ -172,11 +172,14 @@ EOF
     rm -f SUCCESS
     # Apparently Travis's bionic images have nested virtualization enabled, so
     # we can use KVM... but the default user isn't in the appropriate groups
-    # to use KVM, so we have to use 'sudo' to add that.
+    # to use KVM, so we have to use 'sudo' to add that. And then a second
+    # 'sudo', because by default we have rights to run arbitrary commands as
+    # root, but we don't have rights to run a command as ourselves but with a
+    # tweaked group setting.
     #
     # Travis Linux VMs have 7.5 GiB RAM, so we give our nested VM 6 GiB RAM
     # (-m 6144).
-    sudo -u $USER -g kvm qemu-system-$VM_CPU \
+    sudo sudo -u $USER -g kvm qemu-system-$VM_CPU \
       -enable-kvm \
       -M pc \
       -m 6144 \

--- a/ci.sh
+++ b/ci.sh
@@ -137,6 +137,7 @@ cat /proc/cpuinfo
 # Pass-through JOB_NAME + the env vars that codecov-bash looks at
 export JOB_NAME="$JOB_NAME"
 export CI="$CI"
+export TRAVIS="$TRAVIS"
 export TRAVIS_COMMIT="$TRAVIS_COMMIT"
 export TRAVIS_PULL_REQUEST_SHA="$TRAVIS_PULL_REQUEST_SHA"
 export TRAVIS_JOB_NUMBER="$TRAVIS_JOB_NUMBER"

--- a/ci.sh
+++ b/ci.sh
@@ -53,7 +53,7 @@ fi
 ### Travis + macOS ###
 
 if [ "$TRAVIS_OS_NAME" = "osx" ]; then
-    CODECOV_NAME="osx_${MACPYTHON}"
+    JOB_NAME="osx_${MACPYTHON}"
     $CURL -Lo macpython.pkg https://www.python.org/ftp/python/${MACPYTHON}/python-${MACPYTHON}-macosx10.6.pkg
     sudo installer -pkg macpython.pkg -target /
     ls /Library/Frameworks/Python.framework/Versions/*/bin/
@@ -68,7 +68,7 @@ fi
 ### PyPy nightly (currently on Travis) ###
 
 if [ "$PYPY_NIGHTLY_BRANCH" != "" ]; then
-    CODECOV_NAME="pypy_nightly_${PYPY_NIGHTLY_BRANCH}"
+    JOB_NAME="pypy_nightly_${PYPY_NIGHTLY_BRANCH}"
     $CURL -fLo pypy.tar.bz2 http://buildbot.pypy.org/nightly/${PYPY_NIGHTLY_BRANCH}/pypy-c-jit-latest-linux64.tar.bz2
     if [ ! -s pypy.tar.bz2 ]; then
         # We know:


### PR DESCRIPTION
I'm not sure if this is actually useful... I just got curious about it
today and it came together more easily than I expected, so now I'm
curious if it actually works :-).

Rumor says that Travis supports nested KVM acceleration now, if you're
using their 'bionic' image, so in theory this should work and be
reasonably fast?

Right now, it isn't especially useful. But if we started adding
support for new Linux kernel features like pidfd (#1241) or
io_uring (#932), then this would become important, because AFAICT this
is the only way to run tests on new kernels on any of the hosted CI
services.

I guess we could also use it to like, test on ARM or something, if we
cared? I experimented with testing on 32-bit, but the test setup
failed because cryptography has stopped shipping 32-bit wheels, and I
couldn't be bothered to figure out how to fix it.