### PR TITLE
Avoid creating reference cycles

### DIFF
--- a/newsfragments/1770.bugfix.rst
+++ b/newsfragments/1770.bugfix.rst
@@ -1,0 +1,3 @@
+Trio now avoids creating cyclic garbage as often. This should have a
+minimal impact on most programs, but can slightly reduce how often the
+cycle collector GC runs on CPython, which can reduce latency spikes.

--- a/trio/_core/_multierror.py
+++ b/trio/_core/_multierror.py
@@ -114,6 +114,9 @@ def _filter_impl(handler, root_exc):
     preserved = set()
     new_root_exc = filter_tree(root_exc, preserved)
     push_tb_down(None, root_exc, preserved)
+    # Delete the local functions avoid a reference cycle (see
+    # test_simple_cancel_scope_usage_doesnt_create_cyclic_garbage)
+    del filter_tree, push_tb_down
     return new_root_exc
 
 
@@ -132,6 +135,7 @@ class MultiErrorCatcher:
     def __exit__(self, etype, exc, tb):
         if exc is not None:
             filtered_exc = MultiError.filter(self._handler, exc)
+
             if filtered_exc is exc:
                 # Let the interpreter re-raise it
                 return False

--- a/trio/_core/_multierror.py
+++ b/trio/_core/_multierror.py
@@ -114,7 +114,7 @@ def _filter_impl(handler, root_exc):
     preserved = set()
     new_root_exc = filter_tree(root_exc, preserved)
     push_tb_down(None, root_exc, preserved)
-    # Delete the local functions avoid a reference cycle (see
+    # Delete the local functions to avoid a reference cycle (see
     # test_simple_cancel_scope_usage_doesnt_create_cyclic_garbage)
     del filter_tree, push_tb_down
     return new_root_exc

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -937,7 +937,12 @@ class Nursery(metaclass=NoPublicConstructor):
         popped = self._parent_task._child_nurseries.pop()
         assert popped is self
         if self._pending_excs:
-            return MultiError(self._pending_excs)
+            try:
+                return MultiError(self._pending_excs)
+            finally:
+                # avoid a garbage cycle
+                # (see test_nursery_cancel_doesnt_create_cyclic_garbage)
+                del self._pending_excs
 
     def start_soon(self, async_fn, *args, name=None):
         """Creates a child task, scheduling ``await async_fn(*args)``.


### PR DESCRIPTION
When put together, this change +
https://github.com/python-trio/outcome/pull/29 should fix #1770

Note that the tests on this PR are expected to fail until that fix to
`outcome` lands and has been released, since this PR includes a full
end-to-end test.