### PR TITLE
Deprecation warning for python3.5

### DIFF
--- a/trio/__init__.py
+++ b/trio/__init__.py
@@ -64,7 +64,7 @@ from ._highlevel_ssl_helpers import (
     open_ssl_over_tcp_stream, open_ssl_over_tcp_listeners, serve_ssl_over_tcp
 )
 
-from ._deprecate import TrioDeprecationWarning, warn_deprecated
+from ._deprecate import TrioDeprecationWarning
 
 # Submodules imported by default
 from . import hazmat

--- a/trio/__init__.py
+++ b/trio/__init__.py
@@ -173,5 +173,7 @@ del fixup_module_metadata
 
 import sys
 if sys.version_info < (3, 6):
-    _deprecate.warn_deprecated("Support for Python 3.5", "0.14", issue=75, instead="Python 3.6+")
+    _deprecate.warn_deprecated(
+        "Support for Python 3.5", "0.14", issue=75, instead="Python 3.6+"
+    )
 del sys

--- a/trio/__init__.py
+++ b/trio/__init__.py
@@ -64,7 +64,7 @@ from ._highlevel_ssl_helpers import (
     open_ssl_over_tcp_stream, open_ssl_over_tcp_listeners, serve_ssl_over_tcp
 )
 
-from ._deprecate import TrioDeprecationWarning
+from ._deprecate import TrioDeprecationWarning, warn_deprecated
 
 # Submodules imported by default
 from . import hazmat
@@ -170,3 +170,8 @@ fixup_module_metadata(
     __name__ + ".subprocess", _deprecated_subprocess_reexports.__dict__
 )
 del fixup_module_metadata
+
+import sys
+if sys.version_info < (3, 6):
+    _deprecate.warn_deprecated("Support for Python 3.5", "0.14", issue=75, instead="Python 3.6+")
+del sys


### PR DESCRIPTION
This is the deprecation warning needed for #1396. I tested that the deprecation warning works as expected locally and it looks good to me:

```
(venv) wgwz@icegarden ~/code/trio $ python
Python 3.5.9+ (heads/3.5:276eb67c29, Feb 19 2020, 11:04:36)
[GCC 9.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import trio
__main__:1: TrioDeprecationWarning: Support for Python 3.5 is deprecated since Trio 0.14; use Python 3.6+ instead (https://github.com/python-trio/trio/issues/75)                            
>>>
```

Running the tests locally worked as expected as well and I now see this warning there too (expected):

```
venv/lib/python3.5/site-packages/py/_path/local.py:701
  /home/wgwz/code/trio/venv/lib/python3.5/site-packages/py/_path/local.py:701: TrioDeprecationWarning: Support for Python 3.5 is deprecated since Trio 0.14; use Python 3.6+ instead (https://github.com/python-trio/trio/issues/75)
    __import__(modname)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
```