### PR TITLE
Skip frequently failing test on Windows + 3.10

### DIFF
--- a/trio/tests/test_ssl.py
+++ b/trio/tests/test_ssl.py
@@ -1,3 +1,4 @@
+import os
 import re
 import sys
 

--- a/trio/tests/test_ssl.py
+++ b/trio/tests/test_ssl.py
@@ -765,6 +765,10 @@ async def test_wait_writable_calls_underlying_wait_writable():
     assert record == ["ok"]
 
 
+@pytest.mark.skipif(
+    os.name == "nt" and sys.version_info >= (3, 10),
+    reason="frequently fails on Windows + Python 3.10",
+)
 async def test_checkpoints(client_ctx):
     async with ssl_echo_server(client_ctx) as s:
         with assert_checkpoints():


### PR DESCRIPTION
We decided to merge #1921 knowing that we had this mysterious flaky test: https://gitter.im/python-trio/general?at=60c7cdc0184fef617ae9effc. We said we'd look into it later, and we should have, but we never did, and it fails at least 10% of the time, which is annoying.

cc @altendky @graingert @njsmith 