### PR TITLE
Use pidfd to implement trio.Process.wait, when available

### DIFF
--- a/newsfragments/1241.feature.rst
+++ b/newsfragments/1241.feature.rst
@@ -1,0 +1,4 @@
+On Linux kernels v5.3 or newer, `trio.Process.wait` now uses `the
+pidfd API <https://lwn.net/Articles/794707/>`__ to track child
+processes. This shouldn't have any user-visible change, but it makes
+working with subprocesses faster and use less memory.

--- a/trio/_subprocess.py
+++ b/trio/_subprocess.py
@@ -22,7 +22,7 @@ except ImportError:
         import ctypes
         _cdll_for_pidfd_open = ctypes.CDLL(None, use_errno=True)
         _cdll_for_pidfd_open.syscall.restype = ctypes.c_long
-        # fd and flags are actually int-sized, but the syscall() function
+        # pid and flags are actually int-sized, but the syscall() function
         # always takes longs. (Except on x32 where long is 32-bits and syscall
         # takes 64-bit arguments. But in the unlikely case that anyone is
         # using x32, this will still work, b/c we only need to pass in 32 bits


### PR DESCRIPTION
Fixes #1241

The new QEMU-based CI run (#1292) *should* let us test this. I'm curious
to see what codecov says :-).

But unfortunately, even with that, we're still only testing the
ctypes-based configuration, not the configuration that uses the stdlib
`os.pidfd_open` that currently only exists in CPython master. We're
running tests on CPython master, and we're running tests on a new
kernel, but we aren't doing both at the same time. AFAICT the only way
to test that configuration would be to check out and build CPython
master from inside the nested VM, which sounds like a real hassle.
OTOH, I'm not super comfortable about shipping code that hasn't been
tested... `os.pidfd_open` is pretty simple but it's always possible my
ctypes-based implementation has some subtle behavioral difference I
missed.

Also, maybe we should add some tests to confirm the pidfd is cleaned
up properly?

CC: @benjaminp