### PR TITLE
Add EventStream class based on 'pulse' prototype

### DIFF
--- a/docs/source/reference-core.rst
+++ b/docs/source/reference-core.rst
@@ -1433,6 +1433,17 @@ deadlock. Using an unbounded channel avoids this, because it means
 that :meth:`~trio.abc.SendChannel.send` never blocks.
 
 
+Higher-level synchronization primitives
+---------------------------------------
+
+While events and channels are useful in a very wide range of
+applications, some less common problems are best tackled with some
+higher-level concurrency primitives that focus on a specific problem.
+
+.. autoclass:: EventStream
+   :members:
+
+
 Lower-level synchronization primitives
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/trio/__init__.py
+++ b/trio/__init__.py
@@ -52,6 +52,7 @@ from ._sync import (
     Lock,
     StrictFIFOLock,
     Condition,
+    EventStream,
 )
 
 from ._highlevel_generic import aclose_forcefully, StapledStream


### PR DESCRIPTION
Add the EventStream class, which allows multiple subscribers to a stream of events without exhibiting a missing wakeups problem.

I think the documentation is far from fully fleshed out here - I want to draw up a diagram of the read/write cursor interpretation for EventStream  - but this is the bare bones of the direction I took this so I'm submitting it for sokme early feedbac.