### PR TITLE
Deprecate the tiebreaker= argument to wait_all_tasks_blocked

### DIFF
--- a/newsfragments/1587.deprecated.rst
+++ b/newsfragments/1587.deprecated.rst
@@ -1,0 +1,4 @@
+The ``tiebreaker`` argument to `trio.testing.wait_all_tasks_blocked`
+has been deprecated. This is a highly obscure feature that was
+probably never used by anyone except `trio.testing.MockClock`, and
+`~trio.testing.MockClock` doesn't need it anymore.

--- a/trio/_core/_generated_run.py
+++ b/trio/_core/_generated_run.py
@@ -161,7 +161,7 @@ def current_trio_token():
         raise RuntimeError("must be called from async context")
 
 
-async def wait_all_tasks_blocked(cushion=0.0, tiebreaker=0):
+async def wait_all_tasks_blocked(cushion=0.0, tiebreaker='deprecated'):
     """Block until there are no runnable tasks.
 
         This is useful in testing code when you want to give other tasks a
@@ -179,9 +179,7 @@ async def wait_all_tasks_blocked(cushion=0.0, tiebreaker=0):
         then the one with the shortest ``cushion`` is the one woken (and
         this task becoming unblocked resets the timers for the remaining
         tasks). If there are multiple tasks that have exactly the same
-        ``cushion``, then the one with the lowest ``tiebreaker`` value is
-        woken first. And if there are multiple tasks with the same ``cushion``
-        and the same ``tiebreaker``, then all are woken.
+        ``cushion``, then all are woken.
 
         You should also consider :class:`trio.testing.Sequencer`, which
         provides a more explicit way to control execution ordering within a

--- a/trio/tests/test_testing.py
+++ b/trio/tests/test_testing.py
@@ -103,7 +103,8 @@ async def test_wait_all_tasks_blocked_with_cushion():
     ]
 
 
-async def test_wait_all_tasks_blocked_with_tiebreaker():
+# This test can be deleted after tiebreaker= is removed
+async def test_wait_all_tasks_blocked_with_tiebreaker(recwarn):
     record = []
 
     async def do_wait(cushion, tiebreaker):


### PR DESCRIPTION
It was only added for the autojump clock, it wasn't very good at that,
and since gh-1588, the autojump clock doesn't even use it anyway.