### PR TITLE
Fix FreeBSD build by busting the cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ jobs:
         - "FREEBSD_INSTALLER_ISO_XZ=https://download.freebsd.org/ftp/releases/amd64/amd64/ISO-IMAGES/12.1/FreeBSD-12.1-RELEASE-amd64-disc1.iso.xz"
         # Increment this each time you change the image build code in
         # ci.sh and want to intentionally bust the cache.
-        - "CACHE_GEN=2"
+        - "CACHE_GEN=3"
       cache:
         directories:
           - travis-cache


### PR DESCRIPTION
This reinstalls/rebuilds packages and stops depending on an old libffi version.

https://forums.freebsd.org/threads/certbot-python3-7-dependency-error.76808/

Failing build, for reference: https://travis-ci.org/github/python-trio/trio/jobs/735639080