### PR TITLE
subprocess - Fix a bug where trio isn't notified about pidfd closes

### DIFF
--- a/trio/tests/test_subprocess.py
+++ b/trio/tests/test_subprocess.py
@@ -1,27 +1,27 @@
 import os
+import random
 import signal
 import subprocess
 import sys
+from functools import partial
 from pathlib import Path as SyncPath
 
 import pytest
-import random
-from functools import partial
 from async_generator import asynccontextmanager
 
 from .. import (
+    ClosedResourceError,
+    Process,
     _core,
-    move_on_after,
     fail_after,
+    move_on_after,
+    run_process,
     sleep,
     sleep_forever,
-    Process,
-    run_process,
-    ClosedResourceError,
 )
+from .._core.tests.tutil import skip_if_fbsd_pipes_broken, slow
 from ..lowlevel import open_process
-from .._core.tests.tutil import slow, skip_if_fbsd_pipes_broken
-from ..testing import wait_all_tasks_blocked
+from ..testing import assert_no_checkpoints, wait_all_tasks_blocked
 
 posix = os.name == "posix"
 if posix:
@@ -570,3 +570,28 @@ async def test_for_leaking_fds():
     with pytest.raises(PermissionError):
         await run_process(["/dev/fd/0"])
     assert set(SyncPath("/dev/fd").iterdir()) == starting_fds
+
+
+async def test_subprocess_pidfd_unnotified():
+    noticed_exit = None
+
+    async def wait_and_tell(proc) -> None:
+        nonlocal noticed_exit
+        noticed_exit = False
+        await proc.wait()
+        noticed_exit = True
+
+    proc = await open_process(SLEEP(9999))
+    async with _core.open_nursery() as nursery:
+        nursery.start_soon(wait_and_tell, proc)
+        await wait_all_tasks_blocked()
+        assert noticed_exit is False
+        proc.terminate()
+        # without giving trio a chance to do so,
+        with assert_no_checkpoints():
+            # wait until the process has actually exited;
+            proc._proc.wait()
+            # force a call to poll (that closes the pidfd on linux)
+            proc.poll()
+        await wait_all_tasks_blocked()
+        assert noticed_exit, "child task wasn't woken after poll, DEADLOCK"


### PR DESCRIPTION
If you have
  1. Task A blocks in `Process.wait`
  2. The child process exits
  3. Task B calls `Process.returncode`

(3) will close the pidfd, but nothing will ever wake up Task A, since
trio wasn't notified.

I noticed this when I wrote a `deliver_cancel` function that was slow
enough that the child actually exited before the call to
`Process.returncode`. In the default `_posix_deliver_cancel`, everything is so
fast that the usual ordering is that (3) comes before (2), and there
isn't an early call to `_pidfd_close`.

This fixes the bug by ensuring we notify trio about closing the pidfd
when we do it!