### PR TITLE
Replaced .format() with f-strings in the tutorial examples

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -273,7 +273,7 @@ this, that tries to call an async function but leaves out the
        trio.sleep(2 * x)
 
        sleep_time = time.perf_counter() - start_time
-       print("Woke up after {:.2f} seconds, feeling well rested!".format(sleep_time))
+       print(f"Woke up after {sleep_time:.2f} seconds, feeling well rested!")
 
    trio.run(broken_double_sleep, 3)
 
@@ -774,7 +774,7 @@ above, it's baked into Trio's design that when it has multiple tasks,
 they take turns, so at each moment only one of them is actively running.
 We're not so much overcoming the GIL as embracing it. But if you're
 willing to accept that, plus a bit of extra work to put these new
-``async`` and ``await`` keywords in the right places, then in exchange 
+``async`` and ``await`` keywords in the right places, then in exchange
 you get:
 
 * Excellent scalability: Trio can run 10,000+ tasks simultaneously
@@ -836,8 +836,8 @@ Networking with Trio
 Now let's take what we've learned and use it to do some I/O, which is
 where async/await really shines.
 
-The traditional toy application for demonstrating network APIs is an 
-"echo server": a program that awaits arbitrary data from  remote clients, 
+The traditional toy application for demonstrating network APIs is an
+"echo server": a program that awaits arbitrary data from  remote clients,
 and then sends that same data right back. (Probably a more relevant example
 these days would be an application that does lots of concurrent HTTP
 requests, but for that `you need an HTTP library
@@ -845,9 +845,9 @@ requests, but for that `you need an HTTP library
 such as `asks <https://asks.readthedocs.io>`__, so we'll stick
 with the echo server tradition.)
 
-In this tutorial, we present both ends of the pipe: the client, and the 
-server. The client periodically sends data to the server, and displays its 
-answers. The server awaits connections; when a client connects, it recopies 
+In this tutorial, we present both ends of the pipe: the client, and the
+server. The client periodically sends data to the server, and displays its
+answers. The server awaits connections; when a client connects, it recopies
 the received data back on the pipe.
 
 

--- a/docs/source/tutorial/echo-client.py
+++ b/docs/source/tutorial/echo-client.py
@@ -13,19 +13,19 @@ async def sender(client_stream):
     print("sender: started!")
     while True:
         data = b"async can sometimes be confusing, but I believe in you!"
-        print("sender: sending {!r}".format(data))
+        print(f"sender: sending {data!r}")
         await client_stream.send_all(data)
         await trio.sleep(1)
 
 async def receiver(client_stream):
     print("receiver: started!")
     async for data in client_stream:
-        print("receiver: got data {!r}".format(data))
+        print(f"receiver: got data {data!r}")
     print("receiver: connection closed")
     sys.exit()
 
 async def parent():
-    print("parent: connecting to 127.0.0.1:{}".format(PORT))
+    print(f"parent: connecting to 127.0.0.1:{PORT}")
     client_stream = await trio.open_tcp_stream("127.0.0.1", PORT)
     async with client_stream:
         async with trio.open_nursery() as nursery:

--- a/docs/source/tutorial/echo-server.py
+++ b/docs/source/tutorial/echo-server.py
@@ -15,12 +15,12 @@ async def echo_server(server_stream):
     # Assign each connection a unique number to make our debug prints easier
     # to understand when there are multiple simultaneous connections.
     ident = next(CONNECTION_COUNTER)
-    print("echo_server {}: started".format(ident))
+    print(f"echo_server {ident}: started")
     try:
         async for data in server_stream:
-            print("echo_server {}: received data {!r}".format(ident, data))
+            print(f"echo_server {ident}: received data {data!r}")
             await server_stream.send_all(data)
-        print("echo_server {}: connection closed".format(ident))
+        print(f"echo_server {ident}: connection closed")
     # FIXME: add discussion of MultiErrors to the tutorial, and use
     # MultiError.catch here. (Not important in this case, but important if the
     # server code uses nurseries internally.)
@@ -28,7 +28,7 @@ async def echo_server(server_stream):
         # Unhandled exceptions will propagate into our parent and take
         # down the whole program. If the exception is KeyboardInterrupt,
         # that's what we want, but otherwise maybe not...
-        print("echo_server {}: crashed: {!r}".format(ident, exc))
+        print(f"echo_server {ident}: crashed: {exc!r}")
 
 async def main():
     await trio.serve_tcp(echo_server, PORT)
@@ -38,4 +38,3 @@ async def main():
 # back and factor it out into a separate function anyway. So it's simplest to
 # just make it a standalone function from the beginning.
 trio.run(main)
-


### PR DESCRIPTION
Since the lowest version we're now supporting is **Python3.6**, I took the liberty to replace the `.format()` style strings in the **tutorial** with **f-strings** for enhanced readability. 