### PR TITLE
Inject runner into TheIOManager

### DIFF
--- a/trio/_core/_io_common.py
+++ b/trio/_core/_io_common.py
@@ -4,7 +4,7 @@ from .. import _core
 
 
 # Utility function shared between _io_epoll and _io_windows
-def wake_all(waiters, exc):
+def wake_all(runner, waiters, exc):
     try:
         current_task = _core.current_task()
     except RuntimeError:
@@ -16,7 +16,7 @@ def wake_all(waiters, exc):
             if task is current_task:
                 raise_at_end = True
             else:
-                _core.reschedule(task, outcome.Error(copy.copy(exc)))
+                runner.reschedule(task, outcome.Error(copy.copy(exc)))
             setattr(waiters, attr_name, None)
     if raise_at_end:
         raise exc

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -1222,6 +1222,9 @@ class Runner:
     is_guest = attr.ib(default=False)
     guest_tick_scheduled = attr.ib(default=False)
 
+    def __attrs_post_init__(self):
+        self.io_manager = self.io_manager(self)
+
     def force_guest_tick_asap(self):
         if self.guest_tick_scheduled:
             return
@@ -1778,7 +1781,6 @@ def setup_runner(clock, instruments, restrict_keyboard_interrupt_to_checkpoints)
     if clock is None:
         clock = SystemClock()
     instruments = list(instruments)
-    io_manager = TheIOManager()
     system_context = copy_context()
     system_context.run(current_async_library_cvar.set, "trio")
     ki_manager = KIManager()
@@ -1786,7 +1788,7 @@ def setup_runner(clock, instruments, restrict_keyboard_interrupt_to_checkpoints)
     runner = Runner(
         clock=clock,
         instruments=instruments,
-        io_manager=io_manager,
+        io_manager=TheIOManager,
         system_context=system_context,
         ki_manager=ki_manager,
     )


### PR DESCRIPTION
Improve performance by injecting the runner, instead of using thread locals.

I've been following `trio` for a while, tinkering to understand how the `_core` works and https://github.com/python-trio/trio/issues/1595 inspired me to see whether a small change could speed things up. This change improved the dnsperf example given in that issue by around 10% on a couple of runs. Can anyone reproduce similar performance gains?

Is injecting the runner like this of interest, as I think there are a fair number of places where TLS is used to access the runner by an object in `_core`?