### PR TITLE
Merge two competing newsfragments

### DIFF
--- a/newsfragments/1104.feature.rst
+++ b/newsfragments/1104.feature.rst
@@ -1,3 +1,9 @@
 You can now conveniently spawn a child process in a background task
 and interact it with on the fly using ``process = await
 nursery.start(run_process, ...)``. See `run_process` for more details.
+We recommend most users switch to this new API. Also note that:
+
+- ``trio.open_process`` has been deprecated in favor of
+  `trio.lowlevel.open_process`,
+- The ``aclose`` method on `Process` has been deprecated along with
+  ``async with process_obj``.

--- a/newsfragments/1104.removal.rst
+++ b/newsfragments/1104.removal.rst
@@ -1,5 +1,0 @@
-``trio.open_process`` has been renamed to
-`trio.lowlevel.open_process`, and the ``aclose`` method on `Process`
-has been deprecated, along with ``async with process_obj``. We
-recommend most users switch to the new
-``nursery.start(trio.run_process, ...)`` API instead.


### PR DESCRIPTION
It turns out towncrier will ignore the removal and only consider the
feature, which means we have to merge them.