### PR TITLE
Stop allowing subclassing public classes

### DIFF
--- a/newsfragments/1726.deprecated.rst
+++ b/newsfragments/1726.deprecated.rst
@@ -1,0 +1,1 @@
+Stop allowing subclassing public classes. This behavior was deprecated in 0.15.0.

--- a/trio/_core/_local.py
+++ b/trio/_core/_local.py
@@ -1,7 +1,7 @@
 # Runvar implementations
 from . import _run
 
-from .._util import SubclassingDeprecatedIn_v0_15_0
+from .._util import Final
 
 
 class _RunVarToken:
@@ -19,7 +19,7 @@ class _RunVarToken:
         self.redeemed = False
 
 
-class RunVar(metaclass=SubclassingDeprecatedIn_v0_15_0):
+class RunVar(metaclass=Final):
     """The run-local variant of a context variable.
 
     :class:`RunVar` objects are similar to context variable objects,

--- a/trio/_core/_mock_clock.py
+++ b/trio/_core/_mock_clock.py
@@ -4,7 +4,7 @@ from math import inf
 from .. import _core
 from ._run import GLOBAL_RUN_CONTEXT
 from .._abc import Clock
-from .._util import SubclassingDeprecatedIn_v0_15_0
+from .._util import Final
 
 ################################################################
 # The glorious MockClock
@@ -14,7 +14,7 @@ from .._util import SubclassingDeprecatedIn_v0_15_0
 # Prior art:
 #   https://twistedmatrix.com/documents/current/api/twisted.internet.task.Clock.html
 #   https://github.com/ztellman/manifold/issues/57
-class MockClock(Clock, metaclass=SubclassingDeprecatedIn_v0_15_0):
+class MockClock(Clock, metaclass=Final):
     """A user-controllable clock suitable for writing tests.
 
     Args:

--- a/trio/_core/_parking_lot.py
+++ b/trio/_core/_parking_lot.py
@@ -75,7 +75,7 @@ import attr
 from collections import OrderedDict
 
 from .. import _core
-from .._util import SubclassingDeprecatedIn_v0_15_0
+from .._util import Final
 
 _counter = count()
 
@@ -86,7 +86,7 @@ class _ParkingLotStatistics:
 
 
 @attr.s(eq=False, hash=False)
-class ParkingLot(metaclass=SubclassingDeprecatedIn_v0_15_0):
+class ParkingLot(metaclass=Final):
     """A fair wait queue with cancellation and requeueing.
 
     This class encapsulates the tricky parts of implementing a wait

--- a/trio/_core/_unbounded_queue.py
+++ b/trio/_core/_unbounded_queue.py
@@ -2,7 +2,7 @@ import attr
 
 from .. import _core
 from .._deprecate import deprecated
-from .._util import SubclassingDeprecatedIn_v0_15_0
+from .._util import Final
 
 
 @attr.s(frozen=True)
@@ -11,7 +11,7 @@ class _UnboundedQueueStats:
     tasks_waiting = attr.ib()
 
 
-class UnboundedQueue(metaclass=SubclassingDeprecatedIn_v0_15_0):
+class UnboundedQueue(metaclass=Final):
     """An unbounded queue suitable for certain unusual forms of inter-task
     communication.
 

--- a/trio/_highlevel_generic.py
+++ b/trio/_highlevel_generic.py
@@ -3,7 +3,7 @@ import attr
 import trio
 from .abc import HalfCloseableStream
 
-from trio._util import SubclassingDeprecatedIn_v0_15_0
+from trio._util import Final
 
 
 async def aclose_forcefully(resource):
@@ -37,7 +37,7 @@ async def aclose_forcefully(resource):
 
 
 @attr.s(eq=False, hash=False)
-class StapledStream(HalfCloseableStream, metaclass=SubclassingDeprecatedIn_v0_15_0):
+class StapledStream(HalfCloseableStream, metaclass=Final):
     """This class `staples <https://en.wikipedia.org/wiki/Staple_(fastener)>`__
     together two unidirectional streams to make single bidirectional stream.
 

--- a/trio/_highlevel_socket.py
+++ b/trio/_highlevel_socket.py
@@ -5,7 +5,7 @@ from contextlib import contextmanager
 
 import trio
 from . import socket as tsocket
-from ._util import ConflictDetector, SubclassingDeprecatedIn_v0_15_0
+from ._util import ConflictDetector, Final
 from .abc import HalfCloseableStream, Listener
 
 # XX TODO: this number was picked arbitrarily. We should do experiments to
@@ -35,7 +35,7 @@ def _translate_socket_errors_to_stream_errors():
             ) from exc
 
 
-class SocketStream(HalfCloseableStream, metaclass=SubclassingDeprecatedIn_v0_15_0):
+class SocketStream(HalfCloseableStream, metaclass=Final):
     """An implementation of the :class:`trio.abc.HalfCloseableStream`
     interface based on a raw network socket.
 
@@ -315,7 +315,7 @@ for name in _ignorable_accept_errno_names:
         pass
 
 
-class SocketListener(Listener[SocketStream], metaclass=SubclassingDeprecatedIn_v0_15_0):
+class SocketListener(Listener[SocketStream], metaclass=Final):
     """A :class:`~trio.abc.Listener` that uses a listening socket to accept
     incoming connections as :class:`SocketStream` objects.
 

--- a/trio/_path.py
+++ b/trio/_path.py
@@ -6,7 +6,7 @@ import types
 import pathlib
 
 import trio
-from trio._util import async_wraps, SubclassingDeprecatedIn_v0_15_0
+from trio._util import async_wraps, Final
 
 
 # re-wrap return value from methods that return new instances of pathlib.Path
@@ -77,7 +77,7 @@ def classmethod_wrapper_factory(cls, meth_name):
     return wrapper
 
 
-class AsyncAutoWrapperType(SubclassingDeprecatedIn_v0_15_0):
+class AsyncAutoWrapperType(Final):
     def __init__(cls, name, bases, attrs):
         super().__init__(name, bases, attrs)
 

--- a/trio/_ssl.py
+++ b/trio/_ssl.py
@@ -158,7 +158,7 @@ import trio
 from .abc import Stream, Listener
 from ._highlevel_generic import aclose_forcefully
 from . import _sync
-from ._util import ConflictDetector, SubclassingDeprecatedIn_v0_15_0
+from ._util import ConflictDetector, Final
 from ._deprecate import warn_deprecated
 
 ################################################################
@@ -224,7 +224,7 @@ class _Once:
 _State = _Enum("_State", ["OK", "BROKEN", "CLOSED"])
 
 
-class SSLStream(Stream, metaclass=SubclassingDeprecatedIn_v0_15_0):
+class SSLStream(Stream, metaclass=Final):
     r"""Encrypted communication using SSL/TLS.
 
     :class:`SSLStream` wraps an arbitrary :class:`~trio.abc.Stream`, and
@@ -870,7 +870,7 @@ class SSLStream(Stream, metaclass=SubclassingDeprecatedIn_v0_15_0):
                 await self.transport_stream.wait_send_all_might_not_block()
 
 
-class SSLListener(Listener[SSLStream], metaclass=SubclassingDeprecatedIn_v0_15_0):
+class SSLListener(Listener[SSLStream], metaclass=Final):
     """A :class:`~trio.abc.Listener` for SSL/TLS-encrypted servers.
 
     :class:`SSLListener` wraps around another Listener, and converts

--- a/trio/_sync.py
+++ b/trio/_sync.py
@@ -7,11 +7,11 @@ import trio
 
 from ._core import enable_ki_protection, ParkingLot
 from ._deprecate import deprecated
-from ._util import SubclassingDeprecatedIn_v0_15_0
+from ._util import Final
 
 
 @attr.s(repr=False, eq=False, hash=False)
-class Event(metaclass=SubclassingDeprecatedIn_v0_15_0):
+class Event(metaclass=Final):
     """A waitable boolean value useful for inter-task synchronization,
     inspired by :class:`threading.Event`.
 
@@ -99,7 +99,7 @@ class _CapacityLimiterStatistics:
 
 
 @async_cm
-class CapacityLimiter(metaclass=SubclassingDeprecatedIn_v0_15_0):
+class CapacityLimiter(metaclass=Final):
     """An object for controlling access to a resource with limited capacity.
 
     Sometimes you need to put a limit on how many tasks can do something at
@@ -342,7 +342,7 @@ class CapacityLimiter(metaclass=SubclassingDeprecatedIn_v0_15_0):
 
 
 @async_cm
-class Semaphore(metaclass=SubclassingDeprecatedIn_v0_15_0):
+class Semaphore(metaclass=Final):
     """A `semaphore <https://en.wikipedia.org/wiki/Semaphore_(programming)>`__.
 
     A semaphore holds an integer value, which can be incremented by
@@ -562,7 +562,7 @@ class _LockImpl:
         )
 
 
-class Lock(_LockImpl, metaclass=SubclassingDeprecatedIn_v0_15_0):
+class Lock(_LockImpl, metaclass=Final):
     """A classic `mutex
     <https://en.wikipedia.org/wiki/Lock_(computer_science)>`__.
 
@@ -576,7 +576,7 @@ class Lock(_LockImpl, metaclass=SubclassingDeprecatedIn_v0_15_0):
     """
 
 
-class StrictFIFOLock(_LockImpl, metaclass=SubclassingDeprecatedIn_v0_15_0):
+class StrictFIFOLock(_LockImpl, metaclass=Final):
     r"""A variant of :class:`Lock` where tasks are guaranteed to acquire the
     lock in strict first-come-first-served order.
 
@@ -646,7 +646,7 @@ class _ConditionStatistics:
 
 
 @async_cm
-class Condition(metaclass=SubclassingDeprecatedIn_v0_15_0):
+class Condition(metaclass=Final):
     """A classic `condition variable
     <https://en.wikipedia.org/wiki/Monitor_(synchronization)>`__, similar to
     :class:`threading.Condition`.

--- a/trio/_unix_pipes.py
+++ b/trio/_unix_pipes.py
@@ -2,7 +2,7 @@ import os
 import errno
 
 from ._abc import Stream
-from ._util import ConflictDetector, SubclassingDeprecatedIn_v0_15_0
+from ._util import ConflictDetector, Final
 
 import trio
 
@@ -74,7 +74,7 @@ class _FdHolder:
         await trio.lowlevel.checkpoint()
 
 
-class FdStream(Stream, metaclass=SubclassingDeprecatedIn_v0_15_0):
+class FdStream(Stream, metaclass=Final):
     """
     Represents a stream given the file descriptor to a pipe, TTY, etc.
 

--- a/trio/_util.py
+++ b/trio/_util.py
@@ -309,20 +309,6 @@ class Final(BaseMeta):
         return super().__new__(cls, name, bases, cls_namespace)
 
 
-class SubclassingDeprecatedIn_v0_15_0(BaseMeta):
-    def __new__(cls, name, bases, cls_namespace):
-        for base in bases:
-            if isinstance(base, SubclassingDeprecatedIn_v0_15_0):
-                warn_deprecated(
-                    f"subclassing {base.__module__}.{base.__qualname__}",
-                    "0.15.0",
-                    issue=1044,
-                    instead="composition or delegation",
-                )
-                break
-        return super().__new__(cls, name, bases, cls_namespace)
-
-
 T = t.TypeVar("T")
 
 

--- a/trio/testing/_memory_streams.py
+++ b/trio/testing/_memory_streams.py
@@ -73,7 +73,7 @@ class _UnboundedByteQueue:
             return self._get_impl(max_bytes)
 
 
-class MemorySendStream(SendStream, metaclass=_util.SubclassingDeprecatedIn_v0_15_0):
+class MemorySendStream(SendStream, metaclass=_util.Final):
     """An in-memory :class:`~trio.abc.SendStream`.
 
     Args:
@@ -187,9 +187,7 @@ class MemorySendStream(SendStream, metaclass=_util.SubclassingDeprecatedIn_v0_15
         return self._outgoing.get_nowait(max_bytes)
 
 
-class MemoryReceiveStream(
-    ReceiveStream, metaclass=_util.SubclassingDeprecatedIn_v0_15_0
-):
+class MemoryReceiveStream(ReceiveStream, metaclass=_util.Final):
     """An in-memory :class:`~trio.abc.ReceiveStream`.
 
     Args:

--- a/trio/testing/_sequencer.py
+++ b/trio/testing/_sequencer.py
@@ -12,7 +12,7 @@ if False:
 
 
 @attr.s(eq=False, hash=False)
-class Sequencer(metaclass=_util.SubclassingDeprecatedIn_v0_15_0):
+class Sequencer(metaclass=_util.Final):
     """A convenience class for forcing code in different tasks to run in an
     explicit linear order.
 

--- a/trio/tests/test_exports.py
+++ b/trio/tests/test_exports.py
@@ -141,6 +141,4 @@ def test_classes_are_final():
                 continue
             # ... insert other special cases here ...
 
-            assert isinstance(
-                class_, (_util.Final, _util.SubclassingDeprecatedIn_v0_15_0)
-            )
+            assert isinstance(class_, (_util.Final, _util.Final))

--- a/trio/tests/test_exports.py
+++ b/trio/tests/test_exports.py
@@ -141,4 +141,4 @@ def test_classes_are_final():
                 continue
             # ... insert other special cases here ...
 
-            assert isinstance(class_, (_util.Final, _util.Final))
+            assert isinstance(class_, _util.Final)

--- a/trio/tests/test_util.py
+++ b/trio/tests/test_util.py
@@ -12,7 +12,6 @@ from .._util import (
     generic_function,
     Final,
     NoPublicConstructor,
-    SubclassingDeprecatedIn_v0_15_0,
 )
 from ..testing import wait_all_tasks_blocked
 
@@ -168,16 +167,6 @@ def test_final_metaclass():
     with pytest.raises(TypeError):
 
         class SubClass(FinalClass):
-            pass
-
-
-def test_subclassing_deprecated_metaclass():
-    class Blah(metaclass=SubclassingDeprecatedIn_v0_15_0):
-        pass
-
-    with pytest.warns(trio.TrioDeprecationWarning):
-
-        class Blah2(Blah):
             pass
 
 


### PR DESCRIPTION
It was deprecated in Trio 0.15.0.