### PR TITLE
Allow dev builds to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,12 @@ jobs:
     - python: 3.7-dev
     - python: 3.8-dev
     - python: nightly
+  allow_failures:
+    - python: 3.5-dev
+    - python: 3.6-dev
+    - python: 3.7-dev
+    - python: 3.8-dev
+    - python: nightly
 
 script:
   - ./ci.sh


### PR DESCRIPTION
Until https://travis-ci.community/t/python-development-versions-no-longer-include-pip-due-to-virtualenv-20-x/7180 is fully resolved.

The fix should land in the Travis Python real soon now, but until then let's unblock all the pull requests that are waiting. I'll revert this as soon as I can confirm the fix.

See #1402 for more details.