### PR TITLE
make sure coroutine locals are promptly destroyed

### DIFF
--- a/newsfragments/1864.bugfix.rst
+++ b/newsfragments/1864.bugfix.rst
@@ -1,0 +1,2 @@
+The event loop now holds on to references of coroutine frames for only
+the minimum necessary period of time.

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -2219,12 +2219,15 @@ def unrolled_run(runner, async_fn, args, host_uses_signal_set_wakeup_fd=False):
                         # which works for at least asyncio and curio.
                         runner.reschedule(task, exc)
                         task._next_send_fn = task.coro.throw
+                    # prevent long-lived reference
+                    # TODO: develop test for this deletion
                     del msg
 
                 if "after_task_step" in runner.instruments:
                     runner.instruments.call("after_task_step", task)
                 del GLOBAL_RUN_CONTEXT.task
-                # prevent long-lived task reference
+                # prevent long-lived references
+                # TODO: develop test for these deletions
                 del task, next_send, next_send_fn
 
     except GeneratorExit:

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -2179,7 +2179,7 @@ def unrolled_run(runner, async_fn, args, host_uses_signal_set_wakeup_fd=False):
                     # Remove local refs so that e.g. cancelled coroutine locals
                     # are not kept alive by this frame until another exception
                     # comes along.
-                    # del tb, task_exc
+                    del tb, task_exc
 
                 if final_outcome is not None:
                     # We can't call this directly inside the except: blocks

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -2176,6 +2176,10 @@ def unrolled_run(runner, async_fn, args, host_uses_signal_set_wakeup_fd=False):
                     for _ in range(CONTEXT_RUN_TB_FRAMES):
                         tb = tb.tb_next
                     final_outcome = Error(task_exc.with_traceback(tb))
+                    # Remove local refs so that e.g. cancelled coroutine locals
+                    # are not kept alive by this frame until another exception
+                    # comes along.
+                    # del tb, task_exc
 
                 if final_outcome is not None:
                     # We can't call this directly inside the except: blocks
@@ -2183,6 +2187,10 @@ def unrolled_run(runner, async_fn, args, host_uses_signal_set_wakeup_fd=False):
                     # themselves to other exceptions as __context__ in
                     # unwanted ways.
                     runner.task_exited(task, final_outcome)
+                    # final_outcome may contain a traceback ref. It's not as
+                    # crucial compared to the above, but will still allow more
+                    # prompt release of resources.
+                    final_outcome = None
                 else:
                     task._schedule_points += 1
                     if msg is CancelShieldedCheckpoint:

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -2167,8 +2167,6 @@ def unrolled_run(runner, async_fn, args, host_uses_signal_set_wakeup_fd=False):
                     msg = task.context.run(next_send_fn, next_send)
                 except StopIteration as stop_iteration:
                     final_outcome = Value(stop_iteration.value)
-                    # prevent long-lived traceback reference
-                    del stop_iteration
                 except BaseException as task_exc:
                     # Store for later, removing uninteresting top frames: 1
                     # frame we always remove, because it's this function
@@ -2181,7 +2179,7 @@ def unrolled_run(runner, async_fn, args, host_uses_signal_set_wakeup_fd=False):
                     # Remove local refs so that e.g. cancelled coroutine locals
                     # are not kept alive by this frame until another exception
                     # comes along.
-                    del tb, task_exc
+                    del tb
 
                 if final_outcome is not None:
                     # We can't call this directly inside the except: blocks

--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -6,6 +6,7 @@ import threading
 import time
 import types
 import warnings
+import weakref
 from contextlib import contextmanager, ExitStack
 from math import inf
 from textwrap import dedent
@@ -2249,3 +2250,27 @@ async def test_nursery_cancel_doesnt_create_cyclic_garbage():
     finally:
         gc.set_debug(old_flags)
         gc.garbage.clear()
+
+
+@pytest.mark.skipif(
+    sys.implementation.name != "cpython", reason="Only makes sense with refcounting GC"
+)
+async def test_locals_destroyed_promptly_on_cancel():
+    destroyed = False
+
+    def finalizer():
+        nonlocal destroyed
+        destroyed = True
+
+    class A:
+        pass
+
+    async def task():
+        a = A()
+        weakref.finalize(a, finalizer)
+        await _core.checkpoint()
+
+    async with _core.open_nursery() as nursery:
+        nursery.start_soon(task)
+        nursery.cancel_scope.cancel()
+    assert destroyed


### PR DESCRIPTION
This PR fixes a "bug" where `unrolled_run` hangs on to `Cancelled` tracebacks too long. They essentially persist until the _next_ exception is thrown out of a task, which may be an indefinite period of time. This was not cleaned up with the earlier cyclic garbage bugfix #1770 because it is not cyclic garbage; it's actually a strong reference that lives unnecessarily long.

(Thinking out loud here) This is just the minimum possible fix. There are actually a number of locals akin to `final_outcome` in `unrolled_run` that may live up to `_MAX_TIMEOUT` seconds and contain references to tasks and potentially to hefty objects, but I haven't actually observed any issues along those lines yet. Scattering `del` statements everywhere is probably untenable, but factoring chunks of `unrolled_run` into function calls would "automate"  that kind of cleanup, at the cost of some overhead.