### PR TITLE
Make trio.from_thread.run() raise RunFinishedError if the system nursery is closed

### DIFF
--- a/newsfragments/1738.bugfix.rst
+++ b/newsfragments/1738.bugfix.rst
@@ -1,0 +1,6 @@
+:func:`trio.from_thread.run` no longer crashes the Trio run if it is
+executed after the system nursery has been closed but before the run
+has finished. Calls made at this time will now raise
+`trio.RunFinishedError`.  This fixes a regression introduced in
+Trio 0.17.0.  The window in question is only one scheduler tick long in
+most cases, but may be longer if async generators need to be cleaned up.

--- a/trio/_core/_generated_run.py
+++ b/trio/_core/_generated_run.py
@@ -126,6 +126,15 @@ def spawn_system_task(async_fn, *args, name=None):
 
         * System tasks do not inherit context variables from their creator.
 
+        Towards the end of a call to :meth:`trio.run`, after the main
+        task and all system tasks have exited, the system nursery
+        becomes closed. At this point, new calls to
+        :func:`spawn_system_task` will raise ``RuntimeError("Nursery
+        is closed to new arrivals")`` instead of creating a system
+        task. It's possible to encounter this state either in
+        a ``finally`` block in an async generator, or in a callback
+        passed to :meth:`TrioToken.run_sync_soon` at the right moment.
+
         Args:
           async_fn: An async callable.
           args: Positional arguments for ``async_fn``. If you want to pass

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -1546,6 +1546,15 @@ class Runner:
 
         * System tasks do not inherit context variables from their creator.
 
+        Towards the end of a call to :meth:`trio.run`, after the main
+        task and all system tasks have exited, the system nursery
+        becomes closed. At this point, new calls to
+        :func:`spawn_system_task` will raise ``RuntimeError("Nursery
+        is closed to new arrivals")`` instead of creating a system
+        task. It's possible to encounter this state either in
+        a ``finally`` block in an async generator, or in a callback
+        passed to :meth:`TrioToken.run_sync_soon` at the right moment.
+
         Args:
           async_fn: An async callable.
           args: Positional arguments for ``async_fn``. If you want to pass

--- a/trio/tests/test_threads.py
+++ b/trio/tests/test_threads.py
@@ -7,6 +7,7 @@ import pytest
 from .. import _core
 from .. import Event, CapacityLimiter, sleep
 from ..testing import wait_all_tasks_blocked
+from .._core.tests.tutil import buggy_pypy_asyncgens
 from .._threads import (
     to_thread_run_sync,
     current_default_thread_limiter,
@@ -554,3 +555,24 @@ async def test_from_thread_inside_trio_thread():
     trio_token = _core.current_trio_token()
     with pytest.raises(RuntimeError):
         from_thread_run_sync(not_called, trio_token=trio_token)
+
+
+@pytest.mark.skipif(buggy_pypy_asyncgens, reason="pypy 7.2.0 is buggy")
+def test_from_thread_run_during_shutdown():
+    save = []
+    record = []
+
+    async def agen():
+        try:
+            yield
+        finally:
+            with pytest.raises(_core.RunFinishedError), _core.CancelScope(shield=True):
+                await to_thread_run_sync(from_thread_run, sleep, 0)
+            record.append("ok")
+
+    async def main():
+        save.append(agen())
+        await save[-1].asend(None)
+
+    _core.run(main)
+    assert record == ["ok"]


### PR DESCRIPTION
Fixes #1738. Also improve the documentation for spawn_system_task() to more clearly indicate this possibility.

Rationale for RunFinishedError: callers to `from_thread.run()` already need to be able to handle the case where the run is finished, and it's difficult to distinguish "has started async generator finalization" from the case where the run is fully done. I would also entertain other options (raise Cancelled? block until the run actually finishes and then raise RunFinishedError?) if anyone wants to make a case for why a different choice might be more robust.