### PR TITLE
Mark upstream-only test

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,5 @@
 [tool:pytest]
 xfail_strict = true
 faulthandler_timeout=60
+markers =
+    redistributors_should_skip: tests that should be skipped by downstream redistributors

--- a/trio/tests/test_exports.py
+++ b/trio/tests/test_exports.py
@@ -49,6 +49,11 @@ def public_namespaces(module):
 NAMESPACES = list(public_namespaces(trio))
 
 
+# It doesn't make sense for downstream redistributors to run this test, since
+# they might be using a newer version of Python with additional symbols which
+# won't be reflected in trio.socket, and this shouldn't cause downstream test
+# runs to start failing.
+@pytest.mark.redistributors_should_skip
 # pylint/jedi often have trouble with alpha releases, where Python's internals
 # are in flux, grammar may not have settled down, etc.
 @pytest.mark.skipif(


### PR DESCRIPTION
This is partly an RFC. I'm not sure if this is exactly the best way to resolve my issue, but I thought a PR would be a good starting point for a discussion.

In Debian, trio packaging can no longer be rebuilt successfully. This is because we run upstream tests as part of the package build, and the upstream tests have started failing. They're failing because `test_exports.py::test_static_tool_sees_all_symbols` fails because Debian has updated Python since I last updated the trio packaging, and `socket.py`'s duplicate list of symbols has fallen behind.

I understand why the test exists, and it makes perfect sense - for upstream. You want CI to fail if the list falls behind, so you can keep it up to date. I'm not sure it makes sense for downstreams that package trio to be running this test though - because we expect to be able to do things like add symbols to Python (by updating its minor version) without making the trio build then fail. Nor do we rerun all the builds for everything that uses Python when we update Python, so we wouldn't detect this situation anyway.

It seems to me that this makes this test rather different to the regular tests somehow. It's a different class of test that serves a different purpose to the others.

There are a few ways I can think of to resolve this:
 * I could cherry-pick #1382 and continue cherry-picking every subsequent similar update as they get applied upstream. But I wouldn't necessarily know when this becomes necessary and so I'm not sure a system that requires individual manual interventions are a good solution.
 * I could apply a patch in packaging to drop or skip this specific test, but then I would have to maintain this patch.
 * We could mark (in upstream) the test as belonging to a class of tests that it is inappropriate for downstreams to run. Then packagers could deselect all tests marked as such when they run their tests.

This PR demonstrates the third case. Then in Debian packaging I add `export PYBUILD_TEST_ARGS=-m not\ upstream_only` and the tests pass again.

What do you think?