### PR TITLE
use attr.s for slotted classes

### DIFF
--- a/trio/_core/_entry_queue.py
+++ b/trio/_core/_entry_queue.py
@@ -126,6 +126,7 @@ class EntryQueue:
             self.wakeup.wakeup_thread_and_signal_safe()
 
 
+@attr.s(eq=False, hash=False, slots=True)
 class TrioToken(metaclass=NoPublicConstructor):
     """An opaque object representing a single call to :func:`trio.run`.
 
@@ -145,10 +146,7 @@ class TrioToken(metaclass=NoPublicConstructor):
 
     """
 
-    __slots__ = ("_reentry_queue", "__weakref__")
-
-    def __init__(self, reentry_queue):
-        self._reentry_queue = reentry_queue
+    _reentry_queue = attr.ib()
 
     def run_sync_soon(self, sync_fn, *args, idempotent=False):
         """Schedule a call to ``sync_fn(*args)`` to occur in the context of a

--- a/trio/_core/_local.py
+++ b/trio/_core/_local.py
@@ -1,24 +1,25 @@
 # Runvar implementations
+import attr
+
 from . import _run
 
 from .._util import Final
 
 
+@attr.s(eq=False, hash=False, slots=True)
 class _RunVarToken:
     _no_value = object()
 
-    __slots__ = ("_var", "previous_value", "redeemed")
+    _var = attr.ib()
+    previous_value = attr.ib(default=_no_value)
+    redeemed = attr.ib(default=False, init=False)
 
     @classmethod
     def empty(cls, var):
-        return cls(var, value=cls._no_value)
-
-    def __init__(self, var, value):
-        self._var = var
-        self.previous_value = value
-        self.redeemed = False
+        return cls(var)
 
 
+@attr.s(eq=False, hash=False, slots=True)
 class RunVar(metaclass=Final):
     """The run-local variant of a context variable.
 
@@ -29,11 +30,8 @@ class RunVar(metaclass=Final):
     """
 
     _NO_DEFAULT = object()
-    __slots__ = ("_name", "_default")
-
-    def __init__(self, name, default=_NO_DEFAULT):
-        self._name = name
-        self._default = default
+    _name = attr.ib()
+    _default = attr.ib(default=_NO_DEFAULT)
 
     def get(self, default=_NO_DEFAULT):
         """Gets the value of this :class:`RunVar` for the current run call."""


### PR DESCRIPTION
to avoid accidentally forgetting the `__weakref__` slot