### PR TITLE
Format MultiError without sys.excepthook

### DIFF
--- a/trio/_core/_multierror.py
+++ b/trio/_core/_multierror.py
@@ -155,8 +155,8 @@ class MultiErrorCatcher:
 class MultiErrorCause(BaseException):
     """
     Helper class for MultiError
-    This is not expected to be raised as an exception - it just wraps multiple
-    causes for printing purposes
+    This is not expected to be raised as an exception - it only inherits
+    from BaseException so it can be assigned to MultiError.__cause__
     """
     def __init__(self, multi_error):
         if not isinstance(multi_error, MultiError):
@@ -210,6 +210,8 @@ class MultiError(BaseException):
             assert len(exceptions) == 1 and exceptions[0] is self
             return
         self.exceptions = exceptions
+        # should be a property, but some of python error handling circumvents
+        # getters and setters
         self.__cause__ = MultiErrorCause(self)
 
     def __new__(cls, exceptions):

--- a/trio/_core/_multierror.py
+++ b/trio/_core/_multierror.py
@@ -168,7 +168,7 @@ class MultiErrorCause(BaseException):
     def __str__(self):
         def lines():
             for i, exc in enumerate(self):
-                yield "\nDetails of embedded exception {}:\n\n".format(i + 1)
+                yield "\nDetails of cause {}:\n\n".format(i + 1)
                 yield from (
                     textwrap.indent(line, " " * 2) for line in
                     traceback.format_exception(
@@ -274,7 +274,8 @@ class MultiError(BaseException):
 # Clean up exception printing:
 MultiError.__module__ = "trio"
 
-MultiErrorCause.__module__ = "trio"
+MultiErrorCause.__name__ = "__cause__"
+MultiErrorCause.__module__ = MultiError.__qualname__
 
 ################################################################
 # concat_tb

--- a/trio/_core/tests/test_multierror.py
+++ b/trio/_core/tests/test_multierror.py
@@ -643,9 +643,6 @@ def test_custom_excepthook():
     completed = run_script("custom_excepthook.py")
     assert_match_in_seq(
         [
-            # The warning
-            "RuntimeWarning",
-            "already have a custom",
             # The message printed by the custom hook, proving we didn't
             # override it
             "custom running!",
@@ -696,10 +693,6 @@ def test_ipython_custom_exc_handler():
     completed = run_script("ipython_custom_exc.py", use_ipython=True)
     assert_match_in_seq(
         [
-            # The warning
-            "RuntimeWarning",
-            "IPython detected",
-            "skip installing Trio",
             # The MultiError
             "MultiError",
             "ValueError",


### PR DESCRIPTION
I think this may be a better approach to MultiError. It doesn't involve clobbering `sys.excepthook`.

Initial thoughts?

Fixes #1065