### PR TITLE
use slots for ParkingLot and Event

### DIFF
--- a/trio/_core/_parking_lot.py
+++ b/trio/_core/_parking_lot.py
@@ -85,7 +85,7 @@ class _ParkingLotStatistics:
     tasks_waiting = attr.ib()
 
 
-@attr.s(eq=False, hash=False)
+@attr.s(eq=False, hash=False, slots=True)
 class ParkingLot(metaclass=Final):
     """A fair wait queue with cancellation and requeueing.
 

--- a/trio/_sync.py
+++ b/trio/_sync.py
@@ -10,7 +10,7 @@ from ._deprecate import deprecated
 from ._util import Final
 
 
-@attr.s(repr=False, eq=False, hash=False)
+@attr.s(repr=False, eq=False, hash=False, slots=True)
 class Event(metaclass=Final):
     """A waitable boolean value useful for inter-task synchronization,
     inspired by :class:`threading.Event`.


### PR DESCRIPTION
`Event` instances can be very numerous in a Trio program, especially considering idioms like "create a new event on every set()".  `Event` contains `ParkingLot` and neither were using slots, which is a source of garbage objects.

closes #1943