### PR TITLE
Turn codecov back on

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -267,7 +267,13 @@ else
         netsh winsock reset
     fi
 
-    bash <(curl-harder -o codecov.sh https://codecov.io/bash) -n "${JOB_NAME}"
+    # The codecov docs recommend something like 'bash <(curl ...)' to pipe the
+    # script directly into bash as its being downloaded. But, the codecov
+    # server is flaky, so we instead save to a temp file with retries, and
+    # wait until we've successfully fetched the whole script before trying to
+    # run it.
+    curl-harder -o codecov.sh https://codecov.io/bash
+    bash codecov.sh -n "${JOB_NAME}"
 
     $PASSED
 fi


### PR DESCRIPTION
Apparently this got accidentally disabled as part of a cleanup a while
ago. (The problem is that the bash <(...) syntax assumes that curl is
printing the file to stdout, but we're actually redirecting to a
temporary file in order to handle retries.)