### PR TITLE
Fix documentation references to `socket.socket`

### DIFF
--- a/docs/source/reference-io.rst
+++ b/docs/source/reference-io.rst
@@ -301,7 +301,7 @@ library socket into a Trio socket:
 
 .. autofunction:: from_stdlib_socket
 
-Unlike :func:`socket.socket`, :func:`trio.socket.socket` is a
+Unlike :class:`socket.socket`, :func:`trio.socket.socket` is a
 function, not a class; if you want to check whether an object is a
 Trio socket, use ``isinstance(obj, trio.socket.SocketType)``.
 
@@ -380,7 +380,7 @@ Socket objects
      additional error checking.
 
    In addition, the following methods are similar to the equivalents
-   in :func:`socket.socket`, but have some Trio-specific quirks:
+   in :class:`socket.socket`, but have some Trio-specific quirks:
 
    .. method:: connect
       :async:
@@ -421,7 +421,7 @@ Socket objects
       False otherwise.
 
    The following methods are identical to their equivalents in
-   :func:`socket.socket`, except async, and the ones that take address
+   :class:`socket.socket`, except async, and the ones that take address
    arguments require pre-resolved addresses:
 
    * :meth:`~socket.socket.accept`
@@ -437,7 +437,7 @@ Socket objects
    * :meth:`~socket.socket.sendmsg` (if available)
 
    All methods and attributes *not* mentioned above are identical to
-   their equivalents in :func:`socket.socket`:
+   their equivalents in :class:`socket.socket`:
 
    * :attr:`~socket.socket.family`
    * :attr:`~socket.socket.type`

--- a/trio/_socket.py
+++ b/trio/_socket.py
@@ -231,7 +231,7 @@ async def getprotobyname(name):
 
 
 def from_stdlib_socket(sock):
-    """Convert a standard library :func:`socket.socket` object into a Trio
+    """Convert a standard library :class:`socket.socket` object into a Trio
     socket object.
 
     """
@@ -271,7 +271,7 @@ def socket(
     proto=0,
     fileno=None,
 ):
-    """Create a new Trio socket, like :func:`socket.socket`.
+    """Create a new Trio socket, like :class:`socket.socket`.
 
     This function's behavior can be customized using
     :func:`set_custom_socket_factory`.


### PR DESCRIPTION
This is a class in the stdlib, not a function. I didn't really dig
into why/when sphinx decided to get fussy about it.

I tested this by building the docs and clicking the link on one of the
changed sites, and it took me to the right place in the Python stdlib docs