### PR TITLE
Switch to heap-based deadline tracking

### DIFF
--- a/newsfragments/1629.feature.rst
+++ b/newsfragments/1629.feature.rst
@@ -1,0 +1,2 @@
+We switched to a new, lower-overhead data structure to track upcoming
+timeouts, which should make your programs faster.


### PR DESCRIPTION
Continuation of @Tronic's work in #1351

Main changes:

- Rebased on top of master, resolving a number of conflicts
- Reworked the heap management code in the `Deadlines` class, in particular to ignore defunct deadlines when computing the `next_deadline`.

Using the microbenchmark here: https://github.com/python-trio/trio/pull/1351#issuecomment-581390193

On my laptop I get:

**Current master**

```
❯ ./wrk http://localhost:5000 --latency
Running 10s test @ http://localhost:5000
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   657.76us  284.24us  12.20ms   90.78%
    Req/Sec     7.74k     1.11k    8.86k    80.20%
  Latency Distribution
     50%  616.00us
     75%  734.00us
     90%    0.85ms
     99%    1.28ms
  155534 requests in 10.10s, 10.09MB read
Requests/sec:  15399.87
Transfer/sec:      1.00MB
```

**This PR**

```
❯ ./wrk http://localhost:5000 --latency
Running 10s test @ http://localhost:5000
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   470.66us  116.54us   4.66ms   74.25%
    Req/Sec    10.64k     1.14k   21.23k    91.54%
  Latency Distribution
     50%  454.00us
     75%  524.00us
     90%  610.00us
     99%  792.00us
  212774 requests in 10.10s, 13.80MB read
Requests/sec:  21068.22
Transfer/sec:      1.37MB
```

**This PR + a stubbed-out `Deadlines` class** (i.e., this is what we'd
get if our deadline tracking heap somehow managed to perform all
operations in zero time)

<details>

```python
class Deadlines:
    def add(self, deadline, cancel_scope):
        pass

    def remove(self, deadline, cancel_scope):
        pass

    def next_deadline(self):
        return inf

    def expire(self, now):
        return False
```

</details>

```
❯ ./wrk http://localhost:5000 --latency
Running 10s test @ http://localhost:5000
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   478.42us  274.25us   9.03ms   97.35%
    Req/Sec    10.72k     1.48k   21.79k    85.57%
  Latency Distribution
     50%  445.00us
     75%  527.00us
     90%  610.00us
     99%    0.86ms
  214433 requests in 10.10s, 13.91MB read
Requests/sec:  21231.28
Transfer/sec:      1.38MB
```

These benchmarks aren't super stable, because a laptop is a terrible benchmarking environment (thermal issues, etc.). But it seems fair to say that this gives roughly a 35% increase in throughput + improves latency, and that there's not a lot of headroom left for further algorithmic improvements. (At least until we make everything else faster!)

Co-authored-by: L. Kärkkäinen <tronic@users.noreply.github.com>