### PR TITLE
✨ Add alternative APIs that improve typing and tooling support (e.g. autocompletion)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include LICENSE LICENSE.MIT LICENSE.APACHE2
 include README.rst
 include CODE_OF_CONDUCT.md CONTRIBUTING.md
 include test-requirements.txt
+include trio/py.typed
 recursive-include trio/tests/test_ssl_certs *.pem
 recursive-include docs *
 prune docs/build

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -973,7 +973,7 @@ class Nursery(metaclass=NoPublicConstructor):
     ) -> Callable[T_ParamSpec, None]:
         def wrapper(*args: T_ParamSpec.args, **kwargs: T_ParamSpec.kwargs) -> None:
             partial_f = functools.partial(async_fn, *args, **kwargs)
-            return self.start_soon(partial_f, name=name)
+            self.start_soon(partial_f, name=name)
 
         return wrapper
 

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -806,7 +806,7 @@ class NurseryManager:
     """
 
     @enable_ki_protection
-    async def __aenter__(self):
+    async def __aenter__(self) -> "Nursery":
         self._scope = CancelScope()
         self._scope.__enter__()
         self._nursery = Nursery._create(current_task(), self._scope)
@@ -845,7 +845,7 @@ class NurseryManager:
         assert False, """Never called, but should be defined"""
 
 
-def open_nursery():
+def open_nursery() -> NurseryManager:
     """Returns an async context manager which must be used to create a
     new `Nursery`.
 

--- a/trio/from_thread.py
+++ b/trio/from_thread.py
@@ -4,4 +4,5 @@ an external thread by means of a Trio Token present in Thread Local Storage
 """
 
 from ._threads import from_thread_run as run
+from ._threads import from_thread_syncify as syncify
 from ._threads import from_thread_run_sync as run_sync

--- a/trio/to_thread.py
+++ b/trio/to_thread.py
@@ -1,2 +1,3 @@
 from ._threads import to_thread_run_sync as run_sync
+from ._threads import to_thread_asyncify as asyncify
 from ._threads import current_default_thread_limiter


### PR DESCRIPTION
✨ Add alternative APIs that improve typing and tooling support (e.g. autocompletion in editors)

## Description

I want to propose adding a new API style for three functions (additional to the current API) that would take advantage of new type annotations ([PEP 612 - Parameter Specification Variables](https://www.python.org/dev/peps/pep-0612/)), to get better tooling and editor support.

In particular, this would allow/support **mypy** checks, **inline editor errors**, and ✨ **autocompletion** ✨ for positional and **keyword arguments** for:

* Sending async tasks in a nursery (equivalent to `nursery.start_soon()`)
* Sending blocking tasks to a worker thread (equivalent to `to_thread.run_sync()`)
* Sending async tasks to the main async loop from a worker thread (equivalent to `from_thread.run()`)

This would also allow mypy and editors to provide type checks, autocompletion, etc. for the **return values** received when sending tasks to a worker thread and when receiving them from a worker thread:

* Equivalent to `to_thread.run_sync()`
* Equivalent to `from_thread.run()`

## Previous Discussion

I proposed this in AnyIO here: https://github.com/agronholm/anyio/pull/403

I was pointed out at the discussion here: https://github.com/python-trio/trio/issues/470

That discussion revolves mainly around accepting keyword arguments for functions called, and this is also related to that. But one of the main things I want from this is better tooling and editor support: **autocompletion** and **inline errors**... not only supporting kwargs. So I thought it was worth sharing this additional perspective.

## Usage

The main difference is that instead of having a function that takes the function to call plus:

* positional arguments (and that requires using partials for keyword arguments)
* configs (like task name)

```Python
trio_function(worker_function, arg1, arg2)
```

...this new API only takes the function to call plus Trio-specific configs (like the task name), and then *returns* another function that takes the positional and keyword arguments. And when that function is called, it does the actual work. So it's used like this:

```Python
trio_functionify(worker_function)(arg1, arg2)
```

And now it also supports keyword arguments, not only positional ones, so it's not necessary to use (and understand) partials to use keyword arguments:

```Python
trio_functionify(worker_function)(arg1, arg2, kwarg1="a", kwarg2="b")
```

...but the main benefit, from my point of view, is actually better typing/tooling support. Autocompletion and inline type errors in the editor and mypy.

## Examples

### Nursery

```Python
import trio


async def program() -> None:
    async def worker(i: int, message: str = "Default worker"):
        print(f"{message} - worker {i}")

    async with trio.open_nursery() as nursery:
        for i in range(3):
            nursery.soonify(worker)(i=i, message="Hello ")


trio.run(program)
```

* Autocompletion for a nursery:

![Selection_032](https://user-images.githubusercontent.com/1326112/147409505-462880f8-15e7-4543-831a-9b01ddc53249.png)

* Inline errors for a nursery:

![Selection_033](https://user-images.githubusercontent.com/1326112/147409518-f3158d43-0453-44ec-acb4-8c3b67486b8b.png)

* Mypy error detection:

```
main.py:10: error: Too few arguments
Found 1 error in 1 file (checked 1 source file)
```

### To Thread (asyncify)

```Python
import time
import trio


def run_slow(i: int, message: str = "Hello ") -> str:
    time.sleep(i)
    return message + str(i)


async def program() -> None:
    for i in range(3):
        result = await trio.to_thread.asyncify(run_slow)(i=i)
        result + 3
        print(result)


trio.run(program)
```

* Autocompletion for sending to worker thread:

![Selection_034](https://user-images.githubusercontent.com/1326112/147409944-0a65bab5-44aa-49e2-8984-97b4319e8098.png)

* Inline errors for sending to worker thread:

![Selection_035](https://user-images.githubusercontent.com/1326112/147409951-684768d3-686c-437b-a0a1-dee64fda5926.png)

* Autocompletion for result value:

![Selection_036](https://user-images.githubusercontent.com/1326112/147409959-ca9577f0-8339-4c1f-a9d1-cb0908c14ff2.png)

* Inline errors for result value:

![Selection_037](https://user-images.githubusercontent.com/1326112/147409969-cf505e11-b9da-4d7f-b54b-ee3a769c9dc6.png)

* Mypy error detection:

```
main.py:13: error: Unsupported operand types for + ("str" and "int")
Found 1 error in 1 file (checked 1 source file)
```

### From Thread (syncify)

```Python
import trio


async def aio_run_slow(i: int, message: str = "Async Hello ") -> str:
    await trio.sleep(i)
    return message + str(i)


def run_slow_embed(i: int) -> str:
    result = trio.from_thread.syncify(aio_run_slow)(i=i, message="Hello sincify ")
    return result


async def program() -> None:
    for i in range(3):
        result = await trio.to_thread.asyncify(run_slow_embed)(i=i)
        print(result)


trio.run(program)
```

* Autocompletion for sending from worker thread:

![Selection_038](https://user-images.githubusercontent.com/1326112/147409987-b61d455e-6419-4574-b715-2108673b86bf.png)

* Inline errors for sending from worker thread:

![Selection_039](https://user-images.githubusercontent.com/1326112/147409999-c58d67bc-15e2-4e33-8332-ce6c792d169c.png)

* Autocompletion for result value:

![Selection_040](https://user-images.githubusercontent.com/1326112/147410022-51812358-b0bc-4c14-93dd-c77b59b078a9.png)

* Inline errors for result value:

![Selection_041](https://user-images.githubusercontent.com/1326112/147410033-2e9d5391-7e14-41dd-8a6c-ca50b2458626.png)

* Mypy error detection:

```
main.py:11: error: Unsupported operand types for + ("str" and "int")
Found 1 error in 1 file (checked 1 source file)
```

## Function names Bikeshedding

I wanted to have short function names that were descriptive enough, that's why the "somethingify".

I thought any more descriptive variant like `generate_async_function_that_calls_run_sync` would be too long. :sweat_smile: 

My rationale is that if a user wants to call a blocking function while inside async stuff, the user might want to have a way to "asyncify" that blocking function. And also the "somethingify" doesn't imply it is being executed/called right away, but that something is "converted" in some way. I would hope that would help with the intuition that it just returns another function that is then called, so it's necessary to add the extra chained parenthesis with any possible needed arguments.

But of course, I can change the names if there's another preference.

## Tests and Docs

I want to gather feedback first before writing tests and docs, but I'll add them if this or something like this is acceptable.

## Type Annotations

I'm also adding the bare minimum type annotation stuff to make it all work with mypy.

## Note on AnyIO

I want to have this on AnyIO: https://github.com/agronholm/anyio/pull/403, but AnyIO would want any decision to be taken here first, so I'm making the PR here as well, even if just as a conversation starter.

## Note on FastAPI

I want to have this type of interface for users and myself, I use **autocompletion** and tooling/types a lot. I thought of adding something like this to FastAPI itself, but I think this would really belong here in Trio and AnyIO, not in FastAPI.

I also intend to add it to the FastAPI docs to explain "advanced" use cases with concurrency and blocking code in threads run from async code, etc. I would like to **document** all those things **in FastAPI** referring to and explaining these libraries directly (AnyIO, Trio), instead of writing wrappers in FastAPI or anything else. :nerd_face:

As I see this (in particular taking kwargs) is quite debated, ~I'm considering building~ *I built* a small package *([Asyncer](https://github.com/tiangolo/asyncer))* just with those wrappers, documenting it as highly experimental and subjective (to my point of view). Maybe that could help gauge how useful that API style is for Trio and AnyIO before making any commitments. I don't like the feel of "yet another library", but it might help separate what is more stable (Trio and AnyIO) and what is a Frankenstein temporary experiment (this idea I'm proposing).

**2022-01-08 Edit**: I built [Asyncer](https://github.com/tiangolo/asyncer) to try out this API design. :nerd_face: 