### PR TITLE
👷  Debug and hopefully fix a CI issue with Fedora

### DIFF
--- a/.builds/fedora.yml
+++ b/.builds/fedora.yml
@@ -1,12 +1,14 @@
 image: fedora/rawhide
 packages:
-  - python3-devel
+  # Comment out to avoid Python 3.10 until cffi has built wheels for Python 3.10
+  # - python3-devel
+  - python3.9
   - python3-pip
 sources:
   - https://github.com/python-trio/trio
 tasks:
   - test: |
-      python3 -m venv venv
+      python3.9 -m venv venv
       source venv/bin/activate
       cd trio
       CI_BUILD_ID=$JOB_ID CI_BUILD_URL=$JOB_URL ./ci.sh


### PR DESCRIPTION
I made a small docs-only PR here: https://github.com/python-trio/trio/pull/2036

And it seems there's an issue for the CI with `fedora.yml`: https://builds.sr.ht/~njs/job/525148

It's about building the wheel for `cffi` from source, so, not really relevant to the original docs PR.

🤞 ~This PR is to try to debug it and hopefully fix it.~  It seems this PR fixes it. 🎉 

---

Fedora Rawhide (the development version) comes with Python 3.10 by default: `3.10.0~b2-3.fc35`

But `cffi` has built wheels for up to Python 3.9.

I see from the logs of CI runs for recent PRs that up to recently it was using Python 3.9, so I suspect it's fine to pin it to 3.9 for now, while there are built wheels for `cffi` for Python 3.10.