### PR TITLE
Add newsfragment for ssl/subprocess removals

### DIFF
--- a/newsfragments/1594.deprecated.rst
+++ b/newsfragments/1594.deprecated.rst
@@ -1,0 +1,1 @@
+Remove the deprecated ``trio.ssl`` and ``trio.subprocess`` modules.


### PR DESCRIPTION
I forgot about it in #1594.