### PR TITLE
Don't hold a reference to the last  job in the thread cache

### DIFF
--- a/newsfragments/1638.fix.rst
+++ b/newsfragments/1638.fix.rst
@@ -1,0 +1,1 @@
+The thread cache didn't release its reference to the previous job.

--- a/trio/_core/_thread_cache.py
+++ b/trio/_core/_thread_cache.py
@@ -69,6 +69,8 @@ class WorkerThread:
                 # instead of spawning a new thread.
                 self._thread_cache._idle_workers[self] = None
                 deliver(result)
+                del fn
+                del deliver
             else:
                 # Timeout acquiring lock, so we can probably exit. But,
                 # there's a race condition: we might be assigned a job *just*

--- a/trio/_core/tests/test_thread_cache.py
+++ b/trio/_core/tests/test_thread_cache.py
@@ -4,7 +4,7 @@ from queue import Queue
 import time
 import sys
 
-from .tutil import slow
+from .tutil import slow, gc_collect_harder
 from .. import _thread_cache
 from .._thread_cache import start_thread_soon, ThreadCache
 
@@ -23,6 +23,29 @@ def test_thread_cache_basics():
     outcome = q.get()
     with pytest.raises(RuntimeError, match="hi"):
         outcome.unwrap()
+
+
+def test_thread_cache_deref():
+    res = [False]
+
+    class del_me:
+        def __call__(self):
+            return 42
+
+        def __del__(self):
+            res[0] = True
+
+    q = Queue()
+
+    def deliver(outcome):
+        q.put(outcome)
+
+    start_thread_soon(del_me(), deliver)
+    outcome = q.get()
+    assert outcome.unwrap() == 42
+
+    gc_collect_harder()
+    assert res[0]
 
 
 @slow


### PR DESCRIPTION
Fixes #1638 