### PR TITLE
Don't shuffle each batch, instead reverse them half the time.

### DIFF
--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -2076,6 +2076,7 @@ def unrolled_run(runner, async_fn, args, host_uses_signal_set_wakeup_fd=False):
             # tie-breaker and the non-deterministic ordering of
             # task._notify_queues.)
             batch = list(runner.runq)
+            runner.runq.clear()
             if _ALLOW_DETERMINISTIC_SCHEDULING:
                 # We're running under Hypothesis, and pytest-trio has patched
                 # this in to make the scheduler deterministic and avoid flaky
@@ -2083,11 +2084,12 @@ def unrolled_run(runner, async_fn, args, host_uses_signal_set_wakeup_fd=False):
                 # operation, since we'll shuffle the list and _r is only
                 # seeded for tests.
                 batch.sort(key=lambda t: t._counter)
-            runner.runq.clear()
-            # 50% chance of reversing the batch, this way each task
-            # can appear before/after any other task.
-            if _r.random() < 0.5:
-                batch = batch[::-1]
+                _r.shuffle(batch)
+            else:
+                # 50% chance of reversing the batch, this way each task
+                # can appear before/after any other task.
+                if _r.random() < 0.5:
+                    batch.reverse()
             while batch:
                 task = batch.pop()
                 GLOBAL_RUN_CONTEXT.task = task

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -2084,7 +2084,10 @@ def unrolled_run(runner, async_fn, args, host_uses_signal_set_wakeup_fd=False):
                 # seeded for tests.
                 batch.sort(key=lambda t: t._counter)
             runner.runq.clear()
-            _r.shuffle(batch)
+            # 50% chance of reversing the batch, this way each task
+            # can appear before/after any other task.
+            if _r.random() < 0.5:
+                batch = batch[::-1]
             while batch:
                 task = batch.pop()
                 GLOBAL_RUN_CONTEXT.task = task

--- a/trio/tests/test_scheduler_determinism.py
+++ b/trio/tests/test_scheduler_determinism.py
@@ -6,7 +6,7 @@ async def scheduler_trace():
     trace = []
 
     async def tracer(name):
-        for i in range(10):
+        for i in range(50):
             trace.append((name, i))
             await trio.sleep(0)
 


### PR DESCRIPTION
I consistently see batch shuffling taking 1% CPU on a real-world
application, and this is a simple fix to make this overhead disappear.
Suggested by @njsmith.