### PR TITLE
updated race example to use variable assignment to track winner instead of memory channel

### DIFF
--- a/docs/source/reference-core.rst
+++ b/docs/source/reference-core.rst
@@ -798,7 +798,7 @@ finishes first::
 
        async def jockey(async_fn, cancel_scope):
            nonlocal winner
-           await winner = async_fn()
+           winner = await async_fn()
            cancel_scope.cancel()
 
        async with trio.open_nursery() as nursery:


### PR DESCRIPTION
When I was first reading through the docs for trio I was a bit thrown off by the use of a memory channel in the race example. Since the memory channel itself is not what is meant to be demonstrated here, I think it might be better to remove it in favor of simple variable assignment. Another plus of this is it demonstrates the ability to use nurseries themselves for waiting. 

I may be alone in being confused with the memory channel, so please let me know if you prefer it the original way, and also let me know if you have any questions about this.

Thanks!
