### PR TITLE
Add back cffi on install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,9 +85,7 @@ setup(
         "idna",
         "outcome",
         "sniffio",
-        # PEP 508 style, but:
-        # https://bitbucket.org/pypa/wheel/issues/181/bdist_wheel-silently-discards-pep-508
-        #"cffi; os_name == 'nt'",  # "cffi is required on windows"
+        "cffi; os_name == 'nt'",  # "cffi is required on windows"
     ],
     # This means, just install *everything* you see under trio/, even if it
     # doesn't look like a source file, so long as it appears in MANIFEST.in:

--- a/setup.py
+++ b/setup.py
@@ -85,20 +85,13 @@ setup(
         "idna",
         "outcome",
         "sniffio",
-        "cffi; os_name == 'nt'",  # "cffi is required on windows"
+        # cffi 1.12 adds from_buffer(require_writable=True) and ffi.release()
+        "cffi>=1.12; os_name == 'nt'",  # "cffi is required on windows"
+        "contextvars>=2.1; python_version < '3.7'"
     ],
     # This means, just install *everything* you see under trio/, even if it
     # doesn't look like a source file, so long as it appears in MANIFEST.in:
     include_package_data=True,
-    # Quirky bdist_wheel-specific way:
-    # https://wheel.readthedocs.io/en/latest/#defining-conditional-dependencies
-    # also supported by pip and setuptools, as long as they're vaguely
-    # recent
-    extras_require={
-        # cffi 1.12 adds from_buffer(require_writable=True) and ffi.release()
-        ":os_name == 'nt'": ["cffi >= 1.12"],  # "cffi is required on windows",
-        ":python_version < '3.7'": ["contextvars>=2.1"]
-    },
     python_requires=">=3.5",
     keywords=["async", "io", "networking", "trio"],
     classifiers=[


### PR DESCRIPTION
The wheel bug was fixed in 2017 by setuptools. Indeed, the METADATA is correct now.

https://github.com/pypa/wheel/issues/181