### PR TITLE
Remove deprecated SSLStream max_refill_bytes parameter

### DIFF
--- a/newsfragments/959.deprecated.rst
+++ b/newsfragments/959.deprecated.rst
@@ -1,1 +1,1 @@
-Remove deprecated ``max_refill_bytes`` from ``SSLStream``.
+Remove deprecated ``max_refill_bytes`` from :class:`SSLStream`.

--- a/newsfragments/959.deprecated.rst
+++ b/newsfragments/959.deprecated.rst
@@ -1,0 +1,1 @@
+Remove deprecated ``max_refill_bytes`` from ``SSLStream``.

--- a/trio/_ssl.py
+++ b/trio/_ssl.py
@@ -159,7 +159,6 @@ from .abc import Stream, Listener
 from ._highlevel_generic import aclose_forcefully
 from . import _sync
 from ._util import ConflictDetector, Final
-from ._deprecate import warn_deprecated
 
 ################################################################
 # SSLStream
@@ -328,12 +327,9 @@ class SSLStream(Stream, metaclass=Final):
         server_hostname=None,
         server_side=False,
         https_compatible=False,
-        max_refill_bytes="unused and deprecated",
     ):
         self.transport_stream = transport_stream
         self._state = _State.OK
-        if max_refill_bytes != "unused and deprecated":
-            warn_deprecated("max_refill_bytes=...", "0.12.0", issue=959, instead=None)
         self._https_compatible = https_compatible
         self._outgoing = _stdlib_ssl.MemoryBIO()
         self._delayed_outgoing = None
@@ -898,10 +894,7 @@ class SSLListener(Listener[SSLStream], metaclass=Final):
         ssl_context,
         *,
         https_compatible=False,
-        max_refill_bytes="unused and deprecated",
     ):
-        if max_refill_bytes != "unused and deprecated":
-            warn_deprecated("max_refill_bytes=...", "0.12.0", issue=959, instead=None)
         self.transport_listener = transport_listener
         self._ssl_context = ssl_context
         self._https_compatible = https_compatible

--- a/trio/tests/test_ssl.py
+++ b/trio/tests/test_ssl.py
@@ -1278,15 +1278,3 @@ async def test_SSLListener(client_ctx):
     await aclose_forcefully(ssl_listener)
     await aclose_forcefully(ssl_client)
     await aclose_forcefully(ssl_server)
-
-
-async def test_deprecated_max_refill_bytes(client_ctx):
-    stream1, stream2 = memory_stream_pair()
-    with pytest.warns(trio.TrioDeprecationWarning):
-        SSLStream(stream1, client_ctx, max_refill_bytes=100)
-    with pytest.warns(trio.TrioDeprecationWarning):
-        # passing None is wrong here, but I'm too lazy to make a fake Listener
-        # and we get away with it for now. And this test will be deleted in a
-        # release or two anyway, so hopefully we'll keep getting away with it
-        # for long enough.
-        SSLListener(None, client_ctx, max_refill_bytes=100)


### PR DESCRIPTION
It was deprecated in trio 0.12.0.