### PR TITLE
Stop using RawGit URL in PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 exec(open("trio/_version.py", encoding="utf-8").read())
 
 LONG_DESC = """\
-.. image:: https://cdn.rawgit.com/python-trio/trio/9b0bec646a31e0d0f67b8b6ecc6939726faf3e17/logo/logo-with-background.svg
+.. image:: https://raw.githubusercontent.com/python-trio/trio/9b0bec646a31e0d0f67b8b6ecc6939726faf3e17/logo/logo-with-background.svg
    :width: 200px
    :align: right
 


### PR DESCRIPTION
RawGit has shut down, but GitHub fixed the original issue so it's no longer needed.

This was fixed for the GitHub README in https://github.com/python-trio/trio/pull/1635, but I forgot about PyPI. I just noticed it now as RawGit stopped serving the image.