### PR TITLE
Update function open_unix_socket to check the type of filename argument

### DIFF
--- a/trio/_highlevel_open_unix_stream.py
+++ b/trio/_highlevel_open_unix_stream.py
@@ -36,12 +36,13 @@ async def open_unix_socket(filename,):
     Raises:
       OSError: If the socket file could not be connected to.
       RuntimeError: If AF_UNIX sockets are not supported.
+      TypeError: if filename is not str or bytes.
     """
     if not has_unix:
         raise RuntimeError("Unix sockets are not supported on this platform")
 
-    if filename is None:
-        raise ValueError("Filename cannot be None")
+    if not isinstance(filename, (str, bytes)):
+        raise TypeError("Filename must be str or bytes")
 
     # much more simplified logic vs tcp sockets - one socket type and only one
     # possible location to connect to

--- a/trio/_highlevel_open_unix_stream.py
+++ b/trio/_highlevel_open_unix_stream.py
@@ -41,8 +41,8 @@ async def open_unix_socket(filename,):
     if not has_unix:
         raise RuntimeError("Unix sockets are not supported on this platform")
 
-    if not isinstance(filename, (str, bytes)):
-        raise TypeError("Filename must be str or bytes")
+    if not isinstance(filename, (str, trio.Path, bytes)):
+        raise TypeError("Filename must be str, trio.Path or bytes")
 
     # much more simplified logic vs tcp sockets - one socket type and only one
     # possible location to connect to

--- a/trio/_highlevel_open_unix_stream.py
+++ b/trio/_highlevel_open_unix_stream.py
@@ -36,18 +36,14 @@ async def open_unix_socket(filename,):
     Raises:
       OSError: If the socket file could not be connected to.
       RuntimeError: If AF_UNIX sockets are not supported.
-      TypeError: if filename is not str or bytes.
     """
     if not has_unix:
         raise RuntimeError("Unix sockets are not supported on this platform")
-
-    if not isinstance(filename, (str, trio.Path, bytes)):
-        raise TypeError("Filename must be str, trio.Path or bytes")
 
     # much more simplified logic vs tcp sockets - one socket type and only one
     # possible location to connect to
     sock = socket(AF_UNIX, SOCK_STREAM)
     with close_on_error(sock):
-        await sock.connect(filename)
+        await sock.connect(trio._util.fspath(filename))
 
     return trio.SocketStream(sock)

--- a/trio/tests/test_highlevel_open_unix_stream.py
+++ b/trio/tests/test_highlevel_open_unix_stream.py
@@ -30,6 +30,12 @@ def test_close_on_error():
     assert c.closed
 
 
+@pytest.mark.parametrize('filename', [4, 4.5])
+async def test_open_with_bad_filename_type(filename):
+    with pytest.raises(TypeError):
+        await open_unix_socket(filename)
+
+
 async def test_open_bad_socket():
     # mktemp is marked as insecure, but that's okay, we don't want the file to
     # exist


### PR DESCRIPTION
Hi,
this PR fixes an edge case where a user can pass a number when calling `open_unix_socket`. In this case he will get a `TypeError`. There are two possibilities:
- We can just let `socket` function raises the error or
- We can intercept the error and print a nicer message, which is what I did

And in all cases, we need to update the docstring :)