### PR TITLE
Allow start_clock() to start the very first system task; make MockClock do so

### DIFF
--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -753,6 +753,7 @@ class NurseryExiter:
     It is used only for the system nursery, which gets entered outside
     of async context.
     """
+
     _manager = attr.ib()
 
     async def __aenter__(self):
@@ -1512,7 +1513,9 @@ class Runner:
         # needs to be done in this function.
         async with NurseryExiter(system_nursery_manager):
             try:
-                self.main_task = self.spawn_impl(async_fn, args, self.system_nursery, None)
+                self.main_task = self.spawn_impl(
+                    async_fn, args, self.system_nursery, None
+                )
             except BaseException as exc:
                 self.main_task_outcome = Error(exc)
                 self.system_nursery.cancel_scope.cancel()
@@ -2007,7 +2010,11 @@ def unrolled_run(runner, async_fn, args, host_uses_signal_set_wakeup_fd=False):
         # This works because __aenter__ is secretly synchronous (doesn't await).
         system_nursery_manager = open_nursery()
         runner.init_task = runner.spawn_impl(
-            runner.init, (system_nursery_manager, async_fn, args), None, "<init>", system_task=True,
+            runner.init,
+            (system_nursery_manager, async_fn, args),
+            None,
+            "<init>",
+            system_task=True,
         )
         GLOBAL_RUN_CONTEXT.task = runner.init_task
         try:

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -2021,10 +2021,10 @@ def unrolled_run(runner, async_fn, args, host_uses_signal_set_wakeup_fd=False):
             system_nursery_manager.__aenter__().send(None)
         except StopIteration as exc:
             runner.system_nursery = exc.value
-        else:
+        else:  # pragma: no cover
             raise TrioInternalError("NurseryManager.__aenter__() yielded")
         finally:
-            del GLOBAL_RUN_CONTEXT.task
+            del GLOBAL_RUN_CONTEXT.task  # pragma: no branch
 
         runner.clock.start_clock()
 

--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -295,8 +295,8 @@ async def test_current_statistics(mock_clock):
 
     stats = _core.current_statistics()
     print(stats)
-    # 2 system tasks + us
-    assert stats.tasks_living == 3
+    # init + autojumper + run_sync_soon task + us
+    assert stats.tasks_living == 4
     assert stats.run_sync_soon_queue_size == 0
 
     async with _core.open_nursery() as nursery:
@@ -307,8 +307,8 @@ async def test_current_statistics(mock_clock):
         token.run_sync_soon(lambda: None, idempotent=True)
         stats = _core.current_statistics()
         print(stats)
-        # 2 system tasks + us + child
-        assert stats.tasks_living == 4
+        # as above + child
+        assert stats.tasks_living == 5
         # the exact value here might shift if we change how we do accounting
         # (currently it only counts tasks that we already know will be
         # runnable on the next pass), but still useful to at least test the


### PR DESCRIPTION
Preparatory to #1521 in which the order will do anything. As discussed in #265, the autojumper should be the very last thing to get shut down, even after the run_sync_soon task.

This requires some shenanigans because start_clock() runs before the first step of init. We effectively execute the system nursery `__aenter__` outside of async context, so as to have a system nursery when start_clock() runs.