### PR TITLE
[#1500]: Remove unused __all__ variables from Trio modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ pip-log.txt
 htmlcov/
 .tox/
 .venv/
+pyvenv.cfg
 .coverage
 .coverage.*
 .cache

--- a/trio/_core/_entry_queue.py
+++ b/trio/_core/_entry_queue.py
@@ -7,8 +7,6 @@ from .. import _core
 from .._util import NoPublicConstructor
 from ._wakeup_socketpair import WakeupSocketpair
 
-__all__ = ["TrioToken"]
-
 
 @attr.s(slots=True)
 class EntryQueue:

--- a/trio/_core/_ki.py
+++ b/trio/_core/_ki.py
@@ -12,12 +12,6 @@ if False:
     from typing import Any, TypeVar, Callable
     F = TypeVar('F', bound=Callable[..., Any])
 
-__all__ = [
-    "enable_ki_protection",
-    "disable_ki_protection",
-    "currently_ki_protected",
-]
-
 # In ordinary single-threaded Python code, when you hit control-C, it raises
 # an exception and automatically does all the regular unwinding stuff.
 #

--- a/trio/_core/_local.py
+++ b/trio/_core/_local.py
@@ -3,8 +3,6 @@ from . import _run
 
 from .._util import SubclassingDeprecatedIn_v0_15_0
 
-__all__ = ["RunVar"]
-
 
 class _RunVarToken:
     _no_value = object()

--- a/trio/_core/_multierror.py
+++ b/trio/_core/_multierror.py
@@ -5,8 +5,6 @@ import warnings
 
 import attr
 
-__all__ = ["MultiError"]
-
 # python traceback.TracebackException < 3.6.4 does not support unhashable exceptions
 # see https://github.com/python/cpython/pull/4014 for details
 if sys.version_info < (3, 6, 4):

--- a/trio/_core/_parking_lot.py
+++ b/trio/_core/_parking_lot.py
@@ -77,8 +77,6 @@ from collections import OrderedDict
 from .. import _core
 from .._util import SubclassingDeprecatedIn_v0_15_0
 
-__all__ = ["ParkingLot"]
-
 _counter = count()
 
 

--- a/trio/_core/_unbounded_queue.py
+++ b/trio/_core/_unbounded_queue.py
@@ -4,8 +4,6 @@ from .. import _core
 from .._deprecate import deprecated
 from .._util import SubclassingDeprecatedIn_v0_15_0
 
-__all__ = ["UnboundedQueue"]
-
 
 @attr.s(frozen=True)
 class _UnboundedQueueStats:

--- a/trio/_file_io.py
+++ b/trio/_file_io.py
@@ -6,8 +6,6 @@ from ._util import async_wraps
 
 import trio
 
-__all__ = ['open_file', 'wrap_file']
-
 # This list is also in the docs, make sure to keep them in sync
 _FILE_SYNC_ATTRS = {
     'closed',

--- a/trio/_highlevel_open_tcp_listeners.py
+++ b/trio/_highlevel_open_tcp_listeners.py
@@ -5,8 +5,6 @@ from math import inf
 import trio
 from . import socket as tsocket
 
-__all__ = ["open_tcp_listeners", "serve_tcp"]
-
 
 # Default backlog size:
 #

--- a/trio/_highlevel_open_tcp_stream.py
+++ b/trio/_highlevel_open_tcp_stream.py
@@ -3,8 +3,6 @@ from contextlib import contextmanager
 import trio
 from trio.socket import getaddrinfo, SOCK_STREAM, socket
 
-__all__ = ["open_tcp_stream"]
-
 # Implementation of RFC 6555 "Happy eyeballs"
 # https://tools.ietf.org/html/rfc6555
 #

--- a/trio/_highlevel_open_unix_stream.py
+++ b/trio/_highlevel_open_unix_stream.py
@@ -10,8 +10,6 @@ try:
 except ImportError:
     has_unix = False
 
-__all__ = ["open_unix_socket"]
-
 
 @contextmanager
 def close_on_error(obj):

--- a/trio/_highlevel_serve_listeners.py
+++ b/trio/_highlevel_serve_listeners.py
@@ -4,8 +4,6 @@ import os
 
 import trio
 
-__all__ = ["serve_listeners"]
-
 # Errors that accept(2) can return, and which indicate that the system is
 # overloaded
 ACCEPT_CAPACITY_ERRNOS = {

--- a/trio/_highlevel_socket.py
+++ b/trio/_highlevel_socket.py
@@ -8,8 +8,6 @@ from . import socket as tsocket
 from ._util import ConflictDetector, SubclassingDeprecatedIn_v0_15_0
 from .abc import HalfCloseableStream, Listener
 
-__all__ = ["SocketStream", "SocketListener"]
-
 # XX TODO: this number was picked arbitrarily. We should do experiments to
 # tune it. (Or make it dynamic -- one idea is to start small and increase it
 # if we observe single reads filling up the whole buffer, at least within some

--- a/trio/_highlevel_ssl_helpers.py
+++ b/trio/_highlevel_ssl_helpers.py
@@ -3,11 +3,6 @@ import ssl
 
 from ._highlevel_open_tcp_stream import DEFAULT_DELAY
 
-__all__ = [
-    "open_ssl_over_tcp_stream", "open_ssl_over_tcp_listeners",
-    "serve_ssl_over_tcp"
-]
-
 
 # It might have been nice to take a ssl_protocols= argument here to set up
 # NPN/ALPN, but to do this we have to mutate the context object, which is OK

--- a/trio/_path.py
+++ b/trio/_path.py
@@ -6,8 +6,6 @@ import pathlib
 import trio
 from trio._util import async_wraps, SubclassingDeprecatedIn_v0_15_0
 
-__all__ = ['Path']
-
 
 # re-wrap return value from methods that return new instances of pathlib.Path
 def rewrap_path(value):

--- a/trio/_signals.py
+++ b/trio/_signals.py
@@ -5,8 +5,6 @@ from collections import OrderedDict
 import trio
 from ._util import signal_raise, is_main_thread, ConflictDetector
 
-__all__ = ["open_signal_receiver"]
-
 # Discussion of signal handling strategies:
 #
 # - On Windows signals barely exist. There are no options; signal handlers are

--- a/trio/_socket.py
+++ b/trio/_socket.py
@@ -324,8 +324,6 @@ _SOCK_TYPE_MASK = ~(
 )
 
 
-# Note that this is *not* in __all__.
-#
 # This function will modify the given socket to match the behavior in python
 # 3.7. This will become unecessary and can be removed when support for versions
 # older than 3.7 is dropped.

--- a/trio/_sync.py
+++ b/trio/_sync.py
@@ -9,15 +9,6 @@ from ._core import enable_ki_protection, ParkingLot
 from ._deprecate import deprecated
 from ._util import SubclassingDeprecatedIn_v0_15_0
 
-__all__ = [
-    "Event",
-    "CapacityLimiter",
-    "Semaphore",
-    "Lock",
-    "StrictFIFOLock",
-    "Condition",
-]
-
 
 @attr.s(repr=False, eq=False, hash=False)
 class Event(metaclass=SubclassingDeprecatedIn_v0_15_0):

--- a/trio/_timeouts.py
+++ b/trio/_timeouts.py
@@ -2,17 +2,6 @@ from contextlib import contextmanager
 
 import trio
 
-__all__ = [
-    "move_on_at",
-    "move_on_after",
-    "sleep_forever",
-    "sleep_until",
-    "sleep",
-    "fail_at",
-    "fail_after",
-    "TooSlowError",
-]
-
 
 def move_on_at(deadline):
     """Use as a context manager to create a cancel scope with the given

--- a/trio/_wait_for_object.py
+++ b/trio/_wait_for_object.py
@@ -3,8 +3,6 @@ from . import _timeouts
 import trio
 from ._core._windows_cffi import ffi, kernel32, ErrorCodes, raise_winerror, _handle
 
-__all__ = ["WaitForSingleObject"]
-
 
 async def WaitForSingleObject(obj):
     """Async and cancellable variant of WaitForSingleObject. Windows only.

--- a/trio/testing/_check_streams.py
+++ b/trio/testing/_check_streams.py
@@ -8,12 +8,6 @@ from .._highlevel_generic import aclose_forcefully
 from .._abc import SendStream, ReceiveStream, Stream, HalfCloseableStream
 from ._checkpoints import assert_checkpoints
 
-__all__ = [
-    "check_one_way_stream",
-    "check_two_way_stream",
-    "check_half_closeable_stream",
-]
-
 
 class _ForceCloseBoth:
     def __init__(self, both):

--- a/trio/testing/_checkpoints.py
+++ b/trio/testing/_checkpoints.py
@@ -2,8 +2,6 @@ from contextlib import contextmanager
 
 from .. import _core
 
-__all__ = ["assert_checkpoints", "assert_no_checkpoints"]
-
 
 @contextmanager
 def _assert_yields_or_not(expected):

--- a/trio/testing/_memory_streams.py
+++ b/trio/testing/_memory_streams.py
@@ -5,16 +5,6 @@ from .._highlevel_generic import StapledStream
 from .. import _util
 from ..abc import SendStream, ReceiveStream
 
-__all__ = [
-    "MemorySendStream",
-    "MemoryReceiveStream",
-    "memory_stream_pump",
-    "memory_stream_one_way_pair",
-    "memory_stream_pair",
-    "lockstep_stream_one_way_pair",
-    "lockstep_stream_pair",
-]
-
 ################################################################
 # In-memory streams - Unbounded buffer version
 ################################################################

--- a/trio/testing/_mock_clock.py
+++ b/trio/testing/_mock_clock.py
@@ -5,8 +5,6 @@ from .. import _core
 from .._abc import Clock
 from .._util import SubclassingDeprecatedIn_v0_15_0
 
-__all__ = ["MockClock"]
-
 ################################################################
 # The glorious MockClock
 ################################################################

--- a/trio/testing/_network.py
+++ b/trio/testing/_network.py
@@ -1,7 +1,5 @@
 from .. import socket as tsocket
-from .._highlevel_socket import SocketListener, SocketStream
-
-__all__ = ["open_stream_to_socket_listener"]
+from .._highlevel_socket import SocketStream
 
 
 async def open_stream_to_socket_listener(socket_listener):

--- a/trio/testing/_sequencer.py
+++ b/trio/testing/_sequencer.py
@@ -10,8 +10,6 @@ from .. import Event
 if False:
     from typing import DefaultDict, Set
 
-__all__ = ["Sequencer"]
-
 
 @attr.s(eq=False, hash=False)
 class Sequencer(metaclass=_util.SubclassingDeprecatedIn_v0_15_0):

--- a/trio/testing/_trio_test.py
+++ b/trio/testing/_trio_test.py
@@ -3,8 +3,6 @@ from functools import wraps, partial
 from .. import _core
 from ..abc import Clock, Instrument
 
-__all__ = ["trio_test"]
-
 
 # Use:
 #


### PR DESCRIPTION
#1500 

In addition, added `pyvenv.cfg` into `.gitignore`