### PR TITLE
Removed reference to `portal` in from thread example

### DIFF
--- a/docs/source/reference-core/from-thread-example.py
+++ b/docs/source/reference-core/from-thread-example.py
@@ -21,7 +21,7 @@ async def main():
 
     async with trio.open_nursery() as nursery:
         # In a background thread, run:
-        #   thread_fn(portal, receive_from_trio, send_to_trio)
+        #   thread_fn(receive_from_trio, send_to_trio)
         nursery.start_soon(
             trio.to_thread.run_sync, thread_fn, receive_from_trio, send_to_trio
         )


### PR DESCRIPTION
When I was reading the docs, I was unsure of why `portal` was there in the reference.

My assumption is that it's there to hint to the reader that calling `trio.to_thread.run_sync` creates a portal in a sense, but based in the function signature the comment was confusing to me.

Please correct me if I'm misunderstanding anything!