### PR TITLE
Test Fedora 32 VM to get Linux 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ jobs:
       # 'bionic' systems have nested KVM enabled.
       dist: bionic
       env:
-        - "JOB_NAME='Ubuntu 19.10, full VM'"
-        - "LINUX_VM_IMAGE=https://cloud-images.ubuntu.com/eoan/current/eoan-server-cloudimg-amd64.img"
+        - "JOB_NAME='Fedora 32, full VM'"
+        - "LINUX_VM_IMAGE=https://download.fedoraproject.org/pub/fedora/linux/releases/32/Cloud/x86_64/images/Fedora-Cloud-Base-32-1.6.x86_64.qcow2"
 
     - python: 3.6.1  # earliest 3.6 version available on Travis
     - python: 3.6-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,23 @@
 os: linux
 language: python
-dist: bionic
+dist: focal
 
 jobs:
   include:
     # The pypy tests are slow, so we list them first
     - python: pypy3.6-7.2.0
+      dist: bionic
     - language: generic
       env: PYPY_NIGHTLY_BRANCH=py3.6
     # Qemu tests are also slow
     # FreeBSD:
     - language: generic
-      dist: bionic
       env:
         - "JOB_NAME='FreeBSD 12.1-RELEASE, full VM'"
         - "FREEBSD_INSTALLER_ISO_XZ=https://download.freebsd.org/ftp/releases/amd64/amd64/ISO-IMAGES/12.1/FreeBSD-12.1-RELEASE-amd64-disc1.iso.xz"
         # Increment this each time you change the image build code in
         # ci.sh and want to intentionally bust the cache.
-        - "CACHE_GEN=2"
+        - "CACHE_GEN=3"
       cache:
         directories:
           - travis-cache
@@ -28,14 +28,12 @@ jobs:
     # early warning of any issues that might happen in the next Ubuntu
     # LTS.
     - language: generic
-      # We use bionic for the host, b/c rumor says that Travis's
-      # 'bionic' systems have nested KVM enabled.
-      dist: bionic
       env:
         - "JOB_NAME='Fedora 32, full VM'"
         - "LINUX_VM_IMAGE=https://download.fedoraproject.org/pub/fedora/linux/releases/32/Cloud/x86_64/images/Fedora-Cloud-Base-32-1.6.x86_64.qcow2"
 
     - python: 3.6.1  # earliest 3.6 version available on Travis
+      dist: bionic
     - python: 3.6-dev
     - python: 3.7-dev
     - python: 3.8-dev

--- a/ci.sh
+++ b/ci.sh
@@ -319,7 +319,7 @@ trap "poweroff" exit
 uname -a
 echo \$PWD
 id
-cat /etc/lsb-release
+cat /etc/fedora-release
 cat /proc/cpuinfo
 
 # Pass-through JOB_NAME + the env vars that codecov-bash looks at
@@ -340,14 +340,17 @@ env | sort
 mkdir /host-files
 mount -t 9p -o trans=virtio,version=9p2000.L host-files /host-files
 
-# Install and set up the system Python (assumes Debian/Ubuntu)
-apt update
-apt install -y python3-dev python3-virtualenv git build-essential curl
-python3 -m virtualenv -p python3 /venv
+# Set up the system Python (Fedora preinstalls Python 3)
+python3 -m venv /venv
 # Uses unbound shell variable PS1, so have to allow that temporarily
 set +u
 source /venv/bin/activate
 set -u
+
+# We put a tmpfs on the empty dir because coverage uses it for
+# storage, and this makes it *massively* faster than if it's on NFS
+mkdir /host-files/empty
+mount -t tmpfs tmpfs /host-files/empty
 
 # And then we re-invoke ourselves!
 cd /host-files


### PR DESCRIPTION
This includes the newer io_uring.

Interestingly, though, we get this failure on Fedora 32 with Linux 5.6:

```
[  178.198410] cloud-init[668]: =================================== FAILURES ===================================
[  178.210646] cloud-init[668]: __________________________________ test_pipes __________________________________
[  178.222895] cloud-init[668]:     async def test_pipes():
[  178.231072] cloud-init[668]:         async with await open_process(
[  178.240076] cloud-init[668]:             COPY_STDIN_TO_STDOUT_AND_BACKWARD_TO_STDERR,
[  178.250236] cloud-init[668]:             stdin=subprocess.PIPE,
[  178.258906] cloud-init[668]:             stdout=subprocess.PIPE,
[  178.267381] cloud-init[668]:             stderr=subprocess.PIPE,
[  178.275827] cloud-init[668]:         ) as proc:
[  178.282874] cloud-init[668]:             msg = b"the quick brown fox jumps over the lazy dog"
[  178.293632] cloud-init[668]:     
[  178.299695] cloud-init[668]:             async def feed_input():
[  178.307731] cloud-init[668]:                 await proc.stdin.send_all(msg)
[  178.316621] cloud-init[668]:                 await proc.stdin.aclose()
[  178.324972] cloud-init[668]:     
[  178.330520] cloud-init[668]:             async def check_output(stream, expected):
[  178.340674] cloud-init[668]:                 seen = bytearray()
[  178.349319] cloud-init[668]:                 async for chunk in stream:
[  178.358565] cloud-init[668]:                     seen += chunk
[  178.367056] cloud-init[668]:                 assert seen == expected
[  178.376660] cloud-init[668]:     
[  178.382834] cloud-init[668]:             async with _core.open_nursery() as nursery:
[  178.393086] cloud-init[668]:                 # fail quickly if something is broken
[  178.403041] cloud-init[668]:                 nursery.cancel_scope.deadline = _core.current_time() + 3.0
[  178.414754] cloud-init[668]:                 nursery.start_soon(feed_input)
[  178.424084] cloud-init[668]:                 nursery.start_soon(check_output, proc.stdout, msg)
[  178.435395] cloud-init[668]:                 nursery.start_soon(check_output, proc.stderr, msg[::-1])
[  178.446341] cloud-init[668]:     
[  178.452663] cloud-init[668]: >           assert not nursery.cancel_scope.cancelled_caught
[  178.462643] cloud-init[668]: E           assert not True
[  178.470443] cloud-init[668]: E            +  where True = <trio.CancelScope at 0x7fb4613a0f40, exited, cancelled>.cancelled_caught
[  178.484281] cloud-init[668]: E            +    where <trio.CancelScope at 0x7fb4613a0f40, exited, cancelled> = <trio.Nursery object at 0x7fb461767b80>.cancel_scope
[  178.500973] cloud-init[668]: /venv/lib/python3.8/site-packages/trio/tests/test_subprocess.py:126: AssertionError
`` `