### PR TITLE
avoid cubic AFD cancellation scaling with AFDGroups

### DIFF
--- a/newsfragments/1280.bugfix.rst
+++ b/newsfragments/1280.bugfix.rst
@@ -1,0 +1,1 @@
+Previously, on Windows, Trio programs using thousands of sockets at the same time could trigger extreme slowdowns in the Windows kernel. Now, Trio works around this issue, so you should be able to use as many sockets as you want.

--- a/newsfragments/1832.bugfix.rst
+++ b/newsfragments/1832.bugfix.rst
@@ -1,1 +1,0 @@
-Avoid O(n**3) scaling of windows socket cancellation

--- a/newsfragments/1832.bugfix.rst
+++ b/newsfragments/1832.bugfix.rst
@@ -1,0 +1,1 @@
+Avoid O(n**3) scaling of windows socket cancellation

--- a/notes-to-self/socket-scaling.py
+++ b/notes-to-self/socket-scaling.py
@@ -11,14 +11,6 @@
 # On Windows: with the old 'select'-based loop, the cost of scheduling grew
 # with the number of outstanding sockets, which was bad.
 #
-# With the new IOCP-based loop, the cost of scheduling is constant, which is
-# good. But, we find that the cost of cancelling a single wait_readable
-# appears to grow like O(n**2) or so in the number of outstanding
-# wait_readables. This is bad -- it means that cancelling all of the
-# outstanding operations here is something like O(n**3)! To avoid this, we
-# should consider creating multiple AFD helper handles and distributing the
-# AFD_POLL operations across them.
-#
 # To run this on Unix systems, you'll probably first have to run:
 #
 #   ulimit -n 31000

--- a/trio/_core/_io_windows.py
+++ b/trio/_core/_io_windows.py
@@ -628,6 +628,7 @@ class WindowsIOManager:
                 afd_group = AFDGroup(0, _afd_helper_handle())
                 self._register_with_iocp(afd_group.handle, CKeys.AFD_POLL)
                 self._all_afd_handles.append(afd_group.handle)
+            self._vacant_afd_groups.add(afd_group)
 
             lpOverlapped = ffi.new("LPOVERLAPPED")
 
@@ -666,8 +667,8 @@ class WindowsIOManager:
             waiters.current_op = op
             self._afd_ops[lpOverlapped] = op
             afd_group.size += 1
-            if afd_group.size < MAX_AFD_GROUP_SIZE:
-                self._vacant_afd_groups.add(afd_group)
+            if afd_group.size >= MAX_AFD_GROUP_SIZE:
+                self._vacant_afd_groups.remove(afd_group)
 
     async def _afd_poll(self, sock, mode):
         base_handle = _get_base_socket(sock)

--- a/trio/_core/_io_windows.py
+++ b/trio/_core/_io_windows.py
@@ -356,7 +356,7 @@ class AFDPollOp:
 MAX_AFD_GROUP_SIZE = 500  # at 1000, the cubic scaling is just starting to bite
 
 
-@attr.s(slots=True, hash=True)
+@attr.s(slots=True, eq=False)
 class AFDGroup:
     size = attr.ib()
     afd_handle = attr.ib()
@@ -624,8 +624,6 @@ class WindowsIOManager:
         if not flags:
             del self._afd_waiters[base_handle]
         else:
-
-            # get largest afd_group less than MAX_AFD_GROUP_SIZE
             try:
                 afd_group = self._vacant_afd_groups.pop()
             except KeyError:

--- a/trio/_core/_io_windows.py
+++ b/trio/_core/_io_windows.py
@@ -615,7 +615,7 @@ class WindowsIOManager:
             waiters.current_op = None
             self._sorted_afd_groups.discard(afd_group)
             afd_group.size -= 1
-            if MAX_AFD_GROUP_SIZE > afd_group.size > 0:
+            if afd_group.size > 0:
                 self._sorted_afd_groups.add(afd_group)
             else:
                 _check(kernel32.CloseHandle(afd_group.afd_handle))
@@ -679,7 +679,7 @@ class WindowsIOManager:
             waiters.current_op = op
             self._afd_ops[lpOverlapped] = op
             afd_group.size += 1
-            if MAX_AFD_GROUP_SIZE > afd_group.size:
+            if afd_group.size < MAX_AFD_GROUP_SIZE:
                 self._sorted_afd_groups.add(afd_group)
 
     async def _afd_poll(self, sock, mode):

--- a/trio/tests/test_socket.py
+++ b/trio/tests/test_socket.py
@@ -1002,8 +1002,6 @@ async def test_many_sockets():
         for s in sockets:
             nursery.start_soon(_core.wait_readable, s)
         await _core.wait_all_tasks_blocked()
-        for _ in range(1000):
-            await _core.cancel_shielded_checkpoint()
         nursery.cancel_scope.cancel()
     for sock in sockets:
         sock.close()

--- a/trio/tests/test_socket.py
+++ b/trio/tests/test_socket.py
@@ -1,3 +1,5 @@
+import errno
+
 import pytest
 import attr
 
@@ -995,8 +997,12 @@ async def test_interrupted_by_close():
 async def test_many_sockets():
     total = 5000  # Must be more than MAX_AFD_GROUP_SIZE
     sockets = []
-    for _ in range(total // 2):
-        a, b = stdlib_socket.socketpair()
+    for x in range(total // 2):
+        try:
+            a, b = stdlib_socket.socketpair()
+        except OSError as e:
+            assert e.errno in (errno.EMFILE, errno.ENFILE)
+            break
         sockets += [a, b]
     async with _core.open_nursery() as nursery:
         for s in sockets:
@@ -1005,3 +1011,5 @@ async def test_many_sockets():
         nursery.cancel_scope.cancel()
     for sock in sockets:
         sock.close()
+    if x != total // 2 - 1:
+        print(f"Unable to open more than {(x-1)*2} sockets.")


### PR DESCRIPTION
Fixes #1280. By placing the AFD handle within an `AFDGroup` class that keeps track of the number of associated `AFDPollOp`s and giving each op a reference to its group, we can use a `SortedList` to grab the largest not-full group and therefore AFD handle with a simple pop. The bookkeeping is a little unencapsulated, but the bulk of the changes are inside of `WindowsIOManager._refresh_afd` anyway. 

My own benchmarking showed negligible overhead and an optimal `MAX_AFD_GROUP_SIZE` of 500 to avoid scaling issues but YMMV.