### PR TITLE
Run GitHub Actions in forks too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,8 @@ name: CI
 
 on:
   push:
-    branches:
-      - master
+    branches-ignore:
+      - "dependabot/*" 
   pull_request:
 
 jobs:


### PR DESCRIPTION
This is the same configuration that we have in Travis: it allows testing
the CI before sending a pull request.

You can see the CI running on my fork here: https://github.com/pquentin/trio/runs/765167558