### PR TITLE
Use Windows message-oriented pipes to create Channels

### DIFF
--- a/trio/_core/_windows_cffi.py
+++ b/trio/_core/_windows_cffi.py
@@ -357,3 +357,12 @@ def get_pipe_state(handle):
     ):
         raise_winerror()  # pragma: no cover
     return lpState[0]
+
+
+def peek_pipe_message_left(handle):
+    left = ffi.new("LPDWORD")
+    if not kernel32.PeekNamedPipe(
+        _handle(handle), ffi.NULL, 0, ffi.NULL, ffi.NULL, left,
+    ):
+        raise_winerror()  # pragma: no cover
+    return left[0]

--- a/trio/_core/_windows_cffi.py
+++ b/trio/_core/_windows_cffi.py
@@ -362,7 +362,7 @@ def get_pipe_state(handle):
 def peek_pipe_message_left(handle):
     left = ffi.new("LPDWORD")
     if not kernel32.PeekNamedPipe(
-        _handle(handle), ffi.NULL, 0, ffi.NULL, ffi.NULL, left,
+        _handle(handle), ffi.NULL, 0, ffi.NULL, ffi.NULL, left
     ):
         raise_winerror()  # pragma: no cover
     return left[0]

--- a/trio/_core/_windows_cffi.py
+++ b/trio/_core/_windows_cffi.py
@@ -355,5 +355,5 @@ def get_pipe_state(handle):
     if not kernel32.GetNamedPipeHandleStateA(
         _handle(handle), lpState, ffi.NULL, ffi.NULL, ffi.NULL, ffi.NULL, 0
     ):
-        raise_winerror()
+        raise_winerror()  # pragma: no cover
     return lpState[0]

--- a/trio/_windows_pipes.py
+++ b/trio/_windows_pipes.py
@@ -172,7 +172,7 @@ class PipeReceiveChannel(ReceiveChannel[bytes]):
             return await self._receive_some_into(buffer)
         except OSError as e:
             if e.winerror != ErrorCodes.ERROR_MORE_DATA:
-                raise
+                raise  # pragma: no cover
             left = ffi.new("LPDWORD")
             if not kernel32.PeekNamedPipe(
                 _handle(self._handle_holder.handle),
@@ -182,7 +182,7 @@ class PipeReceiveChannel(ReceiveChannel[bytes]):
                 ffi.NULL,
                 left,
             ):
-                raise_winerror()
+                raise_winerror()  # pragma: no cover
             buffer.extend(await self._receive_some_into(bytearray(left[0])))
             return buffer
 

--- a/trio/_windows_pipes.py
+++ b/trio/_windows_pipes.py
@@ -202,12 +202,9 @@ class PipeReceiveChannel(ReceiveChannel[bytes]):
 
                 # Windows raises BrokenPipeError on one end of a pipe
                 # whenever the other end closes, regardless of direction.
-                # Convert this to EndOfChannel
+                # Convert this to EndOfChannel.
                 #
-                # And since we're not raising an exception, we have to
-                # checkpoint. But readinto_overlapped did raise an exception,
-                # so it might not have checkpointed for us. So we have to
-                # checkpoint manually.
+                # Do we have to checkpoint manually? We are raising an exception.
                 await _core.checkpoint()
                 raise _core.EndOfChannel
             else:

--- a/trio/_windows_pipes.py
+++ b/trio/_windows_pipes.py
@@ -1,9 +1,15 @@
 import sys
 from typing import TYPE_CHECKING
 from . import _core
-from ._abc import SendStream, ReceiveStream
+from ._abc import SendStream, ReceiveStream, SendChannel, ReceiveChannel
 from ._util import ConflictDetector, Final
-from ._core._windows_cffi import _handle, raise_winerror, kernel32, ffi
+from ._core._windows_cffi import (
+    _handle,
+    raise_winerror,
+    kernel32,
+    ffi,
+    ErrorCodes,
+)
 
 assert sys.platform == "win32" or not TYPE_CHECKING
 
@@ -126,6 +132,84 @@ class PipeReceiveStream(ReceiveStream, metaclass=Final):
                 # checkpoint manually.
                 await _core.checkpoint()
                 return b""
+            else:
+                del buffer[size:]
+                return buffer
+
+    async def aclose(self):
+        await self._handle_holder.aclose()
+
+
+class PipeSendChannel(SendChannel[bytes]):
+    """Represents a message stream over a pipe object."""
+
+    def __init__(self, handle: int) -> None:
+        self._pss = PipeSendStream(handle)
+        # needed for "detach" via _handle_holder.handle = -1
+        self._handle_holder = self._pss._handle_holder
+
+    async def send(self, value: bytes):
+        # Works just fine if the pipe is message-oriented
+        await self._pss.send_all(value)
+
+    async def aclose(self):
+        await self._handle_holder.aclose()
+
+
+class PipeReceiveChannel(ReceiveChannel[bytes]):
+    """Represents a message stream over a pipe object."""
+
+    def __init__(self, handle: int) -> None:
+        self._handle_holder = _HandleHolder(handle)
+        self._conflict_detector = ConflictDetector(
+            "another task is currently using this pipe"
+        )
+
+    async def receive(self) -> bytes:
+        # Would a io.BytesIO make more sense?
+        buffer = bytearray(DEFAULT_RECEIVE_SIZE)
+        try:
+            return await self._receive_some_into(buffer)
+        except OSError as e:
+            if e.winerror != ErrorCodes.ERROR_MORE_DATA:
+                raise
+            left = ffi.new("LPDWORD")
+            if not kernel32.PeekNamedPipe(
+                _handle(self._handle_holder.handle),
+                ffi.NULL,
+                0,
+                ffi.NULL,
+                ffi.NULL,
+                left,
+            ):
+                raise_winerror()
+            buffer.extend(await self._receive_some_into(bytearray(left[0])))
+            return buffer
+
+    async def _receive_some_into(self, buffer) -> bytes:
+        with self._conflict_detector:
+            if self._handle_holder.closed:
+                raise _core.ClosedResourceError("this pipe is already closed")
+            try:
+                size = await _core.readinto_overlapped(
+                    self._handle_holder.handle, buffer
+                )
+            except BrokenPipeError:
+                if self._handle_holder.closed:
+                    raise _core.ClosedResourceError(
+                        "another task closed this pipe"
+                    ) from None
+
+                # Windows raises BrokenPipeError on one end of a pipe
+                # whenever the other end closes, regardless of direction.
+                # Convert this to EndOfChannel
+                #
+                # And since we're not raising an exception, we have to
+                # checkpoint. But readinto_overlapped did raise an exception,
+                # so it might not have checkpointed for us. So we have to
+                # checkpoint manually.
+                await _core.checkpoint()
+                raise _core.EndOfChannel
             else:
                 del buffer[size:]
                 return buffer

--- a/trio/tests/test_windows_pipes.py
+++ b/trio/tests/test_windows_pipes.py
@@ -231,11 +231,11 @@ async def test_channel_message_never_splits():
         await w.send(big_bytes)
 
     async def read_big():
-      async with read_lock:
-        read_ev.set()
-        nonlocal result
-        with read_cs:
-            result = await r.receive()
+        async with read_lock:
+            read_ev.set()
+            nonlocal result
+            with read_cs:
+                result = await r.receive()
 
     # bug was usually triggered within 5 tries
     for i in range(10):
@@ -269,4 +269,3 @@ async def test_channel_message_never_splits():
                 nursery.cancel_scope.cancel()
 
         assert result is None or len(result) == len(big_bytes)
-

--- a/trio/tests/test_windows_pipes.py
+++ b/trio/tests/test_windows_pipes.py
@@ -196,7 +196,7 @@ async def test_close_stream_during_write():
             assert "another task" in str(excinfo.value)
 
         nursery.start_soon(write_forever)
-        await wait_all_tasks_blocked(0.1)
+        await wait_all_tasks_blocked(0.01)
         await w.aclose()
 
 
@@ -251,7 +251,7 @@ async def test_channel_message_never_splits():
                 nursery.start_soon(read_big)
                 await read_ev.wait()
                 read_cs.cancel()
-                with move_on_after(0.001):
+                with move_on_after(0.01):
                     async with read_lock:
                         result = await r.receive()
                 nursery.cancel_scope.cancel()

--- a/trio/tests/test_windows_pipes.py
+++ b/trio/tests/test_windows_pipes.py
@@ -103,6 +103,11 @@ async def test_closed_resource_error():
 
     send_channel, receive_channel = await make_pipe_channel()
 
+    with pytest.raises(_core.ClosedResourceError):
+        async with _core.open_nursery() as nursery:
+            nursery.start_soon(receive_channel.receive)
+            await wait_all_tasks_blocked(0.01)
+            await receive_channel.aclose()
     await send_channel.aclose()
     with pytest.raises(_core.ClosedResourceError):
         await send_channel.send(b"Hello")

--- a/trio/tests/test_windows_pipes.py
+++ b/trio/tests/test_windows_pipes.py
@@ -137,9 +137,9 @@ async def test_pipe_streams_combined():
 
             assert total_received == count * replicas
 
-    async with _core.open_nursery() as n:
-        n.start_soon(sender)
-        n.start_soon(reader)
+    async with _core.open_nursery() as nursery:
+        nursery.start_soon(sender)
+        nursery.start_soon(reader)
 
 
 async def test_pipe_channels_combined():
@@ -162,9 +162,9 @@ async def test_pipe_channels_combined():
 
             assert total_received == count * replicas
 
-    async with _core.open_nursery() as n:
-        n.start_soon(sender)
-        n.start_soon(reader)
+    async with _core.open_nursery() as nursery:
+        nursery.start_soon(sender)
+        nursery.start_soon(reader)
 
 
 async def test_async_with_stream():


### PR DESCRIPTION
Relevant to #1773, #1767, #824. Maybe even #959 and #1208?

This PR leverages Windows message-oriented pipes to create objects of type `Channel[Bytes]` (according to the current state of #1208), supplementing the existing `Stream`/`Channel[Byte]` classes. This came about as I was trying to find a way to asyncify `multiprocessing.connection.Pipe` for #1781, however the implementation stands totally separate from that. The internals of `Pipe` are *very* similar to `asyncio.windows_utils.pipe` except that the underlying objects are message-oriented rather than byte-oriented, meaning senders dump a whole message to the OS, and if receivers haven't allocated a big enough buffer, they get an "error", which is really just an invitation to get the rest with another, bigger buffer.

Working towards providing an API for #824, in addition to the class constructors it might make sense to provide `make_pipe_stream` and `make_pipe_channel` from `test_windows_pipes`, since it is quite easy to get a windows pipe handle that is in the wrong state. Or possibly add some checks into the class constructors to ensure the pipe is in the right configuration with `SetNamedPipeHandleState`? Also, users will need clear instructions as to how to get one end of the pipe into a subprocess. (I personally have no idea, I've been letting `multiprocessing` do its magic.)

TODO:
- [x] Write tests
- [ ] Expose public API?
- [ ] Write docs
- [ ] Write newsfragment
