### PR TITLE
Only assert platform when type checking

### DIFF
--- a/trio/_core/_io_epoll.py
+++ b/trio/_core/_io_epoll.py
@@ -2,14 +2,14 @@ import select
 import sys
 import attr
 from collections import defaultdict
-from typing import Dict
+from typing import Dict, TYPE_CHECKING
 
 from .. import _core
 from ._run import _public
 from ._io_common import wake_all
 from ._wakeup_socketpair import WakeupSocketpair
 
-assert sys.platform == "linux"
+assert not TYPE_CHECKING or sys.platform == "linux"
 
 
 @attr.s(slots=True, eq=False, frozen=True)

--- a/trio/_core/_io_kqueue.py
+++ b/trio/_core/_io_kqueue.py
@@ -11,7 +11,7 @@ from .. import _core
 from ._run import _public
 from ._wakeup_socketpair import WakeupSocketpair
 
-assert not TYPE_CHECKING or sys.platform != "linux" and sys.platform != "win32"
+assert not TYPE_CHECKING or (sys.platform != "linux" and sys.platform != "win32")
 
 
 @attr.s(slots=True, eq=False, frozen=True)

--- a/trio/_core/_io_kqueue.py
+++ b/trio/_core/_io_kqueue.py
@@ -1,5 +1,6 @@
 import select
 import sys
+from typing import TYPE_CHECKING
 
 import outcome
 from contextlib import contextmanager
@@ -10,7 +11,7 @@ from .. import _core
 from ._run import _public
 from ._wakeup_socketpair import WakeupSocketpair
 
-assert sys.platform != "linux" and sys.platform != "win32"
+assert not TYPE_CHECKING or sys.platform != "linux" and sys.platform != "win32"
 
 
 @attr.s(slots=True, eq=False, frozen=True)

--- a/trio/_core/_io_windows.py
+++ b/trio/_core/_io_windows.py
@@ -3,6 +3,7 @@ from contextlib import contextmanager
 import enum
 import socket
 import sys
+from typing import TYPE_CHECKING
 
 import attr
 
@@ -26,7 +27,7 @@ from ._windows_cffi import (
     IoControlCodes,
 )
 
-assert sys.platform == "win32"
+assert not TYPE_CHECKING or sys.platform == "win32"
 
 # There's a lot to be said about the overall design of a Windows event
 # loop. See


### PR DESCRIPTION
We would like to write:

```
if TYPE_CHECKING:
    assert sys.platform == "linux"
```

But that hides the assert to mypy. This commits finds a way to avoid that issue.

We still use platform checks in `trio._core._run` and `trio._core.__init__`. Do we want to avoid them there too?