### PR TITLE
Better error messages from Final and NoPublicConstructor

### DIFF
--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -2155,11 +2155,7 @@ def test_system_task_contexts():
 
 
 def test_Nursery_init():
-    check_Nursery_error = pytest.raises(
-        TypeError, match='no public constructor available'
-    )
-
-    with check_Nursery_error:
+    with pytest.raises(TypeError):
         _core._run.Nursery(None, None)
 
 
@@ -2170,23 +2166,17 @@ async def test_Nursery_private_init():
 
 
 def test_Nursery_subclass():
-    with pytest.raises(
-        TypeError, match='`Nursery` does not support subclassing'
-    ):
+    with pytest.raises(TypeError):
 
         class Subclass(_core._run.Nursery):
             pass
 
 
 def test_Cancelled_init():
-    check_Cancelled_error = pytest.raises(
-        TypeError, match='no public constructor available'
-    )
-
-    with check_Cancelled_error:
+    with pytest.raises(TypeError):
         raise _core.Cancelled
 
-    with check_Cancelled_error:
+    with pytest.raises(TypeError):
         _core.Cancelled()
 
     # private constructor should not raise
@@ -2199,18 +2189,14 @@ def test_Cancelled_str():
 
 
 def test_Cancelled_subclass():
-    with pytest.raises(
-        TypeError, match='`Cancelled` does not support subclassing'
-    ):
+    with pytest.raises(TypeError):
 
         class Subclass(_core.Cancelled):
             pass
 
 
 def test_CancelScope_subclass():
-    with pytest.raises(
-        TypeError, match='`CancelScope` does not support subclassing'
-    ):
+    with pytest.raises(TypeError):
 
         class Subclass(_core.CancelScope):
             pass

--- a/trio/_util.py
+++ b/trio/_util.py
@@ -216,7 +216,9 @@ class Final(BaseMeta):
         for base in bases:
             if isinstance(base, Final):
                 raise TypeError(
-                    "`%s` does not support subclassing" % base.__name__
+                    "the {!r} class does not support subclassing".format(
+                        base.__name__
+                    )
                 )
         return super().__new__(cls, name, bases, cls_namespace)
 
@@ -240,7 +242,9 @@ class NoPublicConstructor(Final):
     - TypeError if a sub class or an instance is created.
     """
     def __call__(self, *args, **kwargs):
-        raise TypeError("no public constructor available")
+        raise TypeError(
+            "the {!r} class has no public constructor".format(self.__name__)
+        )
 
     def _create(self, *args, **kwargs):
         return super().__call__(*args, **kwargs)

--- a/trio/_util.py
+++ b/trio/_util.py
@@ -216,9 +216,7 @@ class Final(BaseMeta):
         for base in bases:
             if isinstance(base, Final):
                 raise TypeError(
-                    "the {!r} class does not support subclassing".format(
-                        base.__name__
-                    )
+                    f"{base.__module__}.{base.__qualname__} does not support subclassing"
                 )
         return super().__new__(cls, name, bases, cls_namespace)
 
@@ -243,7 +241,7 @@ class NoPublicConstructor(Final):
     """
     def __call__(self, *args, **kwargs):
         raise TypeError(
-            "the {!r} class has no public constructor".format(self.__name__)
+            f"{self.__module__}.{self.__qualname__} has no public constructor"
         )
 
     def _create(self, *args, **kwargs):

--- a/trio/tests/test_util.py
+++ b/trio/tests/test_util.py
@@ -100,9 +100,7 @@ def test_final_metaclass():
     class FinalClass(metaclass=Final):
         pass
 
-    with pytest.raises(
-        TypeError, match="`FinalClass` does not support subclassing"
-    ):
+    with pytest.raises(TypeError):
 
         class SubClass(FinalClass):
             pass
@@ -112,12 +110,10 @@ def test_no_public_constructor_metaclass():
     class SpecialClass(metaclass=NoPublicConstructor):
         pass
 
-    with pytest.raises(TypeError, match="no public constructor available"):
+    with pytest.raises(TypeError):
         SpecialClass()
 
-    with pytest.raises(
-        TypeError, match="`SpecialClass` does not support subclassing"
-    ):
+    with pytest.raises(TypeError):
 
         class SubClass(SpecialClass):
             pass


### PR DESCRIPTION
This is a pretty trivial change, but I noticed it while working on
gh-1496 so I figured I'd just fix it.