### PR TITLE
Use Ubuntu 20.04 in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 os: linux
 language: python
-dist: bionic
+dist: focal
 
 jobs:
   include:
     # The pypy tests are slow, so we list them first
     - python: pypy3.6-7.2.0
+      dist: bionic
     - language: generic
       env: PYPY_NIGHTLY_BRANCH=py3.6
     # Qemu tests are also slow
@@ -15,13 +16,11 @@ jobs:
     # early warning of any issues that might happen in the next Ubuntu
     # LTS.
     - language: generic
-      # We use bionic for the host, b/c rumor says that Travis's
-      # 'bionic' systems have nested KVM enabled.
-      dist: bionic
       env:
-        - "JOB_NAME='Ubuntu 19.10, full VM'"
-        - "VM_IMAGE=https://cloud-images.ubuntu.com/eoan/current/eoan-server-cloudimg-amd64.img"
+        - "JOB_NAME='Ubuntu 20.04, full VM'"
+        - "VM_IMAGE=https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img"
     - python: 3.6.1  # earliest 3.6 version available on Travis
+      dist: bionic
     - python: 3.6-dev
     - python: 3.7-dev
     - python: 3.8-dev

--- a/ci.sh
+++ b/ci.sh
@@ -106,6 +106,7 @@ fi
 ### Qemu virtual-machine inception, on Travis
 
 if [ "$VM_IMAGE" != "" ]; then
+    uname -a
     VM_CPU=${VM_CPU:-x86_64}
 
     sudo apt update


### PR DESCRIPTION
I used `gsutil ls gs://travis-ci-language-archives/python/binaries/ubuntu/20.04/x86_64/` to see what versions of Python were available.