### PR TITLE
Port Azure Pipelines configuration to Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [pull_request, push]
+on: [pull_request]
 
 jobs:
   Windows:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,90 @@
+name: CI
+
+on: [pull_request, push]
+
+jobs:
+  Windows:
+    name: 'Windows (${{ matrix.python }}, ${{ matrix.arch }}${{ matrix.extra_name }})'
+    timeout-minutes: 20
+    runs-on: 'windows-latest'
+    strategy:
+      matrix:
+        python: ['3.5', '3.6', '3.7', '3.8']
+        arch: ['x86', 'x64']
+        lsp: ['']
+        extra_name: ['']
+        include:
+          - python: '3.8'
+            arch: 'x64'
+            lsp: 'http://www.proxifier.com/download/ProxifierSetup.exe'
+            extra_name: ', with IFS LSP'
+          - python: '3.8'
+            arch: 'x64'
+            lsp: 'http://download.pctools.com/mirror/updates/9.0.0.2308-SDavfree-lite_en.exe'
+            extra_name: ', with non-IFS LSP'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup python
+        uses: actions/setup-python@v1
+        with:
+          python-version: '${{ matrix.python }}'
+          architecture: '${{ matrix.arch }}'
+      - name: Run tests
+        run: ./ci.sh
+        shell: bash
+        env:
+          LSP: '${{ matrix.lsp }}'
+          # Should match 'name:' up above
+          JOB_NAME: 'Windows (${{ matrix.python }}, ${{ matrix.arch }}${{ matrix.extra_name }})'
+
+  Linux:
+    name: 'Linux (${{ matrix.python }}${{ matrix.extra_name }})'
+    timeout-minutes: 10
+    runs-on: 'ubuntu-latest'
+    strategy:
+      matrix:
+        python: ['3.5', '3.6', '3.7', '3.8']
+        check_docs: ['0']
+        check_formatting: ['0']
+        extra_name: ['']
+        include:
+          - python: '3.8'
+            check_docs: '1'
+            extra_name: ', check docs'
+          - python: '3.8'
+            check_formatting: '1'
+            extra_name: ', check formatting'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup python
+        uses: actions/setup-python@v1
+        with:
+          python-version: '${{ matrix.python }}'
+      - name: Run tests
+        run: ./ci.sh
+        env:
+          CHECK_DOCS: '${{ matrix.check_docs }}'
+          CHECK_FORMATTING: '${{ matrix.check_formatting }}'
+          # Should match 'name:' up above
+          JOB_NAME: 'Linux (${{ matrix.python }}${{ matrix.extra_name }})'
+
+  macOS:
+    name: 'macOS (${{ matrix.python }})'
+    timeout-minutes: 10
+    runs-on: 'macos-latest'
+    strategy:
+      matrix:
+        python: ['3.5', '3.6', '3.7', '3.8']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup python
+        uses: actions/setup-python@v1
+        with:
+          python-version: '${{ matrix.python }}'
+      - name: Run tests
+        run: ./ci.sh
+        env:
+          JOB_NAME: 'macOS (${{ matrix.python }})'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,4 +87,5 @@ jobs:
       - name: Run tests
         run: ./ci.sh
         env:
+          # Should match 'name:' up above
           JOB_NAME: 'macOS (${{ matrix.python }})'

--- a/trio/_tools/gen_exports.py
+++ b/trio/_tools/gen_exports.py
@@ -10,7 +10,6 @@ import astor
 import os
 from pathlib import Path
 import sys
-import yapf.yapflib.yapf_api as formatter
 
 from textwrap import indent
 


### PR DESCRIPTION
Github Actions is probably a better choice anyway, because the free
tier gives us 2x the resources, plus it avoids all the janky stuff
with managing separate Pipelines user accounts. But the final straw is
that Azure Pipelines has been totally broken for unknown reasons for
the last week+, see: #1455, #1466, etc.