### PR TITLE
📝  Add small description of call stack in tutorial

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -600,7 +600,10 @@ suddenly we're back in :func:`trio.run` deciding what to run next. How
 does this happen? The secret is that :func:`trio.run` and
 :func:`trio.sleep` work together to make it happen: :func:`trio.sleep`
 has access to some special magic that lets it pause its entire
-call stack, so it sends a note to :func:`trio.run` requesting to be
+call stack, which is all the things in memory up to that specific point
+in the code, including the variables created in the parent function that
+called :func:`trio.sleep`, the exact point in that function where it was
+called, etc. so it sends a note to :func:`trio.run` requesting to be
 woken again after 1 second, and then suspends the task. And once the
 task is suspended, Python gives control back to :func:`trio.run`,
 which decides what to do next. (If this sounds similar to the way that

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -599,11 +599,8 @@ Each task runs until it hits the call to :func:`trio.sleep`, and then
 suddenly we're back in :func:`trio.run` deciding what to run next. How
 does this happen? The secret is that :func:`trio.run` and
 :func:`trio.sleep` work together to make it happen: :func:`trio.sleep`
-has access to some special magic that lets it pause its entire
-call stack, which is all the things in memory up to that specific point
-in the code, including the variables created in the parent function that
-called :func:`trio.sleep`, the exact point in that function where it was
-called, etc. so it sends a note to :func:`trio.run` requesting to be
+has access to some special magic that lets it pause itself,
+so it sends a note to :func:`trio.run` requesting to be
 woken again after 1 second, and then suspends the task. And once the
 task is suspended, Python gives control back to :func:`trio.run`,
 which decides what to do next. (If this sounds similar to the way that


### PR DESCRIPTION
:memo: Add small description of "call stack" in tutorial.

---

Thanks for building Trio! I love how beginner-friendly the tutorial is, it makes me feel that I'm learning and that I'm welcome.

In the same spirit, I realized the first mention of "call stack" doesn't have an explanation about what it is.

I think it might not be obvious, and given there's a great explanation above about async context managers, I thought this could be relevant too.