### PR TITLE
Add fail-fast: false to Github Actions config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ jobs:
     timeout-minutes: 20
     runs-on: 'windows-latest'
     strategy:
+      fail-fast: false
       matrix:
         python: ['3.5', '3.6', '3.7', '3.8']
         arch: ['x86', 'x64']
@@ -43,6 +44,7 @@ jobs:
     timeout-minutes: 10
     runs-on: 'ubuntu-latest'
     strategy:
+      fail-fast: false
       matrix:
         python: ['3.5', '3.6', '3.7', '3.8']
         check_docs: ['0']
@@ -75,6 +77,7 @@ jobs:
     timeout-minutes: 10
     runs-on: 'macos-latest'
     strategy:
+      fail-fast: false
       matrix:
         python: ['3.5', '3.6', '3.7', '3.8']
     steps:


### PR DESCRIPTION
By default, as soon as a single job in a group fails, then GA will
cancel all the other jobs. This is kind of confusing, e.g. I was just
looking at a PR that had a Python 3.5-specific failure, but that
wasn't immediately obvious, because GA only ran the 3.5 tests and then
skipped all the others. So let's disable that behavior.