### PR TITLE
Improve module-level AttributeError message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ __pycache__/
 .installed.cfg
 *.egg
 /.pybuild
+pip-wheel-metadata/
 
 # Installer logs
 pip-log.txt
@@ -64,3 +65,6 @@ coverage.xml
 
 # Sphinx documentation
 doc/_build/
+
+# PyCharm
+.idea/

--- a/trio/_deprecate.py
+++ b/trio/_deprecate.py
@@ -122,7 +122,8 @@ class _ModuleWithDeprecations(ModuleType):
             )
             return info.value
 
-        raise AttributeError(name)
+        msg = "module '{}' has no attribute '{}'"
+        raise AttributeError(msg.format(self.__name__, name))
 
 
 def enable_attribute_deprecations(module_name):


### PR DESCRIPTION
This PR improves the error message by specifying the module name and also renames `_deprecate.py --> _check_attrs.py` as it might be somewhat misleading for an actual `AttributeError` to be raised from a module named `_deprecate.py`. This latter change might be controversial?

```python
In [1]: import trio

In [2]: trio.stuff
Traceback (most recent call last):

  File "<ipython-input-2-558a186a1b55>", line 1, in <module>
    trio.stuff

  File "c:\users\dhirschf\code\github\python-trio\trio\trio\_check_attrs.py", line 125, in __getattr__
    raise AttributeError(msg)

AttributeError: module 'trio' has no attribute 'stuff'
```