### PR TITLE
Added helpful error message if an async function is passed to trio.to_thread_run_sync

### DIFF
--- a/newsfragments/1573.bugfix.rst
+++ b/newsfragments/1573.bugfix.rst
@@ -1,0 +1,1 @@
+Added a helpful error message if an async function is passed to `trio.to_thread_run_sync`.

--- a/newsfragments/1573.bugfix.rst
+++ b/newsfragments/1573.bugfix.rst
@@ -1,1 +1,1 @@
-Added a helpful error message if an async function is passed to `trio.to_thread_run_sync`.
+Added a helpful error message if an async function is passed to `trio.to_thread.run_sync`.

--- a/trio/tests/test_threads.py
+++ b/trio/tests/test_threads.py
@@ -457,6 +457,15 @@ async def test_trio_to_thread_run_sync_token():
     assert callee_token == caller_token
 
 
+async def test_trio_to_thread_run_sync():
+    # Test correct error when passed async function
+    async def async_fn():  # pragma: no cover
+        pass
+
+    with pytest.raises(TypeError, match="expected a sync function"):
+        await to_thread_run_sync(async_fn)
+
+
 async def test_trio_from_thread_run_sync():
     # Test that to_thread_run_sync correctly "hands off" the trio token to
     # trio.from_thread.run_sync()

--- a/trio/tests/test_threads.py
+++ b/trio/tests/test_threads.py
@@ -457,7 +457,7 @@ async def test_trio_to_thread_run_sync_token():
     assert callee_token == caller_token
 
 
-async def test_trio_to_thread_run_sync():
+async def test_trio_to_thread_run_sync_expected_error():
     # Test correct error when passed async function
     async def async_fn():  # pragma: no cover
         pass


### PR DESCRIPTION
This functionality was previously added to the `trio.from_thread` functions in #1513

Closes #1573 