### PR TITLE
Synchronous .close() method for memory channels

### DIFF
--- a/newsfragments/1797.feature.rst
+++ b/newsfragments/1797.feature.rst
@@ -1,0 +1,2 @@
+Add synchronous ``.close()`` methods and context manager (``with x``) support
+for `.MemorySendChannel` and `.MemoryReceiveChannel`.

--- a/trio/_channel.py
+++ b/trio/_channel.py
@@ -206,6 +206,12 @@ class MemorySendChannel(SendChannel, metaclass=NoPublicConstructor):
             raise trio.ClosedResourceError
         return MemorySendChannel._create(self._state)
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
     @enable_ki_protection
     def close(self):
         """Close this send channel object synchronously.
@@ -214,6 +220,9 @@ class MemorySendChannel(SendChannel, metaclass=NoPublicConstructor):
         Memory channels can also be closed synchronously. This has the same
         effect on the channel and other tasks using it, but `close` is not a
         trio checkpoint. This simplifies cleaning up in cancelled tasks.
+
+        Using ``with send_channel:`` will close the channel object on leaving
+        the with block.
 
         """
         if self._closed:
@@ -336,6 +345,12 @@ class MemoryReceiveChannel(ReceiveChannel, metaclass=NoPublicConstructor):
             raise trio.ClosedResourceError
         return MemoryReceiveChannel._create(self._state)
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
     @enable_ki_protection
     def close(self):
         """Close this receive channel object synchronously.
@@ -344,6 +359,9 @@ class MemoryReceiveChannel(ReceiveChannel, metaclass=NoPublicConstructor):
         Memory channels can also be closed synchronously. This has the same
         effect on the channel and other tasks using it, but `close` is not a
         trio checkpoint. This simplifies cleaning up in cancelled tasks.
+
+        Using ``with receive_channel:`` will close the channel object on
+        leaving the with block.
 
         """
         if self._closed:

--- a/trio/tests/test_channel.py
+++ b/trio/tests/test_channel.py
@@ -285,7 +285,7 @@ async def test_inf_capacity():
     s, r = open_memory_channel(float("inf"))
 
     # It's accepted, and we can send all day without blocking
-    async with s:
+    with s:
         for i in range(10):
             s.send_nowait(i)
 

--- a/trio/tests/test_channel.py
+++ b/trio/tests/test_channel.py
@@ -220,7 +220,7 @@ async def test_receive_channel_clone_and_close():
 
     s.send_nowait(None)
     await r.aclose()
-    async with r2:
+    with r2:
         pass
 
     with pytest.raises(trio.ClosedResourceError):


### PR DESCRIPTION
This is part of #719. @njsmith asked whether memory channels should have a sync `.close()` method. @oremanj , @lordmauve and myself have said that this would be useful, and no-one has argued against it (please correct me if I've overlooked it!).

My rationale: it's possible to create memory channels and send/receive using synchronous methods, so it seems odd that you need async code to close them. It also makes clean-up after cancellation more difficult, because `await chan.aclose()` will raise `Cancelled` again, so you either need to ensure nothing runs after it, or shield it as described in [Cancellation semantics](https://trio.readthedocs.io/en/stable/reference-core.html#cancellation-semantics).

I've also included synchronous context manager (`with chan:`) support, as I think that's a natural counterpart to the synchronous `.close()` method.