### PR TITLE
Enforce mypy-cleanliness on trio._core

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -27,6 +27,8 @@ flake8 trio/ \
 # We specify Linux so that we get the same results on all platforms. Without
 # that, mypy would complain on macOS that epoll does not exist, and we can't
 # ignore it as it would cause a mypy error on Linux
+# In the future, we will run mypy on all platforms and use platform assert
+# guards to avoid typechecking the wrong IOManagers
 mypy -p trio._core --platform linux || EXIT_STATUS=$?
 
 # Finally, leave a really clear warning of any issues and exit

--- a/check.sh
+++ b/check.sh
@@ -23,6 +23,12 @@ flake8 trio/ \
     --ignore=D,E,W,F401,F403,F405,F821,F822\
     || EXIT_STATUS=$?
 
+# Run mypy
+# We specify Linux so that we get the same results on all platforms. Without
+# that, mypy would complain on macOS that epoll does not exist, and we can't
+# ignore it as it would cause a mypy error on Linux
+mypy -p trio._core --platform linux || EXIT_STATUS=$?
+
 # Finally, leave a really clear warning of any issues and exit
 if [ $EXIT_STATUS -ne 0 ]; then
     cat <<EOF

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -9,12 +9,14 @@ jedi           # for jedi code completion tests
 
 # Tools
 black; implementation_name == "cpython"
+mypy; implementation_name == "cpython"
 flake8
 astor          # code generation
-mypy
 
 # https://github.com/python-trio/trio/pull/654#issuecomment-420518745
 typed_ast; implementation_name == "cpython"
+mypy-extensions; implementation_name == "cpython"
+typing-extensions; implementation_name == "cpython"
 
 # Trio's own dependencies
 cffi; os_name == "nt"

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -11,6 +11,7 @@ jedi           # for jedi code completion tests
 black; implementation_name == "cpython"
 flake8
 astor          # code generation
+mypy
 
 # https://github.com/python-trio/trio/pull/654#issuecomment-420518745
 typed_ast; implementation_name == "cpython"

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -26,6 +26,8 @@ jedi==0.17.0              # via -r test-requirements.in, ipython
 lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via flake8, pylint
 more-itertools==8.3.0     # via pytest
+mypy-extensions==0.4.3    # via mypy
+mypy==0.780               # via -r test-requirements.in
 outcome==1.0.1            # via -r test-requirements.in
 packaging==20.4           # via pytest
 parso==0.7.0              # via jedi
@@ -53,5 +55,6 @@ toml==0.10.1              # via black, pylint
 traitlets==4.3.3          # via ipython
 trustme==0.6.0            # via -r test-requirements.in
 typed-ast==1.4.1 ; implementation_name == "cpython"  # via -r test-requirements.in, black
+typing-extensions==3.7.4.2  # via mypy
 wcwidth==0.2.4            # via prompt-toolkit, pytest
 wrapt==1.12.1             # via astroid

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -26,8 +26,8 @@ jedi==0.17.0              # via -r test-requirements.in, ipython
 lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via flake8, pylint
 more-itertools==8.3.0     # via pytest
-mypy-extensions==0.4.3    # via mypy
-mypy==0.780               # via -r test-requirements.in
+mypy-extensions==0.4.3 ; implementation_name == "cpython"  # via mypy
+mypy==0.780 ; implementation_name == "cpython"  # via -r test-requirements.in
 outcome==1.0.1            # via -r test-requirements.in
 packaging==20.4           # via pytest
 parso==0.7.0              # via jedi
@@ -55,6 +55,6 @@ toml==0.10.1              # via black, pylint
 traitlets==4.3.3          # via ipython
 trustme==0.6.0            # via -r test-requirements.in
 typed-ast==1.4.1 ; implementation_name == "cpython"  # via -r test-requirements.in, black
-typing-extensions==3.7.4.2  # via mypy
+typing-extensions==3.7.4.2; implementation_name == "cpython"  # via mypy
 wcwidth==0.2.4            # via prompt-toolkit, pytest
 wrapt==1.12.1             # via astroid

--- a/trio/_core/__init__.py
+++ b/trio/_core/__init__.py
@@ -4,7 +4,6 @@ and deal with private internal data structures. Things in this namespace
 are publicly available in either trio, trio.lowlevel, or trio.testing.
 """
 
-import typing as _t
 import sys
 
 from ._exceptions import (
@@ -76,13 +75,6 @@ from ._thread_cache import start_thread_soon
 
 from ._mock_clock import MockClock
 
-# Kqueue imports
-if not _t.TYPE_CHECKING:  # pragma: no branch
-    try:
-        from ._run import current_kqueue, monitor_kevent, wait_kevent
-    except ImportError:
-        pass
-
 # Windows imports
 if sys.platform == "win32":
     from ._run import (
@@ -93,3 +85,6 @@ if sys.platform == "win32":
         write_overlapped,
         readinto_overlapped,
     )
+# Kqueue imports
+elif sys.platform != "linux" and sys.platform != "win32":
+    from ._run import current_kqueue, monitor_kevent, wait_kevent

--- a/trio/_core/__init__.py
+++ b/trio/_core/__init__.py
@@ -88,3 +88,5 @@ if sys.platform == "win32":
 # Kqueue imports
 elif sys.platform != "linux" and sys.platform != "win32":
     from ._run import current_kqueue, monitor_kevent, wait_kevent
+
+del sys   # It would be better to import sys as _sys, but mypy does not understand it

--- a/trio/_core/__init__.py
+++ b/trio/_core/__init__.py
@@ -77,11 +77,7 @@ from ._thread_cache import start_thread_soon
 from ._mock_clock import MockClock
 
 # Kqueue imports
-if (
-    sys.platform.startswith("freebsd")
-    or sys.platform.startswith("darwin")
-    or not _t.TYPE_CHECKING
-):
+if not _t.TYPE_CHECKING:  # pragma: no branch
     try:
         from ._run import current_kqueue, monitor_kevent, wait_kevent
     except ImportError:

--- a/trio/_core/__init__.py
+++ b/trio/_core/__init__.py
@@ -4,6 +4,9 @@ and deal with private internal data structures. Things in this namespace
 are publicly available in either trio, trio.lowlevel, or trio.testing.
 """
 
+import typing as _t
+import sys
+
 from ._exceptions import (
     TrioInternalError,
     RunFinishedError,
@@ -74,13 +77,18 @@ from ._thread_cache import start_thread_soon
 from ._mock_clock import MockClock
 
 # Kqueue imports
-try:
-    from ._run import current_kqueue, monitor_kevent, wait_kevent
-except ImportError:
-    pass
+if (
+    sys.platform.startswith("freebsd")
+    or sys.platform.startswith("darwin")
+    or not _t.TYPE_CHECKING
+):
+    try:
+        from ._run import current_kqueue, monitor_kevent, wait_kevent
+    except ImportError:
+        pass
 
 # Windows imports
-try:
+if sys.platform == "win32":
     from ._run import (
         monitor_completion_key,
         current_iocp,
@@ -89,5 +97,3 @@ try:
         write_overlapped,
         readinto_overlapped,
     )
-except ImportError:
-    pass

--- a/trio/_core/__init__.py
+++ b/trio/_core/__init__.py
@@ -89,4 +89,4 @@ if sys.platform == "win32":
 elif sys.platform != "linux" and sys.platform != "win32":
     from ._run import current_kqueue, monitor_kevent, wait_kevent
 
-del sys   # It would be better to import sys as _sys, but mypy does not understand it
+del sys  # It would be better to import sys as _sys, but mypy does not understand it

--- a/trio/_core/_io_epoll.py
+++ b/trio/_core/_io_epoll.py
@@ -1,6 +1,7 @@
 import select
 import attr
 from collections import defaultdict
+from typing import DefaultDict
 
 from .. import _core
 from ._run import _public
@@ -184,8 +185,10 @@ class EpollWaiters:
 class EpollIOManager:
     _epoll = attr.ib(factory=select.epoll)
     # {fd: EpollWaiters}
-    _registered = attr.ib(factory=lambda: defaultdict(EpollWaiters))
-    _force_wakeup = attr.ib(factory=WakeupSocketpair)
+    _registered = attr.ib(
+        factory=lambda: defaultdict(EpollWaiters), type=DefaultDict[int, EpollWaiters]
+    )
+    _force_wakeup = attr.ib(factory=WakeupSocketpair, type=WakeupSocketpair)
     _force_wakeup_fd = attr.ib(default=None)
 
     def __attrs_post_init__(self):

--- a/trio/_core/_io_epoll.py
+++ b/trio/_core/_io_epoll.py
@@ -188,7 +188,7 @@ class EpollIOManager:
     _registered = attr.ib(
         factory=lambda: defaultdict(EpollWaiters), type=Dict[int, EpollWaiters]
     )
-    _force_wakeup = attr.ib(factory=WakeupSocketpair, type=WakeupSocketpair)
+    _force_wakeup = attr.ib(factory=WakeupSocketpair)
     _force_wakeup_fd = attr.ib(default=None)
 
     def __attrs_post_init__(self):

--- a/trio/_core/_io_epoll.py
+++ b/trio/_core/_io_epoll.py
@@ -1,7 +1,7 @@
 import select
 import attr
 from collections import defaultdict
-from typing import DefaultDict
+from typing import Dict
 
 from .. import _core
 from ._run import _public
@@ -186,7 +186,7 @@ class EpollIOManager:
     _epoll = attr.ib(factory=select.epoll)
     # {fd: EpollWaiters}
     _registered = attr.ib(
-        factory=lambda: defaultdict(EpollWaiters), type=DefaultDict[int, EpollWaiters]
+        factory=lambda: defaultdict(EpollWaiters), type=Dict[int, EpollWaiters]
     )
     _force_wakeup = attr.ib(factory=WakeupSocketpair, type=WakeupSocketpair)
     _force_wakeup_fd = attr.ib(default=None)

--- a/trio/_core/_io_kqueue.py
+++ b/trio/_core/_io_kqueue.py
@@ -19,7 +19,7 @@ class _KqueueStatistics:
 
 @attr.s(slots=True, eq=False)
 class KqueueIOManager:
-    _kqueue = attr.ib(factory=select.kqueue)
+    _kqueue = attr.ib(factory=select.kqueue)  # type: ignore
     # {(ident, filter): Task or UnboundedQueue}
     _registered = attr.ib(factory=dict)
     _force_wakeup = attr.ib(factory=WakeupSocketpair)

--- a/trio/_core/_multierror.py
+++ b/trio/_core/_multierror.py
@@ -415,7 +415,7 @@ def traceback_exception_init(
         self.embedded = []
 
 
-traceback.TracebackException.__init__ = traceback_exception_init
+traceback.TracebackException.__init__ = traceback_exception_init  # type: ignore
 traceback_exception_original_format = traceback.TracebackException.format
 
 
@@ -427,7 +427,7 @@ def traceback_exception_format(self, *, chain=True):
         yield from (textwrap.indent(line, " " * 2) for line in exc.format(chain=chain))
 
 
-traceback.TracebackException.format = traceback_exception_format
+traceback.TracebackException.format = traceback_exception_format  # type: ignore
 
 
 def trio_excepthook(etype, value, tb):
@@ -489,7 +489,7 @@ if sys.excepthook.__name__ == "apport_excepthook":
 
     fake_sys = TrioFakeSysModuleForApport()
     fake_sys.__dict__.update(sys.__dict__)
-    fake_sys.__excepthook__ = trio_excepthook
+    fake_sys.__excepthook__ = trio_excepthook  # type: ignore
     apport_python_hook.sys = fake_sys
 
     monkeypatched_or_warned = True

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -16,7 +16,7 @@ import enum
 from contextvars import copy_context
 from math import inf
 from time import perf_counter
-from typing import Callable
+from typing import Callable, TYPE_CHECKING
 
 from sniffio import current_async_library_cvar
 
@@ -2379,10 +2379,10 @@ async def checkpoint_if_cancelled():
 if sys.platform == "win32":
     from ._io_windows import WindowsIOManager as TheIOManager
     from ._generated_io_windows import *
-elif sys.platform == "linux" or hasattr(select, "epoll"):
+elif sys.platform == "linux" or (not TYPE_CHECKING and hasattr(select, "epoll")):
     from ._io_epoll import EpollIOManager as TheIOManager
     from ._generated_io_epoll import *
-elif hasattr(select, "kqueue"):
+elif TYPE_CHECKING or hasattr(select, "kqueue"):
     from ._io_kqueue import KqueueIOManager as TheIOManager
     from ._generated_io_kqueue import *
 else:  # pragma: no cover

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -23,7 +23,7 @@ from sniffio import current_async_library_cvar
 import attr
 from heapq import heapify, heappop, heappush
 from sortedcontainers import SortedDict
-from outcome import Error, Value, capture
+from outcome import Error, Outcome, Value, capture
 
 from ._entry_queue import EntryQueue, TrioToken
 from ._exceptions import TrioInternalError, RunFinishedError, Cancelled
@@ -1225,7 +1225,7 @@ class GuestState:
     done_callback = attr.ib()
     unrolled_run_gen = attr.ib()
     _value_factory: Callable[[], Value] = lambda: Value(None)
-    unrolled_run_next_send = attr.ib(factory=_value_factory, type=Value)
+    unrolled_run_next_send = attr.ib(factory=_value_factory, type=Outcome)
 
     def guest_tick(self):
         try:

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -2385,7 +2385,7 @@ elif sys.platform == "linux" or (not TYPE_CHECKING and hasattr(select, "epoll"))
 elif (
     sys.platform == "darwin"
     or sys.platform.startswith("freebsd")
-    or (not TYPE_CHECKING and hasattr(select, "epoll"))
+    or (not TYPE_CHECKING and hasattr(select, "kqueue"))
 ):
     from ._io_kqueue import KqueueIOManager as TheIOManager
     from ._generated_io_kqueue import *

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -16,7 +16,7 @@ import enum
 from contextvars import copy_context
 from math import inf
 from time import perf_counter
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable
 
 from sniffio import current_async_library_cvar
 
@@ -1151,7 +1151,8 @@ class GuestState:
     run_sync_soon_not_threadsafe = attr.ib()
     done_callback = attr.ib()
     unrolled_run_gen = attr.ib()
-    unrolled_run_next_send = attr.ib(factory=lambda: Value(None), type=object)
+    _value_factory: Callable[[], Value] = lambda: Value(None)
+    unrolled_run_next_send = attr.ib(factory=_value_factory, type=Value)
 
     def guest_tick(self):
         try:

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -16,6 +16,7 @@ import enum
 from contextvars import copy_context
 from math import inf
 from time import perf_counter
+from typing import TYPE_CHECKING, Any
 
 from sniffio import current_async_library_cvar
 
@@ -582,7 +583,7 @@ class CancelScope(metaclass=Final):
         """
         return self._shield
 
-    @shield.setter
+    @shield.setter  # type: ignore  # "decorated property not supported"
     @enable_ki_protection
     def shield(self, new_value):
         if not isinstance(new_value, bool):
@@ -1150,7 +1151,7 @@ class GuestState:
     run_sync_soon_not_threadsafe = attr.ib()
     done_callback = attr.ib()
     unrolled_run_gen = attr.ib()
-    unrolled_run_next_send = attr.ib(factory=lambda: Value(None))
+    unrolled_run_next_send = attr.ib(factory=lambda: Value(None), type=object)
 
     def guest_tick(self):
         try:
@@ -2311,13 +2312,17 @@ async def checkpoint_if_cancelled():
     task._cancel_points += 1
 
 
-if os.name == "nt":
+if sys.platform == "win32":
     from ._io_windows import WindowsIOManager as TheIOManager
     from ._generated_io_windows import *
-elif hasattr(select, "epoll"):
+elif sys.platform == "linux" or (not TYPE_CHECKING and hasattr(select, "epoll")):
     from ._io_epoll import EpollIOManager as TheIOManager
     from ._generated_io_epoll import *
-elif hasattr(select, "kqueue"):
+elif (
+    sys.platform == "darwin"
+    or sys.platform.startswith("freebsd")
+    or (not TYPE_CHECKING and hasattr(select, "epoll"))
+):
     from ._io_kqueue import KqueueIOManager as TheIOManager
     from ._generated_io_kqueue import *
 else:  # pragma: no cover

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -16,7 +16,7 @@ import enum
 from contextvars import copy_context
 from math import inf
 from time import perf_counter
-from typing import TYPE_CHECKING, Any, Callable
+from typing import Callable
 
 from sniffio import current_async_library_cvar
 
@@ -2379,14 +2379,10 @@ async def checkpoint_if_cancelled():
 if sys.platform == "win32":
     from ._io_windows import WindowsIOManager as TheIOManager
     from ._generated_io_windows import *
-elif sys.platform == "linux" or (not TYPE_CHECKING and hasattr(select, "epoll")):
+elif sys.platform == "linux" or hasattr(select, "epoll"):
     from ._io_epoll import EpollIOManager as TheIOManager
     from ._generated_io_epoll import *
-elif (
-    sys.platform == "darwin"
-    or sys.platform.startswith("freebsd")
-    or (not TYPE_CHECKING and hasattr(select, "kqueue"))
-):
+elif hasattr(select, "kqueue"):
     from ._io_kqueue import KqueueIOManager as TheIOManager
     from ._generated_io_kqueue import *
 else:  # pragma: no cover

--- a/trio/_core/tests/test_multierror.py
+++ b/trio/_core/tests/test_multierror.py
@@ -5,8 +5,8 @@ from traceback import (
     extract_tb,
     print_exception,
     format_exception,
-    _cause_message,
 )
+from traceback import _cause_message  # type: ignore
 import sys
 import os
 import re


### PR DESCRIPTION
This is a less ambitious version of #1254, the idea being that we can introduce mypy cleanliness gradually. I did copy relevant code from #1254, and fixed other issues too.

The relevant message in CI can be found in the [check formatting check](https://github.com/python-trio/trio/pull/1610/checks?check_run_id=764547595):
```
++ mypy -p trio._core --platform linux
Success: no issues found in 45 source files
```