### PR TITLE
Support alternatives to trio.run() for pytest-trio

### DIFF
--- a/trio/testing/_trio_test.py
+++ b/trio/testing/_trio_test.py
@@ -12,18 +12,24 @@ from ..abc import Clock, Instrument
 #
 # Also: if a pytest fixture is passed in that subclasses the Clock abc, then
 # that clock is passed to trio.run().
-def trio_test(fn):
-    @wraps(fn)
-    def wrapper(**kwargs):
-        __tracebackhide__ = True
-        clocks = [c for c in kwargs.values() if isinstance(c, Clock)]
-        if not clocks:
-            clock = None
-        elif len(clocks) == 1:
-            clock = clocks[0]
-        else:
-            raise ValueError("too many clocks spoil the broth!")
-        instruments = [i for i in kwargs.values() if isinstance(i, Instrument)]
-        return _core.run(partial(fn, **kwargs), clock=clock, instruments=instruments)
+def trio_test(fn=None, *, run=_core.run):
+    def decorator(fn):
+        @wraps(fn)
+        def wrapper(**kwargs):
+            __tracebackhide__ = True
+            clocks = [c for c in kwargs.values() if isinstance(c, Clock)]
+            if not clocks:
+                clock = None
+            elif len(clocks) == 1:
+                clock = clocks[0]
+            else:
+                raise ValueError("too many clocks spoil the broth!")
+            instruments = [i for i in kwargs.values() if isinstance(i, Instrument)]
+            return run(partial(fn, **kwargs), clock=clock, instruments=instruments)
 
-    return wrapper
+        return wrapper
+
+    if fn is None:
+        return decorator
+
+    return decorator(fn)


### PR DESCRIPTION
Draft for:
- [x] ~~Generally concluding the other PRs are going to work~~
  - Since moving `trio_test()` to pytest-trio, the other PRs no longer depend on this one.
- [ ] Maybe deprecate `trio_test()`, maybe just delete it?

Relates to:
- https://github.com/python-trio/pytest-trio/pull/105
- https://github.com/altendky/qtrio/pull/152