### PR TITLE
Reduce coverage flapping

### DIFF
--- a/trio/testing/_check_streams.py
+++ b/trio/testing/_check_streams.py
@@ -329,14 +329,15 @@ async def check_one_way_stream(stream_maker, clogged_stream_maker):
                     nursery.start_soon(s.send_all, b"123")
                     nursery.start_soon(s.send_all, b"123")
 
-        # closing the receiver causes wait_send_all_might_not_block to return
+        # closing the receiver causes wait_send_all_might_not_block to return,
+        # with or without an exception
         async with _ForceCloseBoth(await clogged_stream_maker()) as (s, r):
 
             async def sender():
                 try:
                     with assert_checkpoints():
                         await s.wait_send_all_might_not_block()
-                except _core.BrokenResourceError:
+                except _core.BrokenResourceError:  # pragma: no cover
                     pass
 
             async def receiver():
@@ -353,7 +354,7 @@ async def check_one_way_stream(stream_maker, clogged_stream_maker):
             try:
                 with assert_checkpoints():
                     await s.wait_send_all_might_not_block()
-            except _core.BrokenResourceError:
+            except _core.BrokenResourceError:  # pragma: no cover
                 pass
 
         # Check that if a task is blocked in a send-side method, then closing

--- a/trio/tests/test_socket.py
+++ b/trio/tests/test_socket.py
@@ -1000,7 +1000,7 @@ async def test_many_sockets():
     for x in range(total // 2):
         try:
             a, b = stdlib_socket.socketpair()
-        except OSError as e:
+        except OSError as e:  # pragma: no cover
             assert e.errno in (errno.EMFILE, errno.ENFILE)
             break
         sockets += [a, b]
@@ -1011,5 +1011,5 @@ async def test_many_sockets():
         nursery.cancel_scope.cancel()
     for sock in sockets:
         sock.close()
-    if x != total // 2 - 1:
+    if x != total // 2 - 1:  # pragma: no cover
         print(f"Unable to open more than {(x-1)*2} sockets.")


### PR DESCRIPTION
Add `# pragma: no cover` to a few places where our tests have
fallbacks for OS flakiness, and that are causing coverage to randomly
go up and down depending on CI host load.