### PR TITLE
Addresses #1958: Move code that handles job into its own method

### DIFF
--- a/trio/_core/_thread_cache.py
+++ b/trio/_core/_thread_cache.py
@@ -57,6 +57,8 @@ class WorkerThread:
         thread.start()
 
     def _handle_job(self):
+        # Handle job in a separate method to ensure user-created
+        # objects are cleaned up in a consistent manner. 
         fn, deliver = self._job
         self._job = None
         result = outcome.capture(fn)

--- a/trio/_core/_thread_cache.py
+++ b/trio/_core/_thread_cache.py
@@ -58,7 +58,7 @@ class WorkerThread:
 
     def _handle_job(self):
         # Handle job in a separate method to ensure user-created
-        # objects are cleaned up in a consistent manner. 
+        # objects are cleaned up in a consistent manner.
         fn, deliver = self._job
         self._job = None
         result = outcome.capture(fn)


### PR DESCRIPTION
Attempting to address #1958 by moving the code that handles jobs into its own method. This is my first contribution, so let me know if I need to do anything differently. Thanks! 