### PR TITLE
Test PyPy 3.7 nightly 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jobs:
     # The pypy tests are slow, so we list them first
     - python: pypy3.6-7.2.0
     - language: generic
-      env: PYPY_NIGHTLY_BRANCH=py3.6
+      env: PYPY_NIGHTLY_BRANCH=py3.7
     # Qemu tests are also slow
     # The unique thing this provides is testing on the given distro's
     # kernel, which is important when we use new kernel features. This

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ jobs:
     # The pypy tests are slow, so we list them first
     - python: pypy3.6-7.2.0
     - language: generic
+      env: PYPY_NIGHTLY_BRANCH=py3.6
+    - language: generic
       env: PYPY_NIGHTLY_BRANCH=py3.7
     # Qemu tests are also slow
     # The unique thing this provides is testing on the given distro's

--- a/trio/_core/_wakeup_socketpair.py
+++ b/trio/_core/_wakeup_socketpair.py
@@ -1,3 +1,4 @@
+import platform
 import socket
 import sys
 from contextlib import contextmanager
@@ -6,7 +7,7 @@ import signal
 from .. import _core
 from .._util import is_main_thread
 
-if sys.version_info >= (3, 7):
+if sys.version_info >= (3, 7) and platform.python_implementation() != "PyPy":
     HAVE_WARN_ON_FULL_BUFFER = True
 else:
     HAVE_WARN_ON_FULL_BUFFER = False


### PR DESCRIPTION
The following tests fail:

```
FAILED trio/tests/test_highlevel_ssl_helpers.py::test_open_ssl_over_tcp_stream_and_everything_else[tls13]
FAILED trio/tests/test_highlevel_ssl_helpers.py::test_open_ssl_over_tcp_stream_and_everything_else[tls12]
FAILED trio/tests/test_ssl.py::test_ssl_client_basics[tls13]
FAILED trio/tests/test_ssl.py::test_get_channel_binding_after_handshake[tls13]
FAILED trio/tests/test_ssl.py::test_ssl_client_basics[tls12]
FAILED trio/tests/test_ssl.py::test_get_channel_binding_after_handshake[tls12]
```

They're all about TLS 1.2 and TLS 1.3. In some cases, we have `AttributeError: '_SSLSocket' object has no attribute 'get_channel_binding'`, and in others, `Failed: DID NOT RAISE <class 'trio.BrokenResourceError'>`. I'm not sure where to go from here, eg. is there a useful bug report to extract here?