### PR TITLE
Temporarily disable testing on python nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,9 @@ jobs:
     - python: 3.7-dev
     - python: 3.8-dev
     - python: 3.9-dev
-    - python: nightly
+    # Temporarily disabled during the high-churn period of 3.10
+    # E.g.: https://github.com/MagicStack/immutables/issues/46
+    #- python: nightly
 
 script:
   - ./ci.sh


### PR DESCRIPTION
To work around issues like https://github.com/MagicStack/immutables/issues/46