### PR TITLE
Automatically run towncrier on RTD for in-development versions

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,3 +9,6 @@ python:
   version: 3.7
   install:
     - requirements: docs-requirements.txt
+
+sphinx:
+  fail_on_warning: true

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,6 +24,18 @@ sys.path.insert(0, os.path.abspath('.'))
 # For trio itself
 sys.path.insert(0, os.path.abspath('../..'))
 
+# https://docs.readthedocs.io/en/stable/builds.html#build-environment
+if "READTHEDOCS" in os.environ:
+    import glob
+    if glob.glob("../../newsfragments/*.*.rst"):
+        print("-- Found newsfragments; running towncrier --", flush=True)
+        import subprocess
+        subprocess.run(
+            ["towncrier", "--yes", "--date", "not released yet"],
+            cwd="../..",
+            check=True,
+        )
+
 # Warn about all references to unknown targets
 nitpicky = True
 # Except for these ones, which we expect to point to unknown targets:


### PR DESCRIPTION
This has several advantages:

- On RTD, folks using the 'latest' tag to look at the git version of
  the docs will be able to see what's changed in git.

- On pull requests, newsfragments will be included in the RTD CI
  build, so we have the option of previewing them in rendered form
  before merging.

This commit also configures RTD sphinx to fail on warnings, in hopes
that this will make RTD CI work as a replacement for our current doc
CI job.