### PR TITLE
Ignore ResourceWarnings in test_deprecate

### DIFF
--- a/trio/tests/test_deprecate.py
+++ b/trio/tests/test_deprecate.py
@@ -16,6 +16,9 @@ from . import module_with_deprecations
 @pytest.fixture
 def recwarn_always(recwarn):
     warnings.simplefilter("always")
+    # ResourceWarnings about unclosed sockets can occur nondeterministically
+    # (during GC) which throws off the tests in this file
+    warnings.simplefilter("ignore", ResourceWarning)
     return recwarn
 
 


### PR DESCRIPTION
Hopefully this will resolve test flakiness in test_deprecated.py, recently discussed in #200.