### PR TITLE
Remove constraint on typed-ast requirement

### DIFF
--- a/test-requirements.in
+++ b/test-requirements.in
@@ -13,7 +13,7 @@ flake8
 astor          # code generation
 
 # https://github.com/python-trio/trio/pull/654#issuecomment-420518745
-typed_ast; python_version < "3.8" and implementation_name == "cpython"
+typed_ast; implementation_name == "cpython"
 
 # Trio's own dependencies
 cffi; os_name == "nt"


### PR DESCRIPTION
Now that Dependabot is using 3.8, a requirement only applicable below 3.8 is completely ignored. But black pulls in typed-ast unconditionally, and pip-tools isn't smart enough to propagate environment constraints along dependency edges, so we wind up with typed-ast as an unconditional dependency which makes pypy builds fail. Constraining it in requirements.in based on only the interpreter, not also the Python version, resolves this (tested by running pip-compile on 3.8 directly).