### PR TITLE
Deprecate support for multiple tasks in the private old_nursery used by start()

### DIFF
--- a/newsfragments/1599.deprecated.rst
+++ b/newsfragments/1599.deprecated.rst
@@ -1,0 +1,19 @@
+In the current implementation of `nursery.start()
+<trio.Nursery.start>`, the new task starts running in a private
+nursery created inside :meth:`trio.Nursery.start`, and only moves to
+its "real" nursery once it calls ``task_status.started()``. Since Trio
+doesn't hand out any references to that private temporary nursery, we
+would like to be able to assume it only contains the single task being
+started. However, the nursery object is still accessible using
+debugging APIs such as
+``trio.lowlevel.current_task().parent_nursery``, and it's possible
+that some users have been using those APIs to start tasks in it. (If
+it wasn't clear, we strongly recommend against this sort of thing,
+because it makes private implementation details affect the behavior of
+your code.)
+
+Until now, these sorts of shenanigans unintentionally *worked*: the
+new tasks would move alongside the task being ``start()``\ed, and one
+might not even realize they weren't getting the ``parent_nursery``
+they were expecting. Supporting this unintentional feature is becoming
+burdensome, though, so we're deprecating it with no replacement.

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -41,7 +41,7 @@ from ._traps import (
 )
 from ._thread_cache import start_thread_soon
 from .. import _core
-from .._deprecate import deprecated
+from .._deprecate import deprecated, warn_deprecated
 from .._util import Final, NoPublicConstructor, coroutine_or_error
 
 _NO_SEND = object()
@@ -656,6 +656,20 @@ class _TaskStatus:
     def started(self, value=None):
         if self._called_started:
             raise RuntimeError("called 'started' twice on the same task status")
+        if len(self._old_nursery._children) > 1:
+            # This can only happen if someone finds the old_nursery through
+            # debugging APIs and spawns more tasks into it. We don't think
+            # that's a reasonable thing to do, and supporting it makes other
+            # extensions to the nursery semantics much harder to implement.
+            # But it unintentionally worked in the past, so it gets a
+            # deprecation period.
+            warn_deprecated(
+                "starting additional tasks in the private old_nursery created "
+                "by Nursery.start()",
+                version="0.16.0",
+                issue=1599,
+                instead="a nursery that you created",
+            )
         self._called_started = True
         self._value = value
 


### PR DESCRIPTION
Fixes #1599; see there (or read the newsfragment) for rationale.