### PR TITLE
Update PyPI search link for Framework::Trio

### DIFF
--- a/docs/source/awesome-trio-libraries.rst
+++ b/docs/source/awesome-trio-libraries.rst
@@ -15,7 +15,7 @@ However, to get much useful work done you will want to use some of
 the great libraries that support Trio-flavoured concurrency. This list
 is not complete, but gives a starting point. Another great way to find
 Trio-compatible libraries is to search on PyPI for the ``Framework :: Trio``
-tag -> `PyPI Search <https://pypi.org/search/?q=Framework+%3A%3A+Trio>`__
+tag -> `PyPI Search <https://pypi.org/search/?c=Framework+%3A%3A+Trio>`__
 
 
 Getting Started


### PR DESCRIPTION
It looks like PyPI now have a specific url for trove serach pattern.
This filter down the result to "only" 3 pages instead of 500.