### PR TITLE
Add the concept of a scope variable (ScopeVar)

### DIFF
--- a/docs/source/reference-core.rst
+++ b/docs/source/reference-core.rst
@@ -656,6 +656,8 @@ finished.
 
    This code will wait 5 seconds (for the child task to finish), and then return.
 
+.. _child-tasks-and-cancellation:
+
 Child tasks and cancellation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/reference-lowlevel.rst
+++ b/docs/source/reference-lowlevel.rst
@@ -226,11 +226,11 @@ Windows-specific API
 
 .. function:: WaitForSingleObject(handle)
     :async:
-    
+
     Async and cancellable variant of `WaitForSingleObject
     <https://msdn.microsoft.com/en-us/library/windows/desktop/ms687032(v=vs.85).aspx>`__.
     Windows only.
-    
+
     :arg handle:
         A Win32 object handle, as a Python integer.
     :raises OSError:
@@ -259,6 +259,12 @@ Global state: system tasks and run-local variables
 .. autoclass:: RunVar
 
 .. autofunction:: spawn_system_task
+
+
+Scope variables
+===============
+
+.. autoclass:: ScopeVar
 
 
 Trio tokens

--- a/newsfragments/1523.feature.rst
+++ b/newsfragments/1523.feature.rst
@@ -1,0 +1,7 @@
+Added the concept of a "scope variable" (`trio.lowlevel.ScopeVar`), which is
+like a context variable except that its value in a new task is determined
+differently. A context variable is inherited by a new task based on its value
+at the location where the task was spawned, while a scope variable is inherited
+based on its value where the task's parent nursery was opened. This distinction
+makes scope variables useful for anything that's naturally inherited along
+parent/child task relationships.

--- a/trio/_core/__init__.py
+++ b/trio/_core/__init__.py
@@ -66,7 +66,7 @@ from ._parking_lot import ParkingLot
 
 from ._unbounded_queue import UnboundedQueue
 
-from ._local import RunVar
+from ._local import RunVar, ScopeVar
 
 # Kqueue imports
 try:

--- a/trio/_core/_local.py
+++ b/trio/_core/_local.py
@@ -1,7 +1,9 @@
-# Runvar implementations
+# Implementations of RunVar and ScopeVar
+import contextvars
+from contextlib import contextmanager
 from . import _run
 
-from .._util import SubclassingDeprecatedIn_v0_15_0
+from .._util import Final, SubclassingDeprecatedIn_v0_15_0
 
 
 class _RunVarToken:
@@ -19,6 +21,9 @@ class _RunVarToken:
         self.redeemed = False
 
 
+_NO_DEFAULT = object()
+
+
 class RunVar(metaclass=SubclassingDeprecatedIn_v0_15_0):
     """The run-local variant of a context variable.
 
@@ -28,7 +33,6 @@ class RunVar(metaclass=SubclassingDeprecatedIn_v0_15_0):
 
     """
 
-    _NO_DEFAULT = object()
     __slots__ = ("_name", "_default")
 
     def __init__(self, name, default=_NO_DEFAULT):
@@ -43,10 +47,10 @@ class RunVar(metaclass=SubclassingDeprecatedIn_v0_15_0):
             raise RuntimeError("Cannot be used outside of a run context") from None
         except KeyError:
             # contextvars consistency
-            if default is not self._NO_DEFAULT:
+            if default is not _NO_DEFAULT:
                 return default
 
-            if self._default is not self._NO_DEFAULT:
+            if self._default is not _NO_DEFAULT:
                 return self._default
 
             raise LookupError(self) from None
@@ -95,3 +99,99 @@ class RunVar(metaclass=SubclassingDeprecatedIn_v0_15_0):
 
     def __repr__(self):
         return "<RunVar name={!r}>".format(self._name)
+
+
+class ScopeVar(metaclass=Final):
+    """A "scope variable": like a context variable except that its value
+    is inherited by new tasks in a different way.
+
+    In simple terms, `ScopeVar` lets you define your own custom state
+    that's inherited in the same way that :ref:`cancel scopes are
+    <child-tasks-and-cancellation>`. Ordinary context variables are
+    inherited by new tasks based on the environment surrounding the
+    :meth:`~trio.Nursery.start_soon` call that created the task.  By
+    contrast, scope variables are inherited based on the environment
+    surrounding the nursery into which the new task was spawned. This
+    difference makes scope variables a better fit than context
+    variables for state that naturally propagates down the task tree.
+
+    Some example uses of a `ScopeVar`:
+
+    * Provide access to a resource that is only usable in a certain
+      scope.  This might be a nursery, network connection, or anything
+      else whose lifetime is bound to a context manager. Tasks that
+      run entirely within the resource's lifetime can use it; tasks
+      that might keep running past the resource being destroyed won't see
+      it at all.
+
+    * Constrain a function's caller-visible behavior, such as what exceptions
+      it might throw. The `ScopeVar`\\'s value will be inherited by every
+      task whose exceptions might propagate to the point where the value was
+      set.
+
+    `ScopeVar` objects support all the same methods as `~contextvars.ContextVar`
+    objects, plus the additional methods :meth:`being` and :meth:`get_in`.
+
+    .. note:: `ScopeVar` values are not directly stored in the
+       `contextvars.Context`, so you can't use `Context.get()
+       <contextvars.Context.get>` to access them; use :meth:`get_in`
+       instead, if you need the value in a context other than your own.
+    """
+
+    __slots__ = ("_cvar",)
+
+    def __init__(self, name, **default):
+        self._cvar = contextvars.ContextVar(name, **default)
+
+    @property
+    def name(self):
+        """The name of the variable, as passed during construction. Read-only."""
+        return self._cvar.name
+
+    def get(self, default=_NO_DEFAULT):
+        """Gets the value of this :class:`ScopeVar` for the current task."""
+        # This is effectively an inlining for efficiency of:
+        # return _run.current_task()._scope_context.run(self._cvar.get, default)
+        try:
+            return _run.GLOBAL_RUN_CONTEXT.task._scope_context[self._cvar]
+        except AttributeError:
+            raise RuntimeError("must be called from async context") from None
+        except KeyError:
+            pass
+        # This will always return the default or raise, because we never give
+        # self._cvar a value in any context in which we run user code.
+        if default is _NO_DEFAULT:
+            return self._cvar.get()
+        else:
+            return self._cvar.get(default)
+
+    def set(self, value):
+        """Sets the value of this :class:`ScopeVar` for the current task and
+        any tasks that run in child nurseries that it later creates.
+        """
+        return _run.current_task()._scope_context.run(self._cvar.set, value)
+
+    def reset(self, token):
+        """Resets the value of this :class:`ScopeVar` to what it was
+        previously, as specified by the token.
+        """
+        _run.current_task()._scope_context.run(self._cvar.reset, token)
+
+    @contextmanager
+    def being(self, value):
+        """Returns a context manager which sets the value of this `ScopeVar` to
+        *value* upon entry and restores its previous value upon exit.
+        """
+        token = self.set(value)
+        try:
+            yield
+        finally:
+            self.reset(token)
+
+    def get_in(self, task_or_nursery, default=_NO_DEFAULT):
+        """Gets the value of this :class:`ScopeVar` for the given task or nursery."""
+        defarg = () if default is _NO_DEFAULT else (default,)
+        return task_or_nursery._scope_context.run(self._cvar.get, *defarg)
+
+    def __repr__(self):
+        return f"<ScopeVar name={self.name!r}>"

--- a/trio/lowlevel.py
+++ b/trio/lowlevel.py
@@ -25,6 +25,7 @@ from ._core import (
     ParkingLot,
     UnboundedQueue,
     RunVar,
+    ScopeVar,
     TrioToken,
     current_trio_token,
     temporarily_detach_coroutine_object,


### PR DESCRIPTION
ScopeVars are like ContextVars except that their initial value in new tasks is determined differently: they are inherited from the new task's parent nursery rather than from its spawner. #1523 has some discussion of the possible uses.

Fixes #1523