### PR TITLE
reenable pytest -p unraisableexception and -p threadexception

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -143,7 +143,7 @@ else
     cd empty
 
     INSTALLDIR=$(python -c "import os, trio; print(os.path.dirname(trio.__file__))")
-    cp ../setup.cfg $INSTALLDIR
+    cp ../pyproject.toml $INSTALLDIR
     # We have to copy .coveragerc into this directory, rather than passing
     # --cov-config=../.coveragerc to pytest, because codecov.sh will run
     # 'coverage xml' to generate the report that it uses, and that will only

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,3 +50,10 @@ directory = "misc"
 name = "Miscellaneous internal changes"
 showcontent = true
 
+[tool.pytest.ini_options]
+addopts = ["--strict-markers", "--strict-config"]
+xfail_strict = true
+faulthandler_timeout = 60
+markers = ["redistributors_should_skip: tests that should be skipped by downstream redistributors"]
+junit_family = "xunit2"
+filterwarnings = ["error"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,0 @@
-[tool:pytest]
-xfail_strict = true
-faulthandler_timeout=60
-markers =
-    redistributors_should_skip: tests that should be skipped by downstream redistributors
-junit_family = xunit2
-addopts =
-    -p no:unraisableexception
-    -p no:threadexception

--- a/trio/_core/tests/test_guest_mode.py
+++ b/trio/_core/tests/test_guest_mode.py
@@ -13,7 +13,7 @@ import time
 
 import trio
 import trio.testing
-from .tutil import gc_collect_harder, buggy_pypy_asyncgens
+from .tutil import gc_collect_harder, buggy_pypy_asyncgens, restore_unraisablehook
 from ..._util import signal_raise
 
 # The simplest possible "host" loop.
@@ -277,6 +277,7 @@ def test_host_wakeup_doesnt_trigger_wait_all_tasks_blocked():
     assert trivial_guest_run(trio_main) == "ok"
 
 
+@restore_unraisablehook()
 def test_guest_warns_if_abandoned():
     # This warning is emitted from the garbage collector. So we have to make
     # sure that our abandoned run is garbage. The easiest way to do this is to
@@ -506,6 +507,7 @@ def test_guest_mode_autojump_clock_threshold_changing():
     sys.implementation.name == "pypy" and sys.version_info >= (3, 7),
     reason="async generator issue under investigation",
 )
+@restore_unraisablehook()
 def test_guest_mode_asyncgens():
     import sniffio
 

--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -23,6 +23,7 @@ from .tutil import (
     gc_collect_harder,
     ignore_coroutine_never_awaited_warnings,
     buggy_pypy_asyncgens,
+    restore_unraisablehook,
 )
 
 from ... import _core
@@ -844,6 +845,7 @@ async def test_failed_abort():
     assert record == ["sleep", "woke", "cancelled"]
 
 
+@restore_unraisablehook()
 def test_broken_abort():
     async def main():
         # These yields are here to work around an annoying warning -- we're
@@ -870,6 +872,7 @@ def test_broken_abort():
     gc_collect_harder()
 
 
+@restore_unraisablehook()
 def test_error_in_run_loop():
     # Blow stuff up real good to check we at least get a TrioInternalError
     async def main():
@@ -2154,6 +2157,7 @@ async def test_detached_coroutine_cancellation():
     assert abort_fn_called
 
 
+@restore_unraisablehook()
 def test_async_function_implemented_in_C():
     # These used to crash because we'd try to mutate the coroutine object's
     # cr_frame, but C functions don't have Python frames.

--- a/trio/_core/tests/test_windows.py
+++ b/trio/_core/tests/test_windows.py
@@ -8,7 +8,7 @@ on_windows = os.name == "nt"
 # Mark all the tests in this file as being windows-only
 pytestmark = pytest.mark.skipif(not on_windows, reason="windows only")
 
-from .tutil import slow, gc_collect_harder
+from .tutil import slow, gc_collect_harder, restore_unraisablehook
 from ... import _core, sleep, move_on_after
 from ...testing import wait_all_tasks_blocked
 
@@ -111,6 +111,7 @@ def pipe_with_overlapped_read():
         kernel32.CloseHandle(ffi.cast("HANDLE", write_handle))
 
 
+@restore_unraisablehook()
 def test_forgot_to_register_with_iocp():
     with pipe_with_overlapped_read() as (write_fp, read_handle):
         with write_fp:

--- a/trio/_core/tests/tutil.py
+++ b/trio/_core/tests/tutil.py
@@ -107,11 +107,11 @@ if sys.version_info >= (3, 8):
 else:
 
     @contextmanager
-    def restore_unraisablehook():
+    def restore_unraisablehook():  # pragma: no cover
         yield
 
     @contextmanager
-    def disable_threading_excepthook():
+    def disable_threading_excepthook():  # pragma: no cover
         yield
 
 

--- a/trio/_core/tests/tutil.py
+++ b/trio/_core/tests/tutil.py
@@ -1,5 +1,6 @@
 # Utilities for testing
 import socket as stdlib_socket
+import threading
 import os
 import sys
 from typing import TYPE_CHECKING
@@ -78,6 +79,40 @@ def ignore_coroutine_never_awaited_warnings():
             # Make sure to trigger any coroutine __del__ methods now, before
             # we leave the context manager.
             gc_collect_harder()
+
+
+def _noop(*args, **kwargs):
+    pass
+
+
+if sys.version_info >= (3, 8):
+
+    @contextmanager
+    def restore_unraisablehook():
+        sys.unraisablehook, prev = sys.__unraisablehook__, sys.unraisablehook
+        try:
+            yield
+        finally:
+            sys.unraisablehook = prev
+
+    @contextmanager
+    def disable_threading_excepthook():
+        threading.excepthook, prev = _noop, threading.excepthook
+        try:
+            yield
+        finally:
+            threading.excephtook = prev
+
+
+else:
+
+    @contextmanager
+    def restore_unraisablehook():
+        yield
+
+    @contextmanager
+    def disable_threading_excepthook():
+        yield
 
 
 # template is like:

--- a/trio/_core/tests/tutil.py
+++ b/trio/_core/tests/tutil.py
@@ -101,7 +101,7 @@ if sys.version_info >= (3, 8):
         try:
             yield
         finally:
-            threading.excephtook = prev
+            threading.excepthook = prev
 
 
 else:


### PR DESCRIPTION
by restoring the default unraisablehook, and disabling the threading.excepthook in tests that need it