### PR TITLE
[ci] Attempt to speed up CI by moving more jobs from Travis → Azure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ dist: xenial
 
 matrix:
   include:
-    - python: 3.8
-      env: CHECK_DOCS=1
-    - python: 3.8
-      env: CHECK_FORMATTING=1
     # The pypy tests are slow, so we list them first
     - python: pypy3
     - language: generic
@@ -30,10 +26,6 @@ matrix:
     # 'trusty' images.
     - python: 3.5.0
       dist: trusty
-    - python: 3.5
-    - python: 3.6
-    - python: 3.7
-    - python: 3.8
     - python: 3.5-dev
     - python: 3.6-dev
     - python: 3.7-dev

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ jobs:
 
 - job: 'Windows'
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-latest'
   timeoutInMinutes: 20
   strategy:
     # Python version list:
@@ -64,38 +64,43 @@ jobs:
       testRunTitle: 'Windows $(python.pkg) $(python.version)'
     condition: succeededOrFailed()
 
-# Currently broken for unclear reasons probably related to openssl v1.1.1:
-#   https://github.com/python-trio/trio/pull/827#issuecomment-457139883
-#
-# - job: 'Linux'
-#   pool:
-#     vmImage: 'ubuntu-16.04'
-#   timeoutInMinutes: 10
-#   strategy:
-#     matrix:
-#       "Python 3.5":
-#         python.version: '3.5'
-#       "Python 3.6":
-#         python.version: '3.6'
-#       "Python 3.7":
-#         python.version: '3.7'
-#
-#   steps:
-#   - task: UsePythonVersion@0
-#     inputs:
-#       versionSpec: '$(python.version)'
-#
-#   - bash: ci.sh
-#     displayName: "Run the actual tests"
-#
-#   - task: PublishTestResults@2
-#     inputs:
-#       testResultsFiles: 'test-results.xml'
-#     condition: succeededOrFailed()
+- job: 'Linux'
+  pool:
+    vmImage: 'ubuntu-latest'
+  timeoutInMinutes: 10
+  strategy:
+    matrix:
+      "Check docs":
+        python.version: '3.8'
+        CHECK_DOCS: 1
+      "Formatting and linting":
+        python.version: '3.8'
+        CHECK_FORMATTING: 1
+      "Python 3.5":
+        python.version: '3.5'
+      "Python 3.6":
+        python.version: '3.6'
+      "Python 3.7":
+        python.version: '3.7'
+      "Python 3.8":
+        python.version: '3.8'
+
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '$(python.version)'
+
+  - bash: ci.sh
+    displayName: "Run the actual tests"
+
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFiles: 'test-results.xml'
+    condition: succeededOrFailed()
 
 - job: 'macOS'
   pool:
-    vmImage: 'macOS-10.13'
+    vmImage: 'macOS-latest'
   timeoutInMinutes: 10
   strategy:
     matrix:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -90,7 +90,7 @@ jobs:
     inputs:
       versionSpec: '$(python.version)'
 
-  - bash: ci.sh
+  - bash: ./ci.sh
     displayName: "Run the actual tests"
 
   - task: PublishTestResults@2


### PR DESCRIPTION
Only Travis has Python dev builds, an up-to-date pypy build, or nested
virtualization. But we can at least move the more generic stuff over
to Azure to take advantage of the higher parallelization.