### PR TITLE
Release v0.15.1

### DIFF
--- a/docs/source/history.rst
+++ b/docs/source/history.rst
@@ -5,6 +5,18 @@ Release history
 
 .. towncrier release notes start
 
+Trio 0.15.1 (2020-05-22)
+------------------------
+
+Bugfixes
+~~~~~~~~
+
+- Fix documentation build. (This must be a new release tag to get readthedocs
+  "stable" to include the changes from 0.15.0.)
+
+- Added a helpful error message if an async function is passed to `trio.from_thread.run_sync` or a sync function to `trio.from_thread.run`. (`#1244 <https://github.com/python-trio/trio/issues/1244>`__)
+
+
 Trio 0.15.0 (2020-05-19)
 ------------------------
 

--- a/newsfragments/1244.bugfix.rst
+++ b/newsfragments/1244.bugfix.rst
@@ -1,1 +1,0 @@
-Added a helpful error message if an async function is passed to `trio.from_thread.run_sync` or a sync function to `trio.from_thread.run`.

--- a/trio/_version.py
+++ b/trio/_version.py
@@ -1,3 +1,3 @@
 # This file is imported from __init__.py and exec'd from setup.py
 
-__version__ = "0.15.1"
+__version__ = "0.15.1+dev"

--- a/trio/_version.py
+++ b/trio/_version.py
@@ -1,3 +1,3 @@
 # This file is imported from __init__.py and exec'd from setup.py
 
-__version__ = "0.15.0+dev"
+__version__ = "0.15.1"


### PR DESCRIPTION
The main reason for another release is to get readthedocs to build our "stable" documentation with the fix in #1541. Due to timing, we also get #1513.