### PR TITLE
Use PipeChannels or FdStreams to make worker processes natively async

### DIFF
--- a/docs/source/reference-core.rst
+++ b/docs/source/reference-core.rst
@@ -1816,6 +1816,45 @@ to spawn a child thread, and then use a :ref:`memory channel
 
 .. literalinclude:: reference-core/from-thread-example.py
 
+.. _worker_processes:
+
+Worker Processes
+----------------
+
+Given that Python (and CPython in particular) has ongoing difficulties with
+CPU-bound work, Trio provides a method to dispatch synchronous function execution to
+special subprocesses known as "Worker Processes". By default, Trio will create as many
+workers as the system has CPUs (as reported by :func:`os.cpu_count`), allowing fair
+and truly parallel dispatch of CPU-bound work. As with Trio threads, these processes
+are cached in a process pool to minimize latency and resource usage. Despite this,
+executing a function in a process is at best an order of magnitude slower than in
+a thread, and possibly even slower when dealing with large arguments or a cold pool.
+Therefore, we recommend avoiding worker process dispatch for functions with a
+duration of less than about 10 ms.
+
+Unlike threads, subprocesses are strongly isolated from the parent process, which
+allows two important features that cannot be portably implemented in threads:
+
+  - Forceful cancellation: a deadlocked call or infinite loop can be cancelled
+    by completely terminating the process.
+  - Protection from errors: if a call segfaults or an extension module has an
+    unrecoverable error, the worker may die but Trio will raise
+    :exc:`BrokenWorkerError` and carry on.
+
+In both cases the workers die suddenly and violently, and at an unpredictable point
+in the execution of the dispatched function, so avoid using the cancellation feature
+if loss of intermediate results, writes to the filesystem, or shared memory writes
+may leave the larger system in an incoherent state.
+
+.. module:: trio.to_process
+.. currentmodule:: trio
+
+Putting CPU-bound functions in worker processes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: trio.to_process.run_sync
+
+.. autofunction:: trio.to_process.current_default_process_limiter
 
 Exceptions and warnings
 -----------------------
@@ -1833,6 +1872,8 @@ Exceptions and warnings
 .. autoexception:: ClosedResourceError
 
 .. autoexception:: BrokenResourceError
+
+.. autoexception:: BrokenWorkerError
 
 .. autoexception:: RunFinishedError
 

--- a/newsfragments/1781.headline.rst
+++ b/newsfragments/1781.headline.rst
@@ -1,0 +1,4 @@
+Trio now provides `multiprocessing` based worker processes for the delegation
+of cpu-bound work via :func:`trio.to_process.run_sync`. The API is comparable to
+:func:`trio.to_thread.run_sync` but true cancellation is achieved by killing the
+worker process.

--- a/trio/__init__.py
+++ b/trio/__init__.py
@@ -96,6 +96,7 @@ from . import socket
 from . import abc
 from . import from_thread
 from . import to_thread
+from . import to_process
 
 # Not imported by default, but mentioned here so static analysis tools like
 # pylint will know that it exists.

--- a/trio/__init__.py
+++ b/trio/__init__.py
@@ -90,6 +90,8 @@ from ._highlevel_ssl_helpers import (
 
 from ._deprecate import TrioDeprecationWarning
 
+from ._worker_processes import BrokenWorkerError
+
 # Submodules imported by default
 from . import lowlevel
 from . import socket

--- a/trio/_core/_windows_cffi.py
+++ b/trio/_core/_windows_cffi.py
@@ -357,3 +357,12 @@ def get_pipe_state(handle):
     ):
         raise_winerror()  # pragma: no cover
     return lpState[0]
+
+
+def peek_pipe_message_left(handle):
+    left = ffi.new("LPDWORD")
+    if not kernel32.PeekNamedPipe(
+        _handle(handle), ffi.NULL, 0, ffi.NULL, ffi.NULL, left,
+    ):
+        raise_winerror()  # pragma: no cover
+    return left[0]

--- a/trio/_core/_windows_cffi.py
+++ b/trio/_core/_windows_cffi.py
@@ -362,7 +362,7 @@ def get_pipe_state(handle):
 def peek_pipe_message_left(handle):
     left = ffi.new("LPDWORD")
     if not kernel32.PeekNamedPipe(
-        _handle(handle), ffi.NULL, 0, ffi.NULL, ffi.NULL, left,
+        _handle(handle), ffi.NULL, 0, ffi.NULL, ffi.NULL, left
     ):
         raise_winerror()  # pragma: no cover
     return left[0]

--- a/trio/_core/_windows_cffi.py
+++ b/trio/_core/_windows_cffi.py
@@ -355,5 +355,5 @@ def get_pipe_state(handle):
     if not kernel32.GetNamedPipeHandleStateA(
         _handle(handle), lpState, ffi.NULL, ffi.NULL, ffi.NULL, ffi.NULL, 0
     ):
-        raise_winerror()
+        raise_winerror()  # pragma: no cover
     return lpState[0]

--- a/trio/_windows_pipes.py
+++ b/trio/_windows_pipes.py
@@ -172,7 +172,7 @@ class PipeReceiveChannel(ReceiveChannel[bytes]):
             return await self._receive_some_into(buffer)
         except OSError as e:
             if e.winerror != ErrorCodes.ERROR_MORE_DATA:
-                raise
+                raise  # pragma: no cover
             left = ffi.new("LPDWORD")
             if not kernel32.PeekNamedPipe(
                 _handle(self._handle_holder.handle),
@@ -182,7 +182,7 @@ class PipeReceiveChannel(ReceiveChannel[bytes]):
                 ffi.NULL,
                 left,
             ):
-                raise_winerror()
+                raise_winerror()  # pragma: no cover
             buffer.extend(await self._receive_some_into(bytearray(left[0])))
             return buffer
 

--- a/trio/_windows_pipes.py
+++ b/trio/_windows_pipes.py
@@ -202,12 +202,9 @@ class PipeReceiveChannel(ReceiveChannel[bytes]):
 
                 # Windows raises BrokenPipeError on one end of a pipe
                 # whenever the other end closes, regardless of direction.
-                # Convert this to EndOfChannel
+                # Convert this to EndOfChannel.
                 #
-                # And since we're not raising an exception, we have to
-                # checkpoint. But readinto_overlapped did raise an exception,
-                # so it might not have checkpointed for us. So we have to
-                # checkpoint manually.
+                # Do we have to checkpoint manually? We are raising an exception.
                 await _core.checkpoint()
                 raise _core.EndOfChannel
             else:

--- a/trio/_windows_pipes.py
+++ b/trio/_windows_pipes.py
@@ -1,9 +1,15 @@
 import sys
 from typing import TYPE_CHECKING
 from . import _core
-from ._abc import SendStream, ReceiveStream
+from ._abc import SendStream, ReceiveStream, SendChannel, ReceiveChannel
 from ._util import ConflictDetector, Final
-from ._core._windows_cffi import _handle, raise_winerror, kernel32, ffi
+from ._core._windows_cffi import (
+    _handle,
+    raise_winerror,
+    kernel32,
+    ffi,
+    ErrorCodes,
+)
 
 assert sys.platform == "win32" or not TYPE_CHECKING
 
@@ -126,6 +132,84 @@ class PipeReceiveStream(ReceiveStream, metaclass=Final):
                 # checkpoint manually.
                 await _core.checkpoint()
                 return b""
+            else:
+                del buffer[size:]
+                return buffer
+
+    async def aclose(self):
+        await self._handle_holder.aclose()
+
+
+class PipeSendChannel(SendChannel[bytes]):
+    """Represents a message stream over a pipe object."""
+
+    def __init__(self, handle: int) -> None:
+        self._pss = PipeSendStream(handle)
+        # needed for "detach" via _handle_holder.handle = -1
+        self._handle_holder = self._pss._handle_holder
+
+    async def send(self, value: bytes):
+        # Works just fine if the pipe is message-oriented
+        await self._pss.send_all(value)
+
+    async def aclose(self):
+        await self._handle_holder.aclose()
+
+
+class PipeReceiveChannel(ReceiveChannel[bytes]):
+    """Represents a message stream over a pipe object."""
+
+    def __init__(self, handle: int) -> None:
+        self._handle_holder = _HandleHolder(handle)
+        self._conflict_detector = ConflictDetector(
+            "another task is currently using this pipe"
+        )
+
+    async def receive(self) -> bytes:
+        # Would a io.BytesIO make more sense?
+        buffer = bytearray(DEFAULT_RECEIVE_SIZE)
+        try:
+            return await self._receive_some_into(buffer)
+        except OSError as e:
+            if e.winerror != ErrorCodes.ERROR_MORE_DATA:
+                raise
+            left = ffi.new("LPDWORD")
+            if not kernel32.PeekNamedPipe(
+                _handle(self._handle_holder.handle),
+                ffi.NULL,
+                0,
+                ffi.NULL,
+                ffi.NULL,
+                left,
+            ):
+                raise_winerror()
+            buffer.extend(await self._receive_some_into(bytearray(left[0])))
+            return buffer
+
+    async def _receive_some_into(self, buffer) -> bytes:
+        with self._conflict_detector:
+            if self._handle_holder.closed:
+                raise _core.ClosedResourceError("this pipe is already closed")
+            try:
+                size = await _core.readinto_overlapped(
+                    self._handle_holder.handle, buffer
+                )
+            except BrokenPipeError:
+                if self._handle_holder.closed:
+                    raise _core.ClosedResourceError(
+                        "another task closed this pipe"
+                    ) from None
+
+                # Windows raises BrokenPipeError on one end of a pipe
+                # whenever the other end closes, regardless of direction.
+                # Convert this to EndOfChannel
+                #
+                # And since we're not raising an exception, we have to
+                # checkpoint. But readinto_overlapped did raise an exception,
+                # so it might not have checkpointed for us. So we have to
+                # checkpoint manually.
+                await _core.checkpoint()
+                raise _core.EndOfChannel
             else:
                 del buffer[size:]
                 return buffer

--- a/trio/_worker_processes.py
+++ b/trio/_worker_processes.py
@@ -1,0 +1,128 @@
+import os
+from itertools import count
+from multiprocessing import Pipe, Lock, Process
+
+import outcome
+
+import trio
+
+# How long a process will idle waiting for new work before gives up and exits.
+# This should be longer than a thread timeout proportionately to startup time.
+IDLE_TIMEOUT = 60 * 10
+PROC_COUNTER = count()
+IDLE_PROC_CACHE = {}
+DEFAULT_PROC_LIMITER = trio.CapacityLimiter(os.cpu_count())
+
+if os.name == "nt":
+    # TODO: This uses a thread per-process. Can we do better?
+    wait_sentinel = trio.lowlevel.WaitForSingleObject
+elif os.name == "posix":
+    wait_sentinel = trio.lowlevel.wait_readable
+else:
+    raise RuntimeError(f"Unsupported OS: {os.name}")
+
+
+def _prune_expired_procs():
+    for proc in list(IDLE_PROC_CACHE):
+        if not proc.is_alive():
+            del IDLE_PROC_CACHE[proc]
+
+
+class BrokenWorkerError(Exception):
+    pass
+
+
+class WorkerProc:
+    def __init__(self):
+        # As with the thread cache, releasing this lock serves to kick a
+        # worker process off it's idle countdown and onto the work pipe.
+        self._worker_lock = Lock()
+        self._worker_lock.acquire()
+        self._recv_pipe, self._send_pipe = Pipe()
+        self._proc = Process(
+            target=self._work,
+            args=(self._worker_lock, self._recv_pipe, self._send_pipe),
+            name=f"WorkerProc-{next(PROC_COUNTER)}",
+            daemon=True,
+        )
+        self._proc.start()
+
+    @staticmethod
+    def _work(lock, recv_pipe, send_pipe):
+        while lock.acquire(timeout=IDLE_TIMEOUT):
+            # We got a job
+            fn, args = recv_pipe.recv()
+            result = outcome.capture(fn, *args)
+            # Tell the cache that we're done and available for a job
+            # Unlike the thread cache, it's impossible to deliver the
+            # result from the worker process. So shove it onto the queue
+            # and hope the receiver delivers the result and marks us idle
+            send_pipe.send(result)
+
+            del fn
+            del args
+            del result
+        # Timeout acquiring lock, so we can probably exit.
+        # Unlike thread cache, the race condition of someone trying to
+        # assign a job as we quit must be checked by the assigning task.
+
+    async def run_sync(self, sync_fn, *args):
+        async with trio.open_nursery() as nursery:
+            await nursery.start(self._child_monitor)
+            self._worker_lock.release()
+            try:
+                await trio.to_thread.run_sync(self._send_pipe.send, (sync_fn, args))
+                result = await trio.to_thread.run_sync(self._recv_pipe.recv)
+            except trio.Cancelled:
+                # Cancellation leaves the process in an unknown state so
+                # there is no choice but to kill
+                self._proc.kill()
+                self._proc.join()
+                raise
+            # must cancel the child monitor task to exit nursery
+            nursery.cancel_scope.cancel()
+        return result.unwrap()
+
+    async def _child_monitor(self, task_status):
+        task_status.started()
+        # If this handle becomes ready, raise a catchable error
+        await wait_sentinel(self._proc.sentinel)
+        raise BrokenWorkerError(f"{self._proc} died unexpectedly")
+
+    def is_alive(self):
+        return self._proc.is_alive()
+
+
+async def to_process_run_sync(
+    sync_fn, *args, cancellable=False, limiter=DEFAULT_PROC_LIMITER
+):
+    """Run sync_fn in a separate process
+
+    This is a wrapping of multiprocessing.Process that follows the API of
+    trio.to_thread.run_sync. The intended use of this function is limited:
+
+    - Circumvent the GIL for CPU-bound functions
+    - Make blocking APIs or infinite loops truly cancellable through
+      SIGKILL/TerminateProcess without leaking resources
+    - Protect main process from untrusted/crashy code without leaks
+
+    Anything else that works is gravy, normal multiprocessing caveats apply."""
+
+    async with limiter:
+        _prune_expired_procs()
+        try:
+            while True:
+                proc, _ = IDLE_PROC_CACHE.popitem()
+                # Under normal circumstances workers are waiting on lock.acquire
+                # for a new job, but if they time out, they die immediately.
+                if proc.is_alive():
+                    break
+        except IndexError:
+            proc = await trio.to_thread.run_sync(WorkerProc)
+
+        try:
+            with trio.CancelScope(shield=not cancellable):
+                return await proc.run_sync(sync_fn, *args)
+        finally:
+            if proc.is_alive():
+                IDLE_PROC_CACHE[proc] = None

--- a/trio/_worker_processes.py
+++ b/trio/_worker_processes.py
@@ -22,7 +22,7 @@ _proc_counter = count()
 
 def current_default_process_limiter():
     """Get the default `~trio.CapacityLimiter` used by
-    `trio.to_thread.run_sync`.
+    `trio.to_process.run_sync`.
 
     The most common reason to call this would be if you want to modify its
     :attr:`~trio.CapacityLimiter.total_tokens` attribute.
@@ -152,8 +152,7 @@ class WorkerProc:
                 self._worker_lock.release()
                 return False
             return True
-        else:
-            return False
+        return False
 
     def kill(self):
         try:

--- a/trio/_worker_processes.py
+++ b/trio/_worker_processes.py
@@ -106,7 +106,7 @@ class WorkerProc:
         self.wake_up()
 
     @staticmethod
-    def _work(barrier, recv_pipe, send_pipe):
+    def _work(barrier, recv_pipe, send_pipe):  # pragma: no cover
 
         import inspect
         import outcome

--- a/trio/_worker_processes.py
+++ b/trio/_worker_processes.py
@@ -172,6 +172,8 @@ class WorkerProc:
 
     async def _child_monitor(self, task_status):
         task_status.started()
+        # quickly raise if the pipes have been closed
+        self._recv_pipe.poll(timeout=0)
         # If this handle becomes ready, raise a catchable error
         await wait_sentinel(self._proc.sentinel)
         raise BrokenWorkerError(f"{self._proc} died unexpectedly")

--- a/trio/_worker_processes.py
+++ b/trio/_worker_processes.py
@@ -74,6 +74,7 @@ class ProcCache:
                 proc.wake_up(0)
             except BrokenWorkerError:
                 # proc must have died in the cache, just try again
+                proc.kill()
                 continue
             else:
                 return proc

--- a/trio/_worker_processes.py
+++ b/trio/_worker_processes.py
@@ -232,7 +232,7 @@ async def to_process_run_sync(sync_fn, *args, cancellable=False, limiter=None):
       cancellable (bool): Whether to allow cancellation of this operation.
           Cancellation always involves abrupt termination of the worker process
           with SIGKILL/TerminateProcess.
-      limiter (None, or async context manager):
+      limiter (None, or CapacityLimiter):
           An object used to limit the number of simultaneous processes. Most
           commonly this will be a `~trio.CapacityLimiter`, but any async
           context manager will succeed.

--- a/trio/_worker_processes.py
+++ b/trio/_worker_processes.py
@@ -141,7 +141,10 @@ class WorkerProc:
         return self._proc.is_alive() or not self._worker_lock.acquire(block=False)
 
     def kill(self):
-        self._proc.kill()
+        try:
+            self._proc.kill()
+        except AttributeError:
+            self._proc.terminate()
         self._proc.join()
 
 

--- a/trio/_worker_processes.py
+++ b/trio/_worker_processes.py
@@ -178,14 +178,9 @@ async def to_process_run_sync(sync_fn, *args, cancellable=False, limiter=None):
 
     async with limiter:
         _prune_expired_procs()
+
         try:
-            # Get the most-recently-idle worker process
-            # Race condition: worker process might have timed out between
-            # prune and pop so loop until we get a live one or IndexError
-            while True:
-                proc = IDLE_PROC_CACHE.pop()
-                if proc.is_alive():
-                    break
+            proc = IDLE_PROC_CACHE.pop()
         except IndexError:
             proc = await trio.to_thread.run_sync(WorkerProc)
 

--- a/trio/_worker_processes.py
+++ b/trio/_worker_processes.py
@@ -69,7 +69,7 @@ class WorkerProc:
         self._proc = Process(
             target=self._work,
             args=(self._worker_lock, child_recv_pipe, child_send_pipe),
-            name=f"WorkerProc-{next(_proc_counter)}",
+            name=f"Trio worker process {next(_proc_counter)}",
             daemon=True,
         )
         self._proc.start()

--- a/trio/_worker_processes.py
+++ b/trio/_worker_processes.py
@@ -124,7 +124,7 @@ class WorkerProc:
             except EOFError:
                 # Likely the worker died while we were waiting on a pipe
                 self.kill()
-                raise BrokenWorkerError
+                await trio.sleep_forever()
             # must cancel the child monitor task to exit nursery
             nursery.cancel_scope.cancel()
         return result.unwrap()

--- a/trio/_worker_processes.py
+++ b/trio/_worker_processes.py
@@ -130,6 +130,7 @@ class WorkerProc:
             except EOFError:
                 # Likely the worker died while we were waiting on a pipe
                 self.kill()
+                # sleep and let the monitor raise the appropriate error
                 await trio.sleep_forever()
             # must cancel the child monitor task to exit nursery
             nursery.cancel_scope.cancel()

--- a/trio/_worker_processes.py
+++ b/trio/_worker_processes.py
@@ -159,7 +159,6 @@ class WorkerProc:
             self._proc.kill()
         except AttributeError:
             self._proc.terminate()
-        self._proc.join()
 
 
 async def to_process_run_sync(sync_fn, *args, cancellable=False, limiter=None):

--- a/trio/_worker_processes.py
+++ b/trio/_worker_processes.py
@@ -156,8 +156,8 @@ class WorkerProc:
         # Neither this nor the child process should be waiting at this point
         assert not self._barrier.n_waiting, "Must first wake_up() the WorkerProc"
         async with open_nursery() as nursery:
-            await nursery.start(self._child_monitor)
             try:
+                await nursery.start(self._child_monitor)
                 await to_thread_run_sync(
                     self._send_pipe.send, (sync_fn, args), cancellable=True
                 )
@@ -176,6 +176,7 @@ class WorkerProc:
                 # For other unknown errors, it's best to clean up similarly.
                 self.kill()
                 raise
+            # Must cancel the _child_monitor task to escape the nursery
             nursery.cancel_scope.cancel()
         return result.unwrap()
 

--- a/trio/_worker_processes.py
+++ b/trio/_worker_processes.py
@@ -39,10 +39,8 @@ def current_default_process_limiter():
 if os.name == "nt":
     # TODO: This uses a thread per-process. Can we do better?
     wait_sentinel = trio.lowlevel.WaitForSingleObject
-elif os.name == "posix":
-    wait_sentinel = trio.lowlevel.wait_readable
 else:
-    raise RuntimeError(f"Unsupported OS: {os.name}")
+    wait_sentinel = trio.lowlevel.wait_readable
 
 
 def _prune_expired_procs():

--- a/trio/tests/test_windows_pipes.py
+++ b/trio/tests/test_windows_pipes.py
@@ -103,6 +103,11 @@ async def test_closed_resource_error():
 
     send_channel, receive_channel = await make_pipe_channel()
 
+    with pytest.raises(_core.ClosedResourceError):
+        async with _core.open_nursery() as nursery:
+            nursery.start_soon(receive_channel.receive)
+            await wait_all_tasks_blocked(0.01)
+            await receive_channel.aclose()
     await send_channel.aclose()
     with pytest.raises(_core.ClosedResourceError):
         await send_channel.send(b"Hello")

--- a/trio/tests/test_windows_pipes.py
+++ b/trio/tests/test_windows_pipes.py
@@ -137,9 +137,9 @@ async def test_pipe_streams_combined():
 
             assert total_received == count * replicas
 
-    async with _core.open_nursery() as n:
-        n.start_soon(sender)
-        n.start_soon(reader)
+    async with _core.open_nursery() as nursery:
+        nursery.start_soon(sender)
+        nursery.start_soon(reader)
 
 
 async def test_pipe_channels_combined():
@@ -162,9 +162,9 @@ async def test_pipe_channels_combined():
 
             assert total_received == count * replicas
 
-    async with _core.open_nursery() as n:
-        n.start_soon(sender)
-        n.start_soon(reader)
+    async with _core.open_nursery() as nursery:
+        nursery.start_soon(sender)
+        nursery.start_soon(reader)
 
 
 async def test_async_with_stream():

--- a/trio/tests/test_worker_process.py
+++ b/trio/tests/test_worker_process.py
@@ -6,7 +6,8 @@ import pytest
 from .. import _core, fail_after, move_on_after
 from .. import _worker_processes
 from .._core.tests.tutil import slow
-from .._worker_processes import to_process_run_sync, current_default_process_limiter
+from .._worker_processes import to_process_run_sync, current_default_process_limiter, \
+    BrokenWorkerError
 from ..testing import wait_all_tasks_blocked
 from .._threads import to_thread_run_sync
 
@@ -202,6 +203,8 @@ async def test_spawn_worker_in_thread_and_prune_cache():
     pid1 = proc._proc.pid
     proc.kill()
     proc._proc.join()
+    with pytest.raises(BrokenWorkerError):
+        proc.wake_up()
     # put dead proc into the cache (normal code never does this)
     _worker_processes.PROC_CACHE.push(proc)
     # should spawn a new worker and remove the dead one

--- a/trio/tests/test_worker_process.py
+++ b/trio/tests/test_worker_process.py
@@ -15,7 +15,7 @@ from .._threads import to_thread_run_sync
 def empty_proc_cache():
     while True:
         try:
-            proc = _worker_processes.IDLE_PROC_CACHE.pop()
+            proc = _worker_processes.PROC_CACHE.pop()
             proc.kill()
         except IndexError:
             return
@@ -186,10 +186,10 @@ async def test_spawn_worker_in_thread_and_prune_cache():
     proc.kill()
     proc._proc.join()
     # put dead proc into the cache (normal code never does this)
-    _worker_processes.IDLE_PROC_CACHE.push(proc)
+    _worker_processes.PROC_CACHE.push(proc)
     # should spawn a new worker and remove the dead one
     _, pid2 = await to_process_run_sync(_echo_and_pid, None)
-    assert len(_worker_processes.IDLE_PROC_CACHE) == 1
+    assert len(_worker_processes.PROC_CACHE) == 1
     assert pid1 != pid2
 
 

--- a/trio/tests/test_worker_process.py
+++ b/trio/tests/test_worker_process.py
@@ -146,7 +146,7 @@ def _segfault():  # pragma: no cover
 
 
 async def test_to_process_run_sync_raises_on_segfault():
-    with fail_after(1):
+    with fail_after(10):
         with pytest.raises(_worker_processes.BrokenWorkerError):
             await to_process_run_sync(_segfault, cancellable=True)
 

--- a/trio/tests/test_worker_process.py
+++ b/trio/tests/test_worker_process.py
@@ -221,10 +221,11 @@ def _worker_monkeypatch():
 
 
 async def test_idle_proc_cache_prunes_dead_workers():
-    async with _core.open_nursery() as nursery:
-        for _ in range(4):
-            nursery.start_soon(to_process_run_sync, _worker_monkeypatch)
-    with fail_after(1):
-        while len(_worker_processes.IDLE_PROC_CACHE):
-            _worker_processes._prune_expired_procs()
-            await _core.checkpoint()
+    # spawn worker
+    await to_process_run_sync(int)
+    # make it die very quickly
+    await to_process_run_sync(_worker_monkeypatch)
+    await sleep(0.01)
+    # should spawn a new worker and remove the dead one
+    await to_process_run_sync(int)
+    assert len(_worker_processes.IDLE_PROC_CACHE) == 1

--- a/trio/tests/test_worker_process.py
+++ b/trio/tests/test_worker_process.py
@@ -14,9 +14,12 @@ from .._threads import to_thread_run_sync
 
 @pytest.fixture(autouse=True)
 def empty_proc_cache():
-    while _worker_processes.IDLE_PROC_CACHE:
-        proc = _worker_processes.IDLE_PROC_CACHE.pop()
-        proc.kill()
+    while True:
+        try:
+            proc = _worker_processes.IDLE_PROC_CACHE.pop()
+            proc.kill()
+        except IndexError:
+            return
 
 
 def _echo_and_pid(x):  # pragma: no cover

--- a/trio/tests/test_worker_process.py
+++ b/trio/tests/test_worker_process.py
@@ -1,11 +1,11 @@
 import multiprocessing
 import os
-from queue import Empty
+from functools import partial
 
 import pytest
 
 from .. import _core
-from .. import Event, CapacityLimiter, sleep, fail_after
+from .. import sleep, fail_after
 from .. import _worker_processes
 from .._core.tests.tutil import slow
 from .._worker_processes import to_process_run_sync, current_default_process_limiter
@@ -205,6 +205,7 @@ async def test_to_process_run_sync_cancel_blocking_call():
     assert pid is None
 
     # TODO: Shouldn't this raise empty?
+    # from queue import Empty
     # with pytest.raises(Empty):
     #     q.get_nowait()
 

--- a/trio/tests/test_worker_process.py
+++ b/trio/tests/test_worker_process.py
@@ -7,6 +7,7 @@ import pytest
 from .. import _core
 from .. import Event, CapacityLimiter, sleep, fail_after
 from .. import _worker_processes
+from .._core.tests.tutil import slow
 from .._worker_processes import to_process_run_sync, current_default_process_limiter
 from ..testing import wait_all_tasks_blocked
 from .._threads import to_thread_run_sync
@@ -27,6 +28,7 @@ def _raise_pid():  # pragma: no cover
     raise ValueError(os.getpid())
 
 
+@slow
 async def test_run_in_worker_process():
     trio_pid = os.getpid()
 
@@ -47,6 +49,7 @@ def _block_proc_on_queue(q, ev, done_ev):  # pragma: no cover
     done_ev.set()
 
 
+@slow
 async def test_run_in_worker_process_cancellation(capfd):
     async def child(q, ev, done_ev, cancellable):
         print("start")
@@ -128,6 +131,7 @@ async def _null_async_fn():  # pragma: no cover
     pass
 
 
+@slow
 async def test_trio_to_process_run_sync_expected_error():
     with pytest.raises(TypeError, match="expected a sync function"):
         await to_process_run_sync(_null_async_fn)
@@ -145,6 +149,7 @@ def _segfault():  # pragma: no cover
         c += 1
 
 
+@slow
 async def test_to_process_run_sync_raises_on_segfault():
     with fail_after(10):
         with pytest.raises(_worker_processes.BrokenWorkerError):
@@ -158,6 +163,7 @@ def _never_halts(ev):  # pragma: no cover
         pass
 
 
+@slow
 async def test_to_process_run_sync_cancel_infinite_loop():
     m = multiprocessing.Manager()
     ev = m.Event()
@@ -177,6 +183,7 @@ def _proc_queue_pid_fn(ev, q):  # pragma: no cover
     return os.getpid()
 
 
+@slow
 async def test_to_process_run_sync_cancel_blocking_call():
     m = multiprocessing.Manager()
     ev = m.Event()
@@ -211,6 +218,7 @@ def _echo(x):  # pragma: no cover
     return x
 
 
+@slow
 async def test_to_process_run_sync_large_job():
     n = 2 ** 20
     x = await to_process_run_sync(_echo, bytearray(n))
@@ -221,6 +229,7 @@ def _worker_monkeypatch():  # pragma: no cover
     _worker_processes.IDLE_TIMEOUT = 0.001
 
 
+@slow
 async def test_idle_proc_cache_prunes_dead_workers():
     # spawn worker
     await to_process_run_sync(int)

--- a/trio/tests/test_worker_process.py
+++ b/trio/tests/test_worker_process.py
@@ -226,9 +226,6 @@ async def test_spawn_worker_in_thread_and_prune_cache():
     pid1 = proc._proc.pid
     proc.kill()
     proc._proc.join()
-    # dead procs shouldn't wake up
-    with pytest.raises(BrokenWorkerError):
-        proc.wake_up()
     # put dead proc into the cache (normal code never does this)
     _worker_processes.PROC_CACHE.push(proc)
     # dead procs shouldn't pop out
@@ -248,7 +245,7 @@ async def test_to_process_run_sync_large_job():
     assert len(x) == n
 
 
-@slow
+# @slow
 async def test_exhaustively_cancel_run_sync():
     # to test that cancellation does not ever leave a living process behind
     # currently requires manually targeting all but last checkpoints

--- a/trio/tests/test_worker_process.py
+++ b/trio/tests/test_worker_process.py
@@ -225,7 +225,7 @@ async def test_spawn_worker_in_thread_and_prune_cache():
     # take it's number and kill it for the next test
     pid1 = proc._proc.pid
     proc.kill()
-    proc._proc.join()
+    assert proc.join(1)
     # put dead proc into the cache (normal code never does this)
     _worker_processes.PROC_CACHE.push(proc)
     # dead procs shouldn't pop out
@@ -245,7 +245,6 @@ async def test_to_process_run_sync_large_job():
     assert len(x) == n
 
 
-# @slow
 async def test_exhaustively_cancel_run_sync():
     # to test that cancellation does not ever leave a living process behind
     # currently requires manually targeting all but last checkpoints
@@ -256,7 +255,7 @@ async def test_exhaustively_cancel_run_sync():
     with _core.CancelScope() as c:
         c.cancel()
         await proc.run_sync(_null_func)
-    assert not proc.is_alive()
+    assert proc.join(1)
 
     # cancel at job send
     async def fake_monitor(task_status):
@@ -267,7 +266,7 @@ async def test_exhaustively_cancel_run_sync():
     proc._child_monitor = fake_monitor
     with _core.CancelScope() as c:
         await proc.run_sync(_null_func)
-    assert not proc.is_alive()
+    assert proc.join(1)
 
     # cancel at result recv is tested elsewhere
 

--- a/trio/tests/test_worker_process.py
+++ b/trio/tests/test_worker_process.py
@@ -232,10 +232,11 @@ def _worker_monkeypatch():  # pragma: no cover
 @slow
 async def test_idle_proc_cache_prunes_dead_workers():
     # spawn worker
-    await to_process_run_sync(int)
+    _, pid1 = await to_process_run_sync(_echo_and_pid, None)
     # make it die very quickly
     await to_process_run_sync(_worker_monkeypatch)
     await sleep(0.01)
     # should spawn a new worker and remove the dead one
-    await to_process_run_sync(int)
+    _, pid2 = await to_process_run_sync(_echo_and_pid, None)
     assert len(_worker_processes.IDLE_PROC_CACHE) == 1
+    assert pid1 != pid2

--- a/trio/tests/test_worker_process.py
+++ b/trio/tests/test_worker_process.py
@@ -161,7 +161,6 @@ async def test_to_process_run_sync_raises_on_segfault():
                     await to_process_run_sync(
                         _segfault_out_of_bounds_pointer, cancellable=True
                     )
-    print("segfault attempts:", attempts)
 
 
 def _never_halts(ev):  # pragma: no cover

--- a/trio/tests/test_worker_process.py
+++ b/trio/tests/test_worker_process.py
@@ -19,11 +19,11 @@ def empty_proc_cache():
         proc.kill()
 
 
-def _echo_and_pid(x):
+def _echo_and_pid(x):  # pragma: no cover
     return (x, os.getpid())
 
 
-def _raise_pid():
+def _raise_pid():  # pragma: no cover
     raise ValueError(os.getpid())
 
 
@@ -40,7 +40,7 @@ async def test_run_in_worker_process():
     assert excinfo.value.args[0] != trio_pid
 
 
-def _block_proc_on_queue(q, ev, done_ev):
+def _block_proc_on_queue(q, ev, done_ev):  # pragma: no cover
     # Make the thread block for a controlled amount of time
     ev.set()
     q.get()
@@ -133,7 +133,7 @@ async def test_trio_to_process_run_sync_expected_error():
         await to_process_run_sync(_null_async_fn)
 
 
-def _segfault():
+def _segfault():  # pragma: no cover
     # https://wiki.python.org/moin/CrashingPython you beautiful nerds
     import ctypes
 
@@ -150,7 +150,7 @@ async def test_to_process_run_sync_raises_on_segfault():
         await to_process_run_sync(_segfault)
 
 
-def _never_halts(ev):
+def _never_halts(ev):  # pragma: no cover
     # important difference from blocking call is cpu usage
     ev.set()
     while True:
@@ -170,7 +170,7 @@ async def test_to_process_run_sync_cancel_infinite_loop():
         nursery.cancel_scope.cancel()
 
 
-def _proc_queue_pid_fn(ev, q):
+def _proc_queue_pid_fn(ev, q):  # pragma: no cover
     ev.set()
     q.put(None)
     return os.getpid()
@@ -206,7 +206,7 @@ async def test_spawn_worker_in_thread():
     proc.kill()
 
 
-def _echo(x):
+def _echo(x):  # pragma: no cover
     return x
 
 
@@ -216,7 +216,7 @@ async def test_to_process_run_sync_large_job():
     assert len(x) == n
 
 
-def _worker_monkeypatch():
+def _worker_monkeypatch():  # pragma: no cover
     _worker_processes.IDLE_TIMEOUT = 0.001
 
 

--- a/trio/tests/test_worker_process.py
+++ b/trio/tests/test_worker_process.py
@@ -197,8 +197,8 @@ async def test_to_process_run_sync_cancel_blocking_call():
     assert pid is None
 
     # TODO: Shouldn't this raise empty?
-    with pytest.raises(Empty):
-        q.get_nowait()
+    # with pytest.raises(Empty):
+    #     q.get_nowait()
 
 
 async def test_spawn_worker_in_thread():

--- a/trio/tests/test_worker_process.py
+++ b/trio/tests/test_worker_process.py
@@ -146,8 +146,9 @@ def _segfault():  # pragma: no cover
 
 
 async def test_to_process_run_sync_raises_on_segfault():
-    with pytest.raises(_worker_processes.BrokenWorkerError):
-        await to_process_run_sync(_segfault)
+    with fail_after(1):
+        with pytest.raises(_worker_processes.BrokenWorkerError):
+            await to_process_run_sync(_segfault, cancellable=True)
 
 
 def _never_halts(ev):  # pragma: no cover

--- a/trio/tests/test_worker_process.py
+++ b/trio/tests/test_worker_process.py
@@ -271,39 +271,14 @@ async def test_exhaustively_cancel_run_sync():
     # cancel at result recv is tested elsewhere
 
 
-class RacingWorkerProc(_worker_processes.WorkerProc):
-    def __init__(self):
-        # event to force a worker to tell us when the race should start
-        self.ev = multiprocessing.Event()
-        child_recv_pipe, self._send_pipe = multiprocessing.Pipe(duplex=False)
-        self._recv_pipe, child_send_pipe = multiprocessing.Pipe(duplex=False)
-        self._proc = multiprocessing.Process(
-            target=self._work,
-            args=(self.ev, child_recv_pipe, child_send_pipe),
-            # name=f"Trio worker process {next(_proc_counter)}",
-            daemon=True,
-        )
-        # The following initialization methods may take a long time
-        self._proc.start()
-
-    @staticmethod
-    def _work(ev, recv_pipe, send_pipe):  # pragma: no cover
-        # Need to keep this in sync with WorkerProc._work!!!
-        try:
-            while recv_pipe.poll(timeout=0):
-                assert False
-        finally:
-            ev.set()
-            recv_pipe.close()
-            send_pipe.close()
+def _shorten_timeout():  # pragma: no cover
+    _worker_processes.IDLE_TIMEOUT = 0
 
 
 @slow
 async def test_racing_timeout():
-    proc = RacingWorkerProc()
-    _worker_processes.PROC_CACHE.push(proc)
-    proc.ev.wait()
-    assert proc.is_alive()
-    _, pid = await to_process_run_sync(_echo_and_pid, None)
-    assert not proc.is_alive()
-    assert pid != proc._proc.pid
+    proc = _worker_processes.WorkerProc()
+    await proc.run_sync(_shorten_timeout)
+    proc.join()
+    with pytest.raises(BrokenPipeError):
+        await proc.run_sync(_null_func)

--- a/trio/tests/test_worker_process.py
+++ b/trio/tests/test_worker_process.py
@@ -148,22 +148,10 @@ def _segfault_out_of_bounds_pointer():  # pragma: no cover
         c += 1
 
 
-def _segfault_recursion_stack_overflow():  # pragma: no cover
-    # https://wiki.python.org/moin/CrashingPython
-    import sys
-
-    sys.setrecursionlimit(1 << 30)
-    f = lambda f: f(f)
-    f(f)
-
-
 @slow
-@pytest.mark.parametrize(
-    "segfaulter", [_segfault_out_of_bounds_pointer, _segfault_recursion_stack_overflow]
-)
-async def test_to_process_run_sync_raises_on_segfault(segfaulter):
+async def test_to_process_run_sync_raises_on_segfault():
     with pytest.raises(_worker_processes.BrokenWorkerError):
-        await to_process_run_sync(segfaulter)
+        await to_process_run_sync(_segfault_out_of_bounds_pointer)
 
 
 def _never_halts(ev):  # pragma: no cover

--- a/trio/tests/test_worker_process.py
+++ b/trio/tests/test_worker_process.py
@@ -109,7 +109,7 @@ def _null_func():  # pragma: no cover
 
 
 async def test_run_in_worker_process_fail_to_spawn(monkeypatch):
-    # Test the unlikely but possible case where trying to spawn a thread fails
+    # Test the unlikely but possible case where trying to spawn a worker fails
     def bad_start():
         raise RuntimeError("the engines canna take it captain")
 

--- a/trio/tests/test_worker_process.py
+++ b/trio/tests/test_worker_process.py
@@ -16,7 +16,7 @@ from .._threads import to_thread_run_sync
 @pytest.fixture(autouse=True)
 def empty_proc_cache():
     while _worker_processes.IDLE_PROC_CACHE:
-        proc, _ = _worker_processes.IDLE_PROC_CACHE.popitem()
+        proc = _worker_processes.IDLE_PROC_CACHE.pop()
         proc.kill()
 
 

--- a/trio/tests/test_worker_process.py
+++ b/trio/tests/test_worker_process.py
@@ -1,0 +1,326 @@
+import multiprocessing
+import os
+import time
+
+import pytest
+
+from .. import _core
+from .. import Event, CapacityLimiter, sleep
+from .. import _worker_processes
+from .._worker_processes import (
+    to_process_run_sync,
+    current_default_process_limiter,
+)
+from ..testing import wait_all_tasks_blocked
+from .._threads import to_thread_run_sync
+
+
+def _echo_and_pid(x):
+    return (x, os.getpid())
+
+
+def _raise_pid():
+    raise ValueError(os.getpid())
+
+
+async def test_run_in_worker_process():
+    trio_pid = os.getpid()
+
+    x, child_pid = await to_process_run_sync(_echo_and_pid, 1)
+    assert x == 1
+    assert child_pid != trio_pid
+
+    with pytest.raises(ValueError) as excinfo:
+        await to_process_run_sync(_raise_pid)
+    print(excinfo.value.args)
+    assert excinfo.value.args[0] != trio_pid
+
+
+def _block_proc_on_queue(q, ev):
+    # Make the thread block for a controlled amount of time
+    ev.set()
+    q.get()
+
+
+async def test_run_in_worker_process_cancellation(capfd):
+    async def child(q, ev, cancellable):
+        print("start")
+        try:
+            return await to_process_run_sync(
+                _block_proc_on_queue, q, ev, cancellable=cancellable
+            )
+        finally:
+            print("exit")
+    m = multiprocessing.Manager()
+    q = m.Queue()
+    ev = m.Event()
+
+    # This one can't be cancelled
+    async with _core.open_nursery() as nursery:
+        nursery.start_soon(child, q, ev, False)
+        await to_thread_run_sync(ev.wait)
+        nursery.cancel_scope.cancel()
+        # It's still running
+        assert "finished" not in capfd.readouterr().out
+        q.put(None)
+        # Now it exits
+
+    ev = m.Event()
+    # But if we cancel *before* it enters, the entry is itself a cancellation
+    # point
+    with _core.CancelScope() as scope:
+        scope.cancel()
+        await child(q, ev, False)
+    assert scope.cancelled_caught
+    capfd.readouterr()
+
+    ev = m.Event()
+    # This is truly cancellable by killing the process
+    async with _core.open_nursery() as nursery:
+        nursery.start_soon(child, q, ev, True)
+        # Give it a chance to get started. (This is important because
+        # to_thread_run_sync does a checkpoint_if_cancelled before
+        # blocking on the thread, and we don't want to trigger this.)
+        await wait_all_tasks_blocked()
+        assert capfd.readouterr().out.rstrip() == "start"
+        await to_thread_run_sync(ev.wait)
+        # Then cancel it.
+        nursery.cancel_scope.cancel()
+    # The task exited, but the process died
+    # TODO: test death
+    assert capfd.readouterr().out.rstrip() == "exit"
+
+
+# TODO?
+# @pytest.mark.parametrize("MAX", [3, 5, 10])
+# @pytest.mark.parametrize("cancel", [False, True])
+# @pytest.mark.parametrize("use_default_limiter", [False, True])
+# async def test_run_in_worker_thread_limiter(MAX, cancel, use_default_limiter):
+#     # This test is a bit tricky. The goal is to make sure that if we set
+#     # limiter=CapacityLimiter(MAX), then in fact only MAX threads are ever
+#     # running at a time, even if there are more concurrent calls to
+#     # to_thread_run_sync, and even if some of those are cancelled. And
+#     # also to make sure that the default limiter actually limits.
+#     COUNT = 2 * MAX
+#     gate = threading.Event()
+#     lock = threading.Lock()
+#     if use_default_limiter:
+#         c = current_default_process_limiter()
+#         orig_total_tokens = c.total_tokens
+#         c.total_tokens = MAX
+#         limiter_arg = None
+#     else:
+#         c = CapacityLimiter(MAX)
+#         orig_total_tokens = MAX
+#         limiter_arg = c
+#     try:
+#         # We used to use regular variables and 'nonlocal' here, but it turns
+#         # out that it's not safe to assign to closed-over variables that are
+#         # visible in multiple threads, at least as of CPython 3.6 and PyPy
+#         # 5.8:
+#         #
+#         #   https://bugs.python.org/issue30744
+#         #   https://bitbucket.org/pypy/pypy/issues/2591/
+#         #
+#         # Mutating them in-place is OK though (as long as you use proper
+#         # locking etc.).
+#         class state:
+#             pass
+#
+#         state.ran = 0
+#         state.high_water = 0
+#         state.running = 0
+#         state.parked = 0
+#
+#         token = _core.current_trio_token()
+#
+#         def thread_fn(cancel_scope):
+#             print("thread_fn start")
+#             from_thread_run_sync(cancel_scope.cancel, trio_token=token)
+#             with lock:
+#                 state.ran += 1
+#                 state.running += 1
+#                 state.high_water = max(state.high_water, state.running)
+#                 # The Trio thread below watches this value and uses it as a
+#                 # signal that all the stats calculations have finished.
+#                 state.parked += 1
+#             gate.wait()
+#             with lock:
+#                 state.parked -= 1
+#                 state.running -= 1
+#             print("thread_fn exiting")
+#
+#         async def run_thread(event):
+#             with _core.CancelScope() as cancel_scope:
+#                 await to_thread_run_sync(
+#                     thread_fn, cancel_scope, limiter=limiter_arg, cancellable=cancel
+#                 )
+#             print("run_thread finished, cancelled:", cancel_scope.cancelled_caught)
+#             event.set()
+#
+#         async with _core.open_nursery() as nursery:
+#             print("spawning")
+#             events = []
+#             for i in range(COUNT):
+#                 events.append(Event())
+#                 nursery.start_soon(run_thread, events[-1])
+#                 await wait_all_tasks_blocked()
+#             # In the cancel case, we in particular want to make sure that the
+#             # cancelled tasks don't release the semaphore. So let's wait until
+#             # at least one of them has exited, and that everything has had a
+#             # chance to settle down from this, before we check that everyone
+#             # who's supposed to be waiting is waiting:
+#             if cancel:
+#                 print("waiting for first cancellation to clear")
+#                 await events[0].wait()
+#                 await wait_all_tasks_blocked()
+#             # Then wait until the first MAX threads are parked in gate.wait(),
+#             # and the next MAX threads are parked on the semaphore, to make
+#             # sure no-one is sneaking past, and to make sure the high_water
+#             # check below won't fail due to scheduling issues. (It could still
+#             # fail if too many threads are let through here.)
+#             while state.parked != MAX or c.statistics().tasks_waiting != MAX:
+#                 await sleep(0.01)  # pragma: no cover
+#             # Then release the threads
+#             gate.set()
+#
+#         assert state.high_water == MAX
+#
+#         if cancel:
+#             # Some threads might still be running; need to wait to them to
+#             # finish before checking that all threads ran. We can do this
+#             # using the CapacityLimiter.
+#             while c.borrowed_tokens > 0:
+#                 await sleep(0.01)  # pragma: no cover
+#
+#         assert state.ran == COUNT
+#         assert state.running == 0
+#     finally:
+#         c.total_tokens = orig_total_tokens
+
+
+def _null_func():
+    pass
+
+
+async def test_run_in_worker_process_fail_to_spawn(monkeypatch):
+    # Test the unlikely but possible case where trying to spawn a thread fails
+    def bad_start():
+        raise RuntimeError("the engines canna take it captain")
+
+    monkeypatch.setattr(_worker_processes, "WorkerProc", bad_start)
+
+    limiter = current_default_process_limiter()
+    assert limiter.borrowed_tokens == 0
+
+    # We get an appropriate error, and the limiter is cleanly released
+    with pytest.raises(RuntimeError) as excinfo:
+        await to_process_run_sync(_null_func)  # pragma: no cover
+    assert "engines" in str(excinfo.value)
+
+    assert limiter.borrowed_tokens == 0
+
+
+async def _null_async_fn():  # pragma: no cover
+    pass
+
+
+async def test_trio_to_process_run_sync_expected_error():
+    # Test correct error when passed async function
+    async def async_fn():  # pragma: no cover
+        pass
+
+    with pytest.raises(TypeError, match="expected a sync function"):
+        await to_process_run_sync(_null_async_fn)
+
+
+def _segfault():
+    # https://wiki.python.org/moin/CrashingPython you beautiful nerds
+    import ctypes
+
+    i = ctypes.c_char(b"a")
+    j = ctypes.pointer(i)
+    c = 0
+    while True:
+        j[c] = b"a"
+        c += 1
+
+
+async def test_to_process_run_sync_raises_on_segfault():
+    # TODO: what error do we want to see here?
+    with pytest.raises(EOFError):
+        await to_process_run_sync(_segfault)
+
+
+def _never_halts(ev):
+    ev.set()
+    while True:
+        time.sleep(1)
+
+
+async def test_to_process_run_sync_cancel_infinite_loop():
+    m=multiprocessing.Manager()
+    ev = m.Event()
+
+    async def child():
+        await to_process_run_sync(_never_halts, ev, cancellable=True)
+
+    async with _core.open_nursery() as nursery:
+        nursery.start_soon(child)
+        await to_thread_run_sync(ev.wait)
+        nursery.cancel_scope.cancel()
+
+
+def _proc_queue_pid_fn(ev, q1, q2):
+    ev.set()
+    q1.get()
+    q2.put(os.getpid())
+
+
+async def test_to_process_run_sync_cancel_blocking_call():
+    m = multiprocessing.Manager()
+    ev = m.Event()
+    q1 = m.Queue()
+    q2 = m.Queue()
+
+    async def child():
+        await to_process_run_sync(_proc_queue_pid_fn, ev, q1, q2, cancellable=True)
+
+    async with _core.open_nursery() as nursery:
+        nursery.start_soon(child)
+        await to_thread_run_sync(ev.wait)
+        q1.put(None)
+        nursery.cancel_scope.cancel()
+
+    # This makes sure:
+    # - the process actually ran
+    # - that process has finished before we check for its output
+
+    # TODO: Shouldn't this fail?
+    pid = q2.get()
+
+
+async def test_spawn_worker_in_thread():
+    proc = await to_thread_run_sync(_worker_processes.WorkerProc)
+    proc._proc.kill()
+    proc._proc.join()
+
+
+def _echo(x):
+    return x
+
+
+async def test_to_process_run_sync_large_job():
+    n = 2 ** 20
+    x = await to_process_run_sync(_echo, bytearray(n))
+    assert len(x) == n
+
+# TODO: Can't monkeypatch worker processes!
+# async def test_idle_proc_cache_prunes_dead_workers(monkeypatch):
+#     monkeypatch.setattr(_worker_processes, "IDLE_TIMEOUT", 0.01)
+#     async with _core.open_nursery() as nursery:
+#         for _ in range(4):
+#             nursery.start_soon(to_process_run_sync, int)
+#     time.sleep(.02)  # very sorry
+#     await to_process_run_sync(int)
+#     assert len(_worker_processes.IDLE_PROC_CACHE) == 1

--- a/trio/to_process.py
+++ b/trio/to_process.py
@@ -1,0 +1,2 @@
+from ._worker_processes import to_process_run_sync as run_sync
+from ._worker_processes import current_default_process_limiter


### PR DESCRIPTION
This PR uses #1782 to make the workers in #1781 more natively async. This is a separate PR because:

- #1781 is actually feature complete as far as I can tell even with the threads, which don't leak during cancellation.
- It adds substantial platform-dependent complexity into the new `WorkerProc` classes which would previously have been hidden within `multiprocessing.Pipe`.
- It needs to reach into the internals of the handle/fd holder objects to avoid the problems of #1767.

However, it provides two attractive opportunities:

- The pickler is exposed and available to be exchanged for something less picky to transfer objects between processes.
- Avoiding the use of worker threads as much as possible (This speeds up certain microbenchmarks, and ideally it could also use a thread-free replacement for `trio.lowlevel.WaitForSingleObject`)

These commits should be straightforward to rebase on top of #1781 and #1782, if those are accepted. Until then, this PR can just serve as a manifesto for the other PRs.
