### PR TITLE
[WIP] Inject deferred KeyboardInterrupt in a new task, instead of waking up the main task to deliver it

### DIFF
--- a/trio/_core/_exceptions.py
+++ b/trio/_core/_exceptions.py
@@ -1,6 +1,9 @@
+# coding: utf-8
+
 import attr
 
 from trio._util import NoPublicConstructor
+from trio import _deprecate
 
 
 class TrioInternalError(Exception):
@@ -64,6 +67,19 @@ class Cancelled(BaseException, metaclass=NoPublicConstructor):
     """
     def __str__(self):
         return "Cancelled"
+
+    def __call__(self):
+        # If a Cancelled exception is passed to an old abort_fn that
+        # expects a raise_cancel callback, someone will eventually try
+        # to call the exception instead of raising it. Provide a
+        # deprecation warning and raise it instead.
+        _deprecate.warn_deprecated(
+            "wait_task_rescheduled's abort_fn taking a callback argument",
+            "0.16.0",
+            issue=1536,
+            instead="an exception argument",
+        )
+        raise self
 
 
 class BusyResourceError(Exception):

--- a/trio/_core/_io_kqueue.py
+++ b/trio/_core/_io_kqueue.py
@@ -104,8 +104,8 @@ class KqueueIOManager:
             )
         self._registered[key] = _core.current_task()
 
-        def abort(raise_cancel):
-            r = abort_func(raise_cancel)
+        def abort(exc):
+            r = abort_func(exc)
             if r is _core.Abort.SUCCEEDED:
                 del self._registered[key]
             return r

--- a/trio/_core/_io_windows.py
+++ b/trio/_core/_io_windows.py
@@ -619,11 +619,11 @@ class WindowsIOManager:
             )
         task = _core.current_task()
         self._overlapped_waiters[lpOverlapped] = task
-        raise_cancel = None
+        cancel_exc = None
 
-        def abort(raise_cancel_):
-            nonlocal raise_cancel
-            raise_cancel = raise_cancel_
+        def abort(cancel_exc_):
+            nonlocal cancel_exc
+            cancel_exc = cancel_exc_
             try:
                 _check(kernel32.CancelIoEx(handle, lpOverlapped))
             except OSError as exc:
@@ -663,8 +663,8 @@ class WindowsIOManager:
             # it will produce the right sorts of exceptions
             code = ntdll.RtlNtStatusToDosError(lpOverlapped.Internal)
             if code == ErrorCodes.ERROR_OPERATION_ABORTED:
-                if raise_cancel is not None:
-                    raise_cancel()
+                if cancel_exc is not None:
+                    raise cancel_exc
                 else:
                     # We didn't request this cancellation, so assume
                     # it happened due to the underlying handle being

--- a/trio/_core/_traps.py
+++ b/trio/_core/_traps.py
@@ -1,3 +1,5 @@
+# coding: utf-8
+
 # These are the only functions that ever yield back to the task runner.
 
 import types
@@ -94,7 +96,7 @@ async def wait_task_rescheduled(abort_func):
        timeout expiring). When this happens, the ``abort_func`` is called. Its
        interface looks like::
 
-           def abort_func(raise_cancel):
+           def abort_func(exc):
                ...
                return trio.lowlevel.Abort.SUCCEEDED  # or FAILED
 
@@ -108,40 +110,43 @@ async def wait_task_rescheduled(abort_func):
        task can't be cancelled at this time, and still has to make sure that
        "someone" eventually calls :func:`reschedule`.
 
-       At that point there are again two possibilities. You can simply ignore
-       the cancellation altogether: wait for the operation to complete and
-       then reschedule and continue as normal. (For example, this is what
-       :func:`trio.to_thread.run_sync` does if cancellation is disabled.)
-       The other possibility is that the ``abort_func`` does succeed in
-       cancelling the operation, but for some reason isn't able to report that
-       right away. (Example: on Windows, it's possible to request that an
-       async ("overlapped") I/O operation be cancelled, but this request is
-       *also* asynchronous – you don't find out until later whether the
-       operation was actually cancelled or not.)  To report a delayed
-       cancellation, then you should reschedule the task yourself, and call
-       the ``raise_cancel`` callback passed to ``abort_func`` to raise a
-       :exc:`~trio.Cancelled` (or possibly :exc:`KeyboardInterrupt`) exception
-       into this task. Either of the approaches sketched below can work::
+       At that point there are again two possibilities. You can simply
+       ignore the cancellation altogether: wait for the operation to
+       complete and then reschedule and continue as normal. (For
+       example, this is what :func:`trio.to_thread.run_sync` does if
+       cancellation is disabled.)  The other possibility is that the
+       ``abort_func`` does succeed in cancelling the operation, but
+       for some reason isn't able to report that right away. (Example:
+       on Windows, it's possible to request that an async
+       ("overlapped") I/O operation be cancelled, but this request is
+       *also* asynchronous – you don't find out until later whether
+       the operation was actually cancelled or not.)  To report a
+       delayed cancellation, you should reschedule the task yourself,
+       and cause it to raise the exception ``exc`` that was passed to
+       ``abort_func``. (Currently ``exc`` will always be a
+       `~trio.Cancelled` exception, but we may use this mechanism to
+       raise other exceptions in the future; you should raise whatever
+       you're given.) Either of the approaches sketched below can
+       work::
 
           # Option 1:
-          # Catch the exception from raise_cancel and inject it into the task.
+          # Directly reschedule the task with the provided exception.
           # (This is what Trio does automatically for you if you return
           # Abort.SUCCEEDED.)
-          trio.lowlevel.reschedule(task, outcome.capture(raise_cancel))
+          trio.lowlevel.reschedule(task, outcome.Error(exc))
 
           # Option 2:
           # wait to be woken by "someone", and then decide whether to raise
           # the error from inside the task.
-          outer_raise_cancel = None
-          def abort(inner_raise_cancel):
-              nonlocal outer_raise_cancel
-              outer_raise_cancel = inner_raise_cancel
+          outer_exc = None
+          def abort(inner_exc):
+              nonlocal outer_exc
+              outer_exc = inner_exc
               TRY_TO_CANCEL_OPERATION()
               return trio.lowlevel.Abort.FAILED
           await wait_task_rescheduled(abort)
           if OPERATION_WAS_SUCCESSFULLY_CANCELLED:
-              # raises the error
-              outer_raise_cancel()
+              raise outer_exc
 
        In any case it's guaranteed that we only call the ``abort_func`` at most
        once per call to :func:`wait_task_rescheduled`.
@@ -228,8 +233,8 @@ async def temporarily_detach_coroutine_object(abort_func):
           detached task directly without going through
           :func:`reattach_detached_coroutine_object`, which would be bad.)
           Your ``abort_func`` should still arrange for whatever the coroutine
-          object is doing to be cancelled, and then reattach to Trio and call
-          the ``raise_cancel`` callback, if possible.
+          object is doing to be cancelled, and then reattach to Trio and raise
+          the exception it received, if possible.
 
     Returns or raises whatever value or exception the new coroutine runner
     uses to resume the coroutine.

--- a/trio/_core/tests/test_ki.py
+++ b/trio/_core/tests/test_ki.py
@@ -386,9 +386,8 @@ def test_ki_protection_works():
         ki_self()
         task = _core.current_task()
 
-        def abort(raise_cancel):
-            result = outcome.capture(raise_cancel)
-            _core.reschedule(task, result)
+        def abort(exc):
+            _core.reschedule(task, outcome.Error(exc))
             return _core.Abort.FAILED
 
         with pytest.raises(KeyboardInterrupt):

--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -1539,9 +1539,8 @@ async def test_slow_abort_basic():
             task = _core.current_task()
             token = _core.current_trio_token()
 
-            def slow_abort(raise_cancel):
-                result = outcome.capture(raise_cancel)
-                token.run_sync_soon(_core.reschedule, task, result)
+            def slow_abort(exc):
+                token.run_sync_soon(_core.reschedule, task, outcome.Error(exc))
                 return _core.Abort.FAILED
 
             await _core.wait_task_rescheduled(slow_abort)
@@ -1554,10 +1553,9 @@ async def test_slow_abort_edge_cases():
         task = _core.current_task()
         token = _core.current_trio_token()
 
-        def slow_abort(raise_cancel):
+        def slow_abort(exc):
             record.append("abort-called")
-            result = outcome.capture(raise_cancel)
-            token.run_sync_soon(_core.reschedule, task, result)
+            token.run_sync_soon(_core.reschedule, task, outcome.Error(exc))
             return _core.Abort.FAILED
 
         with pytest.raises(_core.Cancelled):


### PR DESCRIPTION
Uploading now to fix the issue number for the deprecation message. Still todo: newsfragment, update KI tests, update docs, post on #1.