### PR TITLE
Try moving nightly pypy builds off travis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,11 +61,15 @@ jobs:
       matrix:
         python: ['pypy-3.6', 'pypy-3.7', '3.6', '3.7', '3.8', '3.9', '3.6-dev', '3.7-dev', '3.8-dev', '3.9-dev']
         check_formatting: ['0']
+        pypy_nightly_branch: ['']
         extra_name: ['']
         include:
           - python: '3.8'
             check_formatting: '1'
             extra_name: ', check formatting'
+          - python: '3.7'  # <- not actually used
+            pypy_nightly_branch: 'py3.7'
+            extra_name: ', pypy 3.7 nightly'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -82,6 +86,7 @@ jobs:
       - name: Run tests
         run: ./ci.sh
         env:
+          PYPY_NIGHTLY_BRANCH: '${{ matrix.pypy_nightly_branch }}'
           CHECK_FORMATTING: '${{ matrix.check_formatting }}'
           # Should match 'name:' up above
           JOB_NAME: 'Ubuntu (${{ matrix.python }}${{ matrix.extra_name }})'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,6 @@ dist: focal
 
 jobs:
   include:
-    # The pypy tests are slow, so we list them first
-    - language: generic
-      env: PYPY_NIGHTLY_BRANCH=py3.6
-    - language: generic
-      env: PYPY_NIGHTLY_BRANCH=py3.7
-
     - python: 3.6.1  # earliest 3.6 version available on Travis
       # https://github.com/pypa/setuptools/issues/2350
       env: SETUPTOOLS_USE_DISTUTILS=stdlib


### PR DESCRIPTION
I also dropped the pypy-36 nightly here, b/c I don't think it gives us
much -- new features seem to be happening in py3.7.