### PR TITLE
docs: fix minor code example issues

### DIFF
--- a/docs/source/reference-lowlevel.rst
+++ b/docs/source/reference-lowlevel.rst
@@ -701,8 +701,8 @@ can use as a model::
 
     # A tiny Trio program
     async def trio_main():
-        for i in range(5):
-            print(f"Hello from Trio!")
+        for _ in range(5):
+            print("Hello from Trio!")
             # This is inside Trio, so we have to use Trio APIs
             await trio.sleep(1)
         return "trio done!"


### PR DESCRIPTION
Remove redundant f-string. Replace redundant loop variable with underscore.