### PR TITLE
Improve stability of tests_subprocess

### DIFF
--- a/trio/tests/test_subprocess.py
+++ b/trio/tests/test_subprocess.py
@@ -17,7 +17,6 @@ from .. import (
     sleep_forever,
     Process,
     run_process,
-    TrioDeprecationWarning,
     ClosedResourceError,
 )
 from ..lowlevel import open_process
@@ -41,7 +40,11 @@ def python(code):
 EXIT_TRUE = python("sys.exit(0)")
 EXIT_FALSE = python("sys.exit(1)")
 CAT = python("sys.stdout.buffer.write(sys.stdin.buffer.read())")
-SLEEP = lambda seconds: python("import time; time.sleep({})".format(seconds))
+
+if posix:
+    SLEEP = lambda seconds: ["/bin/sleep", str(seconds)]
+else:
+    SLEEP = lambda seconds: python("import time; time.sleep({})".format(seconds))
 
 
 def got_signal(proc, sig):


### PR DESCRIPTION
On macOS, there appears to be some sort of race where sending SIGTERM
to a process "too early" in its lifetime causes the exit status to
appear as if SIGKILL was sent.
I can reproduce this with the stdlib subprocess. Additionally, this
problem doesn't occur if there is a tiny sleep between spawning a
child subprocess and terminating it.

My proposal is to use `/bin/sleep` on posix (which reliably does not
have this issue on macOS) and continue using the Python form elsewhere.

Related to #851. Originally submitted as #2190 (I was a bit too hasty in cleaning up my old branches)