### PR TITLE
Add a fast path for the simplest cases of socket address resolution

### DIFF
--- a/newsfragments/1595.feature.rst
+++ b/newsfragments/1595.feature.rst
@@ -1,0 +1,3 @@
+If you pass a raw IP address into ``sendto``, it no longer spends any
+time trying to resolve the hostname. If you're using UDP, this should
+substantially reduce your per-packet overhead.


### PR DESCRIPTION
Profiling a user-written DNS microbenchmark in gh-1595 showed that UDP
sendto operations were spending a substantial amount of time in
_resolve_address, which is responsible for resolving any hostname
given in the sendto call. This is weird, since the benchmark wasn't
using hostnames, just a raw IP address.

Surprisingly, it turns out that calling getaddrinfo at all is also
quite expensive, even you give it an already-resolved plain IP address
so there's no work for it to do:

    In [1]: import socket

    In [2]: %timeit socket.getaddrinfo("127.0.0.1", 80)
    5.84 µs ± 53.6 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

    In [3]: %timeit socket.inet_aton("127.0.0.1")
    187 ns ± 1.5 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)

I thought getaddrinfo would be effectively free in this case, but
apparently I was wrong. Also, this doesn't really matter for TCP
connections, since they only pass through this path once per
connection, but UDP goes through here on every packet, so the overhead
adds up quickly.

Solution: add a fast-path to _resolve_address when user's address is
already resolved, so we skip all the work. On the benchmark in gh-1595
on my laptop, this PR takes us from ~7000 queries/second to
~9000 queries/second, so a ~30% speedup.

The patch is a bit more complicated than I expected. There are three
parts:

- The fast path itself

- Skipping unnecessary checkpoints in _resolve_address, including when
  we're on the fastpath: this is an internal function and it turns out
  that almost all our callers are already doing checkpoints, so there's
  no need to do another checkpoint inside _resolve_address. Even with
  the fast checkpoints from gh-1613, the fast-path+checkpoint is still
  only ~8000 queries/second on the DNS microbenchmark, versus ~9000
  queries/second without the checkpoint.

- _resolve_address used to always normalize IPv6 addresses into
  4-tuples, as a side-effect of how getaddrinfo works. The fast path
  doesn't call getaddrinfo, so the tests needed adjusting so they
  don't expect this normalization, and to make sure that our tests for
  the getaddrinfo normalization code don't hit the fast path.