### PR TITLE
Test on macOS + CPython 3.8

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -105,6 +105,8 @@ jobs:
         python.version: '3.6'
       "Python 3.7":
         python.version: '3.7'
+      "Python 3.8":
+        python.version: '3.8'
 
   steps:
   - task: UsePythonVersion@0


### PR DESCRIPTION
The Azure folks are claiming that the 3.8 rollout is "close enough" (https://github.com/microsoft/azure-pipelines-image-generation/issues/1317), so let's give it a try.