### PR TITLE
DOC: Demphasize `asks` from awesome libraries (broken)

### DIFF
--- a/docs/source/awesome-trio-libraries.rst
+++ b/docs/source/awesome-trio-libraries.rst
@@ -27,20 +27,13 @@ Getting Started
 
 Web and HTML
 ------------
+* `httpx <https://www.python-httpx.org/>`__ - HTTPX is a fully featured HTTP client for Python 3, which provides sync and async APIs, and support for both HTTP/1.1 and HTTP/2.
 * `trio-websocket <https://github.com/HyperionGray/trio-websocket>`__ - This library implements the WebSocket protocol, striving for safety, correctness, and ergonomics.
 * `quart-trio <https://gitlab.com/pgjones/quart-trio/>`__ - Like Flask, but for Trio. A simple and powerful framework for building async web applications and REST APIs. Tip: this is an ASGI-based framework, so you'll also need an HTTP server with ASGI support.
 * `hypercorn <https://gitlab.com/pgjones/hypercorn>`__ - An HTTP server for hosting your ASGI apps. Supports HTTP/1.1, HTTP/2, HTTP/3, and Websockets. Can be run as a standalone server, or embedded in a larger Trio app. Use it with ``quart-trio``, or any other Trio-compatible ASGI framework.
-* `httpx <https://www.python-httpx.org/>`__ - HTTPX is a fully featured HTTP client for Python 3, which provides sync and async APIs, and support for both HTTP/1.1 and HTTP/2.
 * `DeFramed <https://github.com/smurfix/deframed>`__ - DeFramed is a Web non-framework that supports a 99%-server-centric approach to Web coding, including support for the `Remi <https://github.com/dddomodossola/remi>`__ GUI library.
 * `pura <https://github.com/groove-x/pura>`__ - A simple web framework for embedding realtime graphical visualization into Trio apps, enabling inspection and manipulation of program state during development.
 * `pyscalpel <https://scalpel.readthedocs.io/en/latest/>`__ - A fast and powerful webscraping library.
-
-
-The following libraries may not be maintained, or do not work with the latests version of trio.
-
-* `asks <https://github.com/theelous3/asks>`__ - asks is an async requests-like http library. As if April 2020, this
-  project seem dormant, and does not work with the latests version of `anyio <https://pypi.org/project/anyio>`__ (2.2.0)
-  despite advertising compatibility with anyio 2.x
 
 
 Database

--- a/docs/source/awesome-trio-libraries.rst
+++ b/docs/source/awesome-trio-libraries.rst
@@ -27,7 +27,6 @@ Getting Started
 
 Web and HTML
 ------------
-* `asks <https://github.com/theelous3/asks>`__ - asks is an async requests-like http library.
 * `trio-websocket <https://github.com/HyperionGray/trio-websocket>`__ - This library implements the WebSocket protocol, striving for safety, correctness, and ergonomics.
 * `quart-trio <https://gitlab.com/pgjones/quart-trio/>`__ - Like Flask, but for Trio. A simple and powerful framework for building async web applications and REST APIs. Tip: this is an ASGI-based framework, so you'll also need an HTTP server with ASGI support.
 * `hypercorn <https://gitlab.com/pgjones/hypercorn>`__ - An HTTP server for hosting your ASGI apps. Supports HTTP/1.1, HTTP/2, HTTP/3, and Websockets. Can be run as a standalone server, or embedded in a larger Trio app. Use it with ``quart-trio``, or any other Trio-compatible ASGI framework.
@@ -35,6 +34,13 @@ Web and HTML
 * `DeFramed <https://github.com/smurfix/deframed>`__ - DeFramed is a Web non-framework that supports a 99%-server-centric approach to Web coding, including support for the `Remi <https://github.com/dddomodossola/remi>`__ GUI library.
 * `pura <https://github.com/groove-x/pura>`__ - A simple web framework for embedding realtime graphical visualization into Trio apps, enabling inspection and manipulation of program state during development.
 * `pyscalpel <https://scalpel.readthedocs.io/en/latest/>`__ - A fast and powerful webscraping library.
+
+
+The following libraries may not be maintained, or do not work with the latests version of trio.
+
+* `asks <https://github.com/theelous3/asks>`__ - asks is an async requests-like http library. As if April 2020, this
+  project seem dormant, and does not work with the latests version of `anyio <https://pypi.org/project/anyio>`__ (2.2.0)
+  despite advertising compatibility with anyio 2.x
 
 
 Database


### PR DESCRIPTION
The project seem to have no activity since October, and does not work
out of the box when installing:

```
 >>> ImportError: cannot import name 'aopen' from 'anyio'
```
It requires anyio ~2.x but is actually failing with it.

As it is the first of the list; it is likely to be tried first and users
wondering if they are doing something wrong (guilty of this myself), or
if trio is broken.