### PR TITLE
Make trio.lowlevel.checkpoint much faster

### DIFF
--- a/newsfragments/1613.feature.rst
+++ b/newsfragments/1613.feature.rst
@@ -1,0 +1,1 @@
+`trio.lowlevel.checkpoint` is now much faster.


### PR DESCRIPTION
This is a bit of a kluge, and will hopefully be cleaned up in the
future when we overhaul KeyboardInterrupt (gh-733) and/or the
cancellation checking APIs (gh-961). But 'checkpoint()' is a common
operation, and this speeds it up by ~7x, so... not bad for a ~4 line
change.

Before this change:

- `await checkpoint()`: ~24k/second
- `await cancel_shielded_checkpoint()`: ~180k/second

After this change:

- `await checkpoint()`: ~170k/second
- `await cancel_shielded_checkpoint()`: ~180k/second

Benchmark script:

```python
import time
import trio

LOOP_SIZE = 1_000_000

async def main():
    start = time.monotonic()
    for _ in range(LOOP_SIZE):
        await trio.lowlevel.checkpoint()
        #await trio.lowlevel.cancel_shielded_checkpoint()
    end = time.monotonic()
    print(f"{LOOP_SIZE / (end - start):.2f} schedules/second")

trio.run(main)
```