### PR TITLE
Enable Python 3.8 coverage

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -267,14 +267,10 @@ else
         netsh winsock reset
     fi
 
-    # Disable coverage on 3.8 until we run 3.8 on Windows CI too
-    #   https://github.com/python-trio/trio/pull/784#issuecomment-446438407
-    if [[ "$(python -V)" = Python\ 3.8* ]]; then
-        true;
     # coverage is broken in pypy3 7.1.1, but is fixed in nightly and should be
     # fixed in the next release after 7.1.1.
     # See: https://bitbucket.org/pypy/pypy/issues/2943/
-    elif [[ "$TRAVIS_PYTHON_VERSION" = "pypy3" ]]; then
+    if [[ "$TRAVIS_PYTHON_VERSION" = "pypy3" ]]; then
         true;
     else
         # Flag pypy and cpython coverage differently, until it settles down...

--- a/trio/_util.py
+++ b/trio/_util.py
@@ -72,9 +72,12 @@ else:
 if sys.version_info < (3, 5, 2):
 
     def aiter_compat(aiter_impl):
-        @wraps(aiter_impl)
+        # de-sugar decorator to fix Python 3.8 coverage issue
+        # https://github.com/python-trio/trio/pull/784#issuecomment-446438407
         async def __aiter__(*args, **kwargs):
             return aiter_impl(*args, **kwargs)
+
+        __aiter__ = wraps(aiter_impl)(__aiter__)
 
         return __aiter__
 else:


### PR DESCRIPTION
We now test Python 3.8 on Windows, so I rebased the commits of https://github.com/python-trio/trio/pull/784 on top of master (without using coverage master). I don't know how to configure Azure Pipelines on my fork, so here's a PR. It's only a draft because I first want to see if we see the same things.