### PR TITLE
Bump to Pytest 6.2.2 with -p no:unraisableexception -p no:threadexception

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,4 @@ markers =
 junit_family = xunit2
 addopts =
     -p no:unraisableexception
+    -p no:threadexception

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,5 @@ faulthandler_timeout=60
 markers =
     redistributors_should_skip: tests that should be skipped by downstream redistributors
 junit_family = xunit2
+addopts =
+    -p no:unraisableexception

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -102,7 +102,7 @@ pyparsing==2.4.7
     # via packaging
 pytest-cov==2.11.1
     # via -r test-requirements.in
-pytest==6.1.2
+pytest==6.2.2
     # via
     #   -r test-requirements.in
     #   pytest-cov


### PR DESCRIPTION
See #1878 for the initial dependabot PR showing the build issues.

https://docs.pytest.org/en/stable/changelog.html (See 6.2.0 features)
https://docs.pytest.org/en/stable/usage.html#unraisable

I think that disabling these new plugins for now is reasonable since it allows us to keep moving forward with pytest versions while retaining the same lack of these checks as if we held the version back.  If there is concern about globally disabling these checks then I think a follow up ticket and PR would be appropriate.

I did make a cursory effort to use `@pytest.mark.filterwarnings()` but failed to get it to successfully avoid the new errors.  I suspect something related to the combination with `-W error` and other pytest features but I did not dig into it.