### PR TITLE
Update dependencies for Fedora CI

### DIFF
--- a/.builds/fedora.yml
+++ b/.builds/fedora.yml
@@ -1,5 +1,6 @@
 image: fedora/rawhide
 packages:
+  - python3-devel
   - python3-pip
 sources:
   - https://github.com/python-trio/trio


### PR DESCRIPTION
I guess previously python3-pip depended on something
that depends on python3-devel (which contains the C headers),
but apparently relying on implicit dependencies is never a good thing.