### PR TITLE
remove unused global trio._core._parking_lot._counter

### DIFF
--- a/trio/_core/_parking_lot.py
+++ b/trio/_core/_parking_lot.py
@@ -70,14 +70,11 @@
 #
 # See: https://github.com/python-trio/trio/issues/53
 
-from itertools import count
 import attr
 from collections import OrderedDict
 
 from .. import _core
 from .._util import Final
-
-_counter = count()
 
 
 @attr.s(frozen=True, slots=True)


### PR DESCRIPTION
according to git -S the last occurance of next(_counter) was removed in 9cc347779ff520299f9b6639bc75e5cae2d898f7