### PR TITLE
Enable GHA CI on pushes to the master branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   Windows:


### PR DESCRIPTION
We don't really care about this in general, because we run CI on
everything before its merged. But codecov cares, because it needs this
to figure out the "baseline" for coverage comparisons.