### PR TITLE
Newer Linux kernels in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ jobs:
       # 'bionic' systems have nested KVM enabled.
       dist: bionic
       env:
-        - "JOB_NAME='Ubuntu 19.10, full VM'"
-        - "LINUX_VM_IMAGE=https://cloud-images.ubuntu.com/eoan/current/eoan-server-cloudimg-amd64.img"
+        - "JOB_NAME='Fedora 32, full VM'"
+        - "LINUX_VM_IMAGE=https://download.fedoraproject.org/pub/fedora/linux/releases/32/Cloud/x86_64/images/Fedora-Cloud-Base-32-1.6.x86_64.qcow2"
 
     - python: 3.6.1  # earliest 3.6 version available on Travis
     - python: 3.6-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,17 @@
 os: linux
 language: python
-dist: bionic
+dist: focal
 
 jobs:
   include:
     # The pypy tests are slow, so we list them first
     - python: pypy3.6-7.2.0
+      dist: bionic
     - language: generic
       env: PYPY_NIGHTLY_BRANCH=py3.6
     # Qemu tests are also slow
     # FreeBSD:
     - language: generic
-      dist: bionic
       env:
         - "JOB_NAME='FreeBSD 12.1-RELEASE, full VM'"
         - "FREEBSD_INSTALLER_ISO_XZ=https://download.freebsd.org/ftp/releases/amd64/amd64/ISO-IMAGES/12.1/FreeBSD-12.1-RELEASE-amd64-disc1.iso.xz"
@@ -28,14 +28,12 @@ jobs:
     # early warning of any issues that might happen in the next Ubuntu
     # LTS.
     - language: generic
-      # We use bionic for the host, b/c rumor says that Travis's
-      # 'bionic' systems have nested KVM enabled.
-      dist: bionic
       env:
         - "JOB_NAME='Fedora 32, full VM'"
         - "LINUX_VM_IMAGE=https://download.fedoraproject.org/pub/fedora/linux/releases/32/Cloud/x86_64/images/Fedora-Cloud-Base-32-1.6.x86_64.qcow2"
 
     - python: 3.6.1  # earliest 3.6 version available on Travis
+      dist: bionic
     - python: 3.6-dev
     - python: 3.7-dev
     - python: 3.8-dev

--- a/ci.sh
+++ b/ci.sh
@@ -319,7 +319,7 @@ trap "poweroff" exit
 uname -a
 echo \$PWD
 id
-cat /etc/lsb-release
+cat /etc/fedora-release
 cat /proc/cpuinfo
 
 # Pass-through JOB_NAME + the env vars that codecov-bash looks at
@@ -340,14 +340,17 @@ env | sort
 mkdir /host-files
 mount -t 9p -o trans=virtio,version=9p2000.L host-files /host-files
 
-# Install and set up the system Python (assumes Debian/Ubuntu)
-apt update
-apt install -y python3-dev python3-virtualenv git build-essential curl
-python3 -m virtualenv -p python3 /venv
+# Set up the system Python (Fedora preinstalls Python 3)
+python3 -m venv /venv
 # Uses unbound shell variable PS1, so have to allow that temporarily
 set +u
 source /venv/bin/activate
 set -u
+
+# We put a tmpfs on the empty dir because coverage uses it for
+# storage, and this makes it *massively* faster than if it's on NFS
+mkdir /host-files/empty
+mount -t tmpfs tmpfs /host-files/empty
 
 # And then we re-invoke ourselves!
 cd /host-files

--- a/ci.sh
+++ b/ci.sh
@@ -245,7 +245,7 @@ source /venv/bin/activate
 set -u
 
 # And put a tmpfs on the empty dir as well, because coverage uses it for
-# storage, and this makes it *massively* faster than if it's on NFS
+# storage, and this is much faster than if coverage has to go through virtfs.
 mkdir empty
 mount -t tmpfs tmpfs ./empty
 


### PR DESCRIPTION
With this change, we'll use Ubuntu 20.04 in most Travis builds, which will allow us to continue testing pidfd, but without using a VM. We'll also use Linux 5.6 with Fedora 32, which will allow to add tests for io_uring in the future. It's not clear yet whether we want to do that now or not, but I wanted to see if it was possible. This is exactly https://github.com/python-trio/trio/pull/1507, but in #1507 GitHub did not see that Travis had succeeded.