### PR TITLE
docs: Fix simple typo, renegotation -> renegotiation

### DIFF
--- a/trio/_ssl.py
+++ b/trio/_ssl.py
@@ -69,7 +69,7 @@
 # able to use this to figure out the key. Is this a real practical problem? I
 # have no idea, I'm not a cryptographer. In any case, some people worry that
 # it's a problem, so their TLS libraries are designed to automatically trigger
-# a renegotation every once in a while on some sort of timer.
+# a renegotiation every once in a while on some sort of timer.
 #
 # The end result is that you might be going along, minding your own business,
 # and then *bam*! a wild renegotiation appears! And you just have to cope.
@@ -542,7 +542,7 @@ class SSLStream(Stream, metaclass=SubclassingDeprecatedIn_v0_15_0):
             # We could do something tricky to keep track of whether a
             # receive_some happens while we're sending, but the case where
             # we have to do both is very unusual (only during a
-            # renegotation), so it's better to keep things simple. So we
+            # renegotiation), so it's better to keep things simple. So we
             # do just one potentially-blocking operation, then check again
             # for fresh information.
             #

--- a/trio/tests/test_ssl.py
+++ b/trio/tests/test_ssl.py
@@ -231,7 +231,7 @@ class PyOpenSSLEchoStream:
         return self._conn.renegotiate_pending()
 
     def renegotiate(self):
-        # Returns false if a renegotation is already in progress, meaning
+        # Returns false if a renegotiation is already in progress, meaning
         # nothing happens.
         assert self._conn.renegotiate()
 
@@ -323,7 +323,7 @@ class PyOpenSSLEchoStream:
 async def test_PyOpenSSLEchoStream_gives_resource_busy_errors():
     # Make sure that PyOpenSSLEchoStream complains if two tasks call send_all
     # at the same time, or ditto for receive_some. The tricky cases where SSLStream
-    # might accidentally do this are during renegotation, which we test using
+    # might accidentally do this are during renegotiation, which we test using
     # PyOpenSSLEchoStream, so this makes sure that if we do have a bug then
     # PyOpenSSLEchoStream will notice and complain.
 


### PR DESCRIPTION
There is a small typo in trio/_ssl.py, trio/tests/test_ssl.py.

Should read `renegotiation` rather than `renegotation`.

