### PR TITLE
Fix setuptools 50 import in Python 3.6.1 pylint test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,8 @@ jobs:
         - "LINUX_VM_IMAGE=https://download.fedoraproject.org/pub/fedora/linux/releases/32/Cloud/x86_64/images/Fedora-Cloud-Base-32-1.6.x86_64.qcow2"
 
     - python: 3.6.1  # earliest 3.6 version available on Travis
+      # https://github.com/pypa/setuptools/issues/2350
+      env: SETUPTOOLS_USE_DISTUTILS=stdlib
       dist: bionic
     - python: 3.6-dev
     - python: 3.7-dev


### PR DESCRIPTION
See https://github.com/pypa/setuptools/issues/2350 for details. pip, setuptools and wheel are the only packages that we don't pin, and indeed the pylint tests started failing with setuptools 50.0 on Python 3.6.1. (No other configuration is affected.)