### PR TITLE
Fixed NotImplementedError for set_wakeup_fd on PyPy3/Windows

### DIFF
--- a/trio/_core/_wakeup_socketpair.py
+++ b/trio/_core/_wakeup_socketpair.py
@@ -60,7 +60,8 @@ class WakeupSocketpair:
 
     @contextmanager
     def wakeup_on_signals(self):
-        if not is_main_thread():
+        # PyPy does not have (or need) set_wakeup_fd() on Windows
+        if not is_main_thread() or not hasattr(signal, 'set_wakeup_fd'):
             yield
             return
         fd = self.write_sock.fileno()

--- a/trio/_core/_wakeup_socketpair.py
+++ b/trio/_core/_wakeup_socketpair.py
@@ -61,7 +61,7 @@ class WakeupSocketpair:
     @contextmanager
     def wakeup_on_signals(self):
         # PyPy does not have (or need) set_wakeup_fd() on Windows
-        if not is_main_thread() or not hasattr(signal, 'set_wakeup_fd'):
+        if not is_main_thread() or sys.implementation.name == 'pypy':
             yield
             return
         fd = self.write_sock.fileno()


### PR DESCRIPTION
PyPy does not have `signal.set_wakeup_fd()` on Windows, but ctrl+c and ctrl+break work just fine without it.

Fixes #1361.