### PR TITLE
Remove the deprecated `tiebreaker` argument

### DIFF
--- a/newsfragments/1558.deprecated.rst
+++ b/newsfragments/1558.deprecated.rst
@@ -1,0 +1,1 @@
+Remove the deprecated ``tiebreaker`` argument to `trio.testing.wait_all_tasks_blocked`.

--- a/trio/_core/_generated_run.py
+++ b/trio/_core/_generated_run.py
@@ -169,7 +169,7 @@ def current_trio_token():
         raise RuntimeError("must be called from async context")
 
 
-async def wait_all_tasks_blocked(cushion=0.0, tiebreaker='deprecated'):
+async def wait_all_tasks_blocked(cushion=0.0):
     """Block until there are no runnable tasks.
 
         This is useful in testing code when you want to give other tasks a
@@ -229,7 +229,7 @@ async def wait_all_tasks_blocked(cushion=0.0, tiebreaker='deprecated'):
         """
     locals()[LOCALS_KEY_KI_PROTECTION_ENABLED] = True
     try:
-        return await GLOBAL_RUN_CONTEXT.runner.wait_all_tasks_blocked(cushion, tiebreaker)
+        return await GLOBAL_RUN_CONTEXT.runner.wait_all_tasks_blocked(cushion)
     except AttributeError:
         raise RuntimeError("must be called from async context")
 

--- a/trio/tests/test_testing.py
+++ b/trio/tests/test_testing.py
@@ -103,33 +103,6 @@ async def test_wait_all_tasks_blocked_with_cushion():
     ]
 
 
-# This test can be deleted after tiebreaker= is removed
-async def test_wait_all_tasks_blocked_with_tiebreaker(recwarn):
-    record = []
-
-    async def do_wait(cushion, tiebreaker):
-        await wait_all_tasks_blocked(cushion=cushion, tiebreaker=tiebreaker)
-        record.append((cushion, tiebreaker))
-
-    async with _core.open_nursery() as nursery:
-        nursery.start_soon(do_wait, 0, 0)
-        nursery.start_soon(do_wait, 0, -1)
-        nursery.start_soon(do_wait, 0, 1)
-        nursery.start_soon(do_wait, 0, -1)
-        nursery.start_soon(do_wait, 0.0001, 10)
-        nursery.start_soon(do_wait, 0.0001, -10)
-
-    assert record == sorted(record)
-    assert record == [
-        (0, -1),
-        (0, -1),
-        (0, 0),
-        (0, 1),
-        (0.0001, -10),
-        (0.0001, 10),
-    ]
-
-
 ################################################################
 
 


### PR DESCRIPTION
Note that we have another `tiebreaker` variable in `self._heap` but I think it's unrelated and still useful.