### PR TITLE
Bump ipython to 7.31.1

### DIFF
--- a/test-requirements.in
+++ b/test-requirements.in
@@ -1,7 +1,8 @@
 # For tests
 pytest >= 5.0         # for faulthandler in core
 pytest-cov >= 2.6.0
-ipython               # for the IPython traceback integration tests
+# ipython 7.x is the last major version supporting Python 3.7
+ipython ~= 7.31       # for the IPython traceback integration tests
 pyOpenSSL             # for the ssl tests
 trustme               # for the ssl tests
 pylint                # for pylint finding all symbols tests

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -38,9 +38,15 @@ idna==3.3
     # via
     #   -r test-requirements.in
     #   trustme
+importlib-metadata==4.2.0
+    # via
+    #   click
+    #   flake8
+    #   pluggy
+    #   pytest
 iniconfig==1.1.1
     # via pytest
-ipython==7.29.0
+ipython==7.31.1
     # via -r test-requirements.in
 isort==5.9.3
     # via pylint
@@ -130,15 +136,26 @@ traitlets==5.1.1
     #   matplotlib-inline
 trustme==0.9.0
     # via -r test-requirements.in
+typed-ast==1.4.3 ; implementation_name == "cpython" and python_version < "3.8"
+    # via
+    #   -r test-requirements.in
+    #   astroid
+    #   black
+    #   mypy
 typing-extensions==4.0.1 ; implementation_name == "cpython"
     # via
     #   -r test-requirements.in
+    #   astroid
     #   black
+    #   importlib-metadata
     #   mypy
+    #   pylint
 wcwidth==0.2.5
     # via prompt-toolkit
 wrapt==1.13.3
     # via astroid
+zipp==3.7.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
GitHub keeps annoying me about https://github.com/advisories/GHSA-pq7m-3gw7-gq5x so I figured I would cave in and update to 7.x (since 8.x does not support Python 3.7).

I also made sure to run pip-compile using Python 3.7, which restores a few dependencies that are probably not needed with later versions.