### PR TITLE
notes-to-self: fix table in how-does-windows-so-reuseaddr-work.py

### DIFF
--- a/notes-to-self/how-does-windows-so-reuseaddr-work.py
+++ b/notes-to-self/how-does-windows-so-reuseaddr-work.py
@@ -43,10 +43,17 @@ def table_entry(mode1, bind_type1, mode2, bind_type2):
 
 print("""
                                                        second bind
-                               | default           | SO_REUSEADDR      | SO_EXCLUSIVEADDRUSE
-                               | specific| wildcard| specific| wildcard| specific| wildcard
-first bind                     ------------------------------------------------------------"""
-#           default | wildcard |   INUSE | Success |  ACCESS | Success |   INUSE | Success
+                               | """
++ " | ".join(["%-19s" % mode for mode in modes])
+)
+
+print("""                              """, end='')
+for mode in modes:
+    print(" | " + " | ".join(["%8s" % bind_type for bind_type in bind_types]), end='')
+
+print("""
+first bind                     -----------------------------------------------------------------"""
+#            default | wildcard |    INUSE |  Success |   ACCESS |  Success |    INUSE |  Success
 )
 
 for i, mode1 in enumerate(modes):
@@ -58,4 +65,4 @@ for i, mode1 in enumerate(modes):
                 row.append(entry)
                 #print(mode1, bind_type1, mode2, bind_type2, entry)
         print("{:>19} | {:>8} | ".format(mode1, bind_type1)
-              + " | ".join(["%7s" % entry for entry in row]))
+              + " | ".join(["%8s" % entry for entry in row]))


### PR DESCRIPTION
- Generate the table headers dynamically.

Prior to this change the table headers were static and incorrect,
'specific' and 'wildcard' labels were reversed.

Example output from before the change (incorrect):
~~~
                   | default           |
                   | specific| wildcard|
                   ---------------------
default | wildcard |   INUSE | Success |
default | wildcard | Success |   INUSE |
~~~

Example output from after the change (correct):
~~~
                   | default             |
                   | wildcard | specific |
                   -----------------------
default | wildcard |    INUSE |  Success |
default | wildcard |  Success |    INUSE |
~~~

Bug: https://github.com/python-trio/trio/issues/928#issuecomment-774630606

Closes #xxxx

---

/cc @njsmith 