### PR TITLE
Test PyPy 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 os: linux
 language: python
-dist: xenial
+dist: bionic
 
 jobs:
   include:
     # The pypy tests are slow, so we list them first
-    - python: pypy3
+    - python: pypy3.6-7.2.0
     - language: generic
       env: PYPY_NIGHTLY_BRANCH=py3.6
     # Qemu tests are also slow

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
+os: linux
 language: python
 dist: xenial
 
-matrix:
+jobs:
   include:
     # The pypy tests are slow, so we list them first
     - python: pypy3

--- a/ci.sh
+++ b/ci.sh
@@ -267,26 +267,12 @@ else
         netsh winsock reset
     fi
 
-    # coverage is broken in pypy3 7.1.1, but is fixed in nightly and should be
-    # fixed in the next release after 7.1.1.
-    # See: https://bitbucket.org/pypy/pypy/issues/2943/
-    if [[ "$TRAVIS_PYTHON_VERSION" = "pypy3" ]]; then
-        true;
-    else
-        # Flag pypy and cpython coverage differently, until it settles down...
-        FLAG="cpython"
-        if [[ "$PYPY_NIGHTLY_BRANCH" == "py3.8" ]]; then
-            FLAG="pypy36nightly"
-        elif [[ "$(python -V)" == *PyPy* ]]; then
-            FLAG="pypy36release"
-        fi
-        # It's more common to do
-        #   bash <(curl ...)
-        # but azure is broken:
-        #   https://developercommunity.visualstudio.com/content/problem/743824/bash-task-on-windows-suddenly-fails-with-bash-devf.html
-        curl-harder -o codecov.sh https://codecov.io/bash
-        bash codecov.sh -n "${JOB_NAME}" -F "$FLAG"
-    fi
+    # It's more common to do
+    #   bash <(curl ...)
+    # but azure is broken:
+    #   https://developercommunity.visualstudio.com/content/problem/743824/bash-task-on-windows-suddenly-fails-with-bash-devf.html
+    curl-harder -o codecov.sh https://codecov.io/bash
+    bash codecov.sh -n "${JOB_NAME}"
 
     $PASSED
 fi

--- a/ci.sh
+++ b/ci.sh
@@ -275,7 +275,7 @@ else
     else
         # Flag pypy and cpython coverage differently, until it settles down...
         FLAG="cpython"
-        if [[ "$PYPY_NIGHTLY_BRANCH" == "py3.6" ]]; then
+        if [[ "$PYPY_NIGHTLY_BRANCH" == "py3.8" ]]; then
             FLAG="pypy36nightly"
         elif [[ "$(python -V)" == *PyPy* ]]; then
             FLAG="pypy36release"


### PR DESCRIPTION
Upgrading to PyPy 7.2 allows removing the coverage workaround.

I also tried using PyPy 3.7 nightly, but there are a few TLS/SSL errors that I don't understand, so I'll try that in another pull request.