### PR TITLE
[WIP] Update various errors/typos in rst documentation and docstrings

### DIFF
--- a/docs/source/reference-core.rst
+++ b/docs/source/reference-core.rst
@@ -1351,7 +1351,7 @@ after an hour, that grows to ~32,400. Eventually, the program will run
 out of memory. And well before we run out of memory, our latency on
 handling individual messages will become abysmal. For example, at the
 one minute mark, the producer is sending message ~600, but the
-producer is still processing message ~60. Message 600 will have to sit
+consumer is still processing message ~60. Message 600 will have to sit
 in the channel for ~9 minutes before the consumer catches up and
 processes it.
 

--- a/docs/source/reference-io.rst
+++ b/docs/source/reference-io.rst
@@ -24,7 +24,7 @@ create complex transport configurations. Here's some examples:
   speak SSL over the network is to wrap an
   :class:`~trio.SSLStream` around a :class:`~trio.SocketStream`.
 
-* If you spawn a :ref:`subprocess`, you can get a
+* If you spawn a :ref:`subprocess <subprocess>`, you can get a
   :class:`~trio.abc.SendStream` that lets you write to its stdin, and
   a :class:`~trio.abc.ReceiveStream` that lets you read from its
   stdout. If for some reason you wanted to speak SSL to a subprocess,

--- a/docs/source/reference-testing.rst
+++ b/docs/source/reference-testing.rst
@@ -118,7 +118,7 @@ some interesting hooks you can set, that let you customize the
 behavior of their methods. This is where you can insert the evil, if
 you want it. :func:`memory_stream_one_way_pair` takes advantage of
 these hooks in a relatively boring way: it just sets it up so that
-when you call ``sendall``, or when you close the send stream, then it
+when you call ``send_all``, or when you close the send stream, then it
 automatically triggers a call to :func:`memory_stream_pump`, which is
 a convenience function that takes data out of a
 :class:`MemorySendStream`\´s buffer and puts it into a

--- a/trio/_abc.py
+++ b/trio/_abc.py
@@ -559,7 +559,7 @@ class SendChannel(AsyncResource, Generic[SendType]):
     with`` block.
 
     If you want to send raw bytes rather than Python objects, see
-    `ReceiveStream`.
+    `SendStream`.
 
     """
     __slots__ = ()

--- a/trio/_core/_generated_run.py
+++ b/trio/_core/_generated_run.py
@@ -193,21 +193,21 @@ async def wait_all_tasks_blocked(cushion=0.0, tiebreaker=0):
                  lock = trio.Lock()
                  await lock.acquire()
                  async with trio.open_nursery() as nursery:
-                     child = nursery.start_soon(lock_taker, lock)
+                     nursery.start_soon(lock_taker, lock)
                      # child hasn't run yet, we have the lock
                      assert lock.locked()
-                     assert lock._owner is trio.current_task()
+                     assert lock._owner is trio.hazmat.current_task()
                      await trio.testing.wait_all_tasks_blocked()
                      # now the child has run and is blocked on lock.acquire(), we
                      # still have the lock
                      assert lock.locked()
-                     assert lock._owner is trio.current_task()
+                     assert lock._owner is trio.hazmat.current_task()
                      lock.release()
                      try:
                          # The child has a prior claim, so we can't have it
                          lock.acquire_nowait()
                      except trio.WouldBlock:
-                         assert lock._owner is child
+                         assert lock._owner is not trio.hazmat.current_task()
                          print("PASS")
                      else:
                          print("FAIL")

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -1581,21 +1581,21 @@ class Runner:
                  lock = trio.Lock()
                  await lock.acquire()
                  async with trio.open_nursery() as nursery:
-                     child = nursery.start_soon(lock_taker, lock)
+                     nursery.start_soon(lock_taker, lock)
                      # child hasn't run yet, we have the lock
                      assert lock.locked()
-                     assert lock._owner is trio.current_task()
+                     assert lock._owner is trio.hazmat.current_task()
                      await trio.testing.wait_all_tasks_blocked()
                      # now the child has run and is blocked on lock.acquire(), we
                      # still have the lock
                      assert lock.locked()
-                     assert lock._owner is trio.current_task()
+                     assert lock._owner is trio.hazmat.current_task()
                      lock.release()
                      try:
                          # The child has a prior claim, so we can't have it
                          lock.acquire_nowait()
                      except trio.WouldBlock:
-                         assert lock._owner is child
+                         assert lock._owner is not trio.hazmat.current_task()
                          print("PASS")
                      else:
                          print("FAIL")

--- a/trio/_highlevel_open_tcp_stream.py
+++ b/trio/_highlevel_open_tcp_stream.py
@@ -212,7 +212,7 @@ async def open_tcp_stream(
           connection attempt to succeed or fail before getting impatient and
           starting another one in parallel. Set to `math.inf` if you want
           to limit to only one connection attempt at a time (like
-          :func:`socket.create_connection`). Default: 0.3 (300 ms).
+          :func:`socket.create_connection`). Default: 0.25 (250 ms).
 
     Returns:
       SocketStream: a :class:`~trio.abc.Stream` connected to the given server.

--- a/trio/_highlevel_ssl_helpers.py
+++ b/trio/_highlevel_ssl_helpers.py
@@ -84,7 +84,7 @@ async def open_ssl_over_tcp_listeners(
       host (str, bytes, or None): The address to bind to; use ``None`` to bind
           to the wildcard address. See :func:`open_tcp_listeners`.
       https_compatible (bool): See :class:`~trio.SSLStream` for details.
-      backlog (int or None): See :class:`~trio.SSLStream` for details.
+      backlog (int or None): See :func:`open_tcp_listeners` for details.
 
     """
     tcp_listeners = await trio.open_tcp_listeners(

--- a/trio/_sync.py
+++ b/trio/_sync.py
@@ -739,7 +739,7 @@ class Condition:
 
     @enable_ki_protection
     async def wait(self):
-        """Wait for another thread to call :meth:`notify` or
+        """Wait for another task to call :meth:`notify` or
         :meth:`notify_all`.
 
         When calling this method, you must hold the lock. It releases the lock

--- a/trio/testing/_memory_streams.py
+++ b/trio/testing/_memory_streams.py
@@ -393,7 +393,7 @@ def memory_stream_pair():
         async def trickle():
             # left is a StapledStream, and left.send_stream is a MemorySendStream
             # right is a StapledStream, and right.recv_stream is a MemoryReceiveStream
-            while memory_stream_pump(left.send_stream, right.recv_stream, max_byes=1):
+            while memory_stream_pump(left.send_stream, right.recv_stream, max_bytes=1):
                 # Pause between each byte
                 await trio.sleep(1)
         # Normally this send_all_hook calls memory_stream_pump directly without


### PR DESCRIPTION
Hi folks,
This PR fixes some typos in documentation. I marked it WIP because I want another change but I don't know how to do it. It concerns this section in reference-io
![subprocess](https://user-images.githubusercontent.com/10879977/74208817-6f4e8680-4c85-11ea-9d7d-3198dcd7f9fe.png)

I don't know if is possible to create an alias for a `:ref:` :(