### PR TITLE
Fix flakiness in test_subprocess::test_basic

### DIFF
--- a/trio/tests/test_subprocess.py
+++ b/trio/tests/test_subprocess.py
@@ -51,7 +51,6 @@ async def test_basic():
     repr_template = "<trio.Process {!r}: {{}}>".format(EXIT_TRUE)
     async with await open_process(EXIT_TRUE) as proc:
         assert isinstance(proc, Process)
-        assert proc.returncode is None
         assert repr(proc) == repr_template.format(
             "running with PID {}".format(proc.pid)
         )


### PR DESCRIPTION
gh-1514 introduced a race condition in this test: now if the process
runs quickly enough, the returncode might have magically become
non-None before we check it.

Example failure: https://travis-ci.org/github/python-trio/trio/jobs/690291915

There are other tests that check the 'p.returncode is None' case (e.g.
test_auto_update_returncode), so we can just delete this.