### PR TITLE
Prevented the installation of cffi on PyPy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,8 @@ setup(
         "sniffio",
         # cffi 1.12 adds from_buffer(require_writable=True) and ffi.release()
         # cffi 1.14 fixes memory leak inside ffi.getwinerror()
-        "cffi>=1.14; os_name == 'nt'",  # "cffi is required on windows"
+        # cffi is required on Windows, except on PyPy where it is built-in
+        "cffi>=1.14; os_name == 'nt' and implementation_name != 'pypy'",
         "contextvars>=2.1; python_version < '3.7'"
     ],
     # This means, just install *everything* you see under trio/, even if it


### PR DESCRIPTION
This allows the installation of trio on Windows + PyPy3.