### PR TITLE
Test Python development versions in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.6', '3.7', '3.8', '3.9.0-rc.2']
+        python: ['3.6', '3.7', '3.8', '3.9']
         arch: ['x86', 'x64']
         lsp: ['']
         lsp_extract_file: ['']
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.6', '3.7', '3.8', '3.9.0-rc.2']
+        python: ['3.6', '3.7', '3.8', '3.9']
         check_formatting: ['0']
         extra_name: ['']
         include:
@@ -87,7 +87,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.6', '3.7', '3.8', '3.9.0-rc.2']
+        python: ['3.6', '3.7', '3.8', '3.9']
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.6', '3.7', '3.8', '3.9']
+        python: ['3.6', '3.7', '3.8', '3.9', '3.6-dev', '3.7-dev', '3.8-dev', '3.9-dev']
         check_formatting: ['0']
         extra_name: ['']
         include:
@@ -71,6 +71,12 @@ jobs:
         uses: actions/checkout@v2
       - name: Setup python
         uses: actions/setup-python@v2
+        if: "!endsWith(matrix.python, '-dev')"
+        with:
+          python-version: '${{ matrix.python }}'
+      - name: Setup python (dev)
+        uses: deadsnakes/action@v2.0.2
+        if: endsWith(matrix.python, '-dev')
         with:
           python-version: '${{ matrix.python }}'
       - name: Run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,6 @@ jobs:
       # https://github.com/pypa/setuptools/issues/2350
       env: SETUPTOOLS_USE_DISTUTILS=stdlib
       dist: bionic
-    - python: 3.6-dev
-    - python: 3.7-dev
-    - python: 3.8-dev
-    - python: 3.9-dev
-    # Temporarily disabled during the high-churn period of 3.10
-    # E.g.: https://github.com/MagicStack/immutables/issues/46
-    #- python: nightly
 
 script:
   - ./ci.sh


### PR DESCRIPTION
This is actually different from Travis as we're not testing nightly builds, but alpha versions. Should we use the deadsnakes nightly builds instead?

Also, 3.10 does not work yet, due to https://github.com/benjaminp/six/issues/341.