### PR TITLE
Fix leaking file descriptors when subprocess creation fails

### DIFF
--- a/newsfragments/2193.bugfix.rst
+++ b/newsfragments/2193.bugfix.rst
@@ -1,0 +1,3 @@
+Trio now deterministically cleans up file descriptors that were opened before
+subprocess creation fails. Previously, they would remain open until the next run of
+the garbage collector.

--- a/newsfragments/README.rst
+++ b/newsfragments/README.rst
@@ -1,0 +1,35 @@
+This directory collects "newsfragments": short files that each contain
+a snippet of ReST-formatted text that will be added to the next
+release notes. This should be a description of aspects of the change
+(if any) that are relevant to users. (This contrasts with your commit
+message and PR description, which are a description of the change as
+relevant to people working on the code itself.)
+
+Each file should be named like ``<ISSUE>.<TYPE>.rst``, where
+``<ISSUE>`` is an issue number, and ``<TYPE>`` is one of:
+
+* ``headline``: a major new feature we want to highlight for users
+* ``breaking``: any breaking changes that happen without a proper
+  deprecation period (note: deprecations, and removal of previously
+  deprecated features after an appropriate time, go in the
+  ``deprecated`` category instead)
+* ``feature``: any new feature that doesn't qualify for ``headline``
+* ``bugfix``
+* ``doc``
+* ``deprecated``
+* ``misc``
+
+So for example: ``123.headline.rst``, ``456.bugfix.rst``,
+``789.deprecated.rst``
+
+If your PR fixes an issue, use that number here. If there is no issue,
+then after you submit the PR and get the PR number you can add a
+newsfragment using that instead.
+
+Your text can use all the same markup that we use in our Sphinx docs.
+For example, you can use double-backticks to mark code snippets, or
+single-backticks to link to a function/class/module.
+
+To check how your formatting looks, the easiest way is to make the PR,
+and then after the CI checks run, click on the "Read the Docs build"
+details link, and navigate to the release history page.

--- a/trio/_subprocess_platform/__init__.py
+++ b/trio/_subprocess_platform/__init__.py
@@ -13,6 +13,17 @@ _wait_child_exiting_error: Optional[ImportError] = None
 _create_child_pipe_error: Optional[ImportError] = None
 
 
+if TYPE_CHECKING:
+    # internal types for the pipe representations used in type checking only
+    class ClosableSendStream(SendStream):
+        def close(self) -> None:
+            ...
+
+
+    class ClosableReceiveStream(ReceiveStream):
+        def close(self) -> None:
+            ...
+
 # Fallback versions of the functions provided -- implementations
 # per OS are imported atop these at the bottom of the module.
 async def wait_child_exiting(process: "_subprocess.Process") -> None:
@@ -30,7 +41,7 @@ async def wait_child_exiting(process: "_subprocess.Process") -> None:
     raise NotImplementedError from _wait_child_exiting_error  # pragma: no cover
 
 
-def create_pipe_to_child_stdin() -> Tuple[SendStream, int]:
+def create_pipe_to_child_stdin() -> Tuple["ClosableSendStream", int]:
     """Create a new pipe suitable for sending data from this
     process to the standard input of a child we're about to spawn.
 
@@ -43,7 +54,7 @@ def create_pipe_to_child_stdin() -> Tuple[SendStream, int]:
     raise NotImplementedError from _create_child_pipe_error  # pragma: no cover
 
 
-def create_pipe_from_child_output() -> Tuple[ReceiveStream, int]:
+def create_pipe_from_child_output() -> Tuple["ClosableReceiveStream", int]:
     """Create a new pipe suitable for receiving data into this
     process from the standard output or error stream of a child
     we're about to spawn.

--- a/trio/_subprocess_platform/__init__.py
+++ b/trio/_subprocess_platform/__init__.py
@@ -19,10 +19,10 @@ if TYPE_CHECKING:
         def close(self) -> None:
             ...
 
-
     class ClosableReceiveStream(ReceiveStream):
         def close(self) -> None:
             ...
+
 
 # Fallback versions of the functions provided -- implementations
 # per OS are imported atop these at the bottom of the module.

--- a/trio/_unix_pipes.py
+++ b/trio/_unix_pipes.py
@@ -67,11 +67,10 @@ class _FdHolder:
     def __del__(self):
         self._raw_close()
 
-    async def aclose(self):
+    def close(self):
         if not self.closed:
             trio.lowlevel.notify_closing(self.fd)
             self._raw_close()
-        await trio.lowlevel.checkpoint()
 
 
 class FdStream(Stream, metaclass=Final):
@@ -180,8 +179,12 @@ class FdStream(Stream, metaclass=Final):
 
             return data
 
+    def close(self):
+        self._fd_holder.close()
+
     async def aclose(self):
-        await self._fd_holder.aclose()
+        self.close()
+        await trio.lowlevel.checkpoint()
 
     def fileno(self):
         return self._fd_holder.fd

--- a/trio/tests/test_subprocess.py
+++ b/trio/tests/test_subprocess.py
@@ -550,8 +550,11 @@ async def test_run_process_background_fail():
             proc = await nursery.start(run_process, EXIT_FALSE)
     assert proc.returncode == 1
 
-@pytest.mark.skipif(not SyncPath("/dev/fd").exists(),
-                    reason="requires a way to iterate through open files")
+
+@pytest.mark.skipif(
+    not SyncPath("/dev/fd").exists(),
+    reason="requires a way to iterate through open files",
+)
 async def test_for_leaking_fds():
     starting_fds = set(SyncPath("/dev/fd").iterdir())
     await run_process(EXIT_TRUE)


### PR DESCRIPTION
If subprocess spawning fails (i.e. unsuccessful call to `exec`), the
created trio resources (i.e. the trio ends of the pipes that will be
used to send/receive data to the child) don't get cleaned up until the
next garbage collection run (which will call their `__del__`).

It would be nicer if this was deterministic, and that resources
created during the run of `open_process` were either completely
transferred to the `Process` object (which can take over the
management of them) or cleaned up (on failure).

To implement this, two ExitStacks are used: One will manage the
resources that need cleaned up unconditionally (the child ends of the
pipe); the other will manage the resources that need cleaned up on
failure.

Trio currently supports versions of python that lack
`contextlib.AsyncExitStack`. While there is a backport for 3.6
available on PyPI, the objects that represent the pipes (_FdHolder and
_HandleHolder) don't really need to have an async close. They are
internal implementation details anyway, so this refactors their
implementation to have the Stream/AsyncResource methods on the actual
Stream objects themselves. This allows us to use the regular ExitStack
and avoid an extra dep