### PR TITLE
Fix Python 3.10 build

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -132,7 +132,7 @@ trustme==0.9.0
     # via -r test-requirements.in
 typed-ast==1.4.3 ; implementation_name == "cpython"
     # via -r test-requirements.in
-typing-extensions==3.10.0.1 ; implementation_name == "cpython"
+typing-extensions==3.10.0.0 ; implementation_name == "cpython"
     # via
     #   -r test-requirements.in
     #   black


### PR DESCRIPTION
black 21.8b0 forbids typing-extensions 3.10.0.1 on Python 3.10.