### PR TITLE
Python 3.11: traceback_exception_init() has new keyword arguments

### DIFF
--- a/trio/_core/_multierror.py
+++ b/trio/_core/_multierror.py
@@ -420,6 +420,7 @@ def traceback_exception_init(
                         # copy the set of _seen exceptions so that duplicates
                         # shared between sub-exceptions are not omitted
                         _seen=None if seen_was_none else set(_seen),
+                        **kwargs
                     )
                 )
         self.embedded = embedded

--- a/trio/_core/_multierror.py
+++ b/trio/_core/_multierror.py
@@ -383,7 +383,7 @@ def traceback_exception_init(
     capture_locals=False,
     compact=False,
     _seen=None,
-    **kwargs
+    **kwargs,
 ):
     if sys.version_info >= (3, 10):
         kwargs["compact"] = compact

--- a/trio/_core/_multierror.py
+++ b/trio/_core/_multierror.py
@@ -420,7 +420,7 @@ def traceback_exception_init(
                         # copy the set of _seen exceptions so that duplicates
                         # shared between sub-exceptions are not omitted
                         _seen=None if seen_was_none else set(_seen),
-                        **kwargs
+                        **kwargs,
                     )
                 )
         self.embedded = embedded

--- a/trio/_core/_multierror.py
+++ b/trio/_core/_multierror.py
@@ -383,11 +383,10 @@ def traceback_exception_init(
     capture_locals=False,
     compact=False,
     _seen=None,
+    **kwargs
 ):
     if sys.version_info >= (3, 10):
-        kwargs = {"compact": compact}
-    else:
-        kwargs = {}
+        kwargs["compact"] = compact
 
     # Capture the original exception and its cause and context as TracebackExceptions
     traceback_exception_original_init(


### PR DESCRIPTION
This avoids:

    ============================= test session starts ==============================
    platform linux -- Python 3.11.0a6, pytest-7.1.1, pluggy-1.0.0
    rootdir: .../trio, configfile: pyproject.toml
    collected 213 items

    trio/_core/tests/test_asyncgen.py .
    INTERNALERROR> Traceback (most recent call last):
    INTERNALERROR>   File ".../trio/__venv__/lib64/python3.11/site-packages/_pytest/main.py", line 268, in wrap_session
    INTERNALERROR>     session.exitstatus = doit(config, session) or 0
    INTERNALERROR>                          ^^^^^^^^^^^^^^^^^^^^^
    INTERNALERROR>   File ".../trio/__venv__/lib64/python3.11/site-packages/_pytest/main.py", line 322, in _main
    INTERNALERROR>     config.hook.pytest_runtestloop(session=session)
    INTERNALERROR>     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    INTERNALERROR>   File ".../trio/__venv__/lib64/python3.11/site-packages/pluggy/_hooks.py", line 265, in __call__
    INTERNALERROR>     return self._hookexec(self.name, self.get_hookimpls(), kwargs, firstresult)
    INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    INTERNALERROR>   File ".../trio/__venv__/lib64/python3.11/site-packages/pluggy/_manager.py", line 80, in _hookexec
    INTERNALERROR>     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
    INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    INTERNALERROR>   File ".../trio/__venv__/lib64/python3.11/site-packages/pluggy/_callers.py", line 60, in _multicall
    INTERNALERROR>     return outcome.get_result()
    INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^
    INTERNALERROR>   File ".../trio/__venv__/lib64/python3.11/site-packages/pluggy/_result.py", line 60, in get_result
    INTERNALERROR>     raise ex[1].with_traceback(ex[2])
    INTERNALERROR>     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    INTERNALERROR>   File ".../trio/__venv__/lib64/python3.11/site-packages/pluggy/_callers.py", line 39, in _multicall
    INTERNALERROR>     res = hook_impl.function(*args)
    INTERNALERROR>           ^^^^^^^^^^^^^^^^^^^^^^^^^
    INTERNALERROR>   File ".../trio/__venv__/lib64/python3.11/site-packages/_pytest/main.py", line 347, in pytest_runtestloop
    INTERNALERROR>     item.config.hook.pytest_runtest_protocol(item=item, nextitem=nextitem)
    INTERNALERROR>     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    INTERNALERROR>   File ".../trio/__venv__/lib64/python3.11/site-packages/pluggy/_hooks.py", line 265, in __call__
    INTERNALERROR>     return self._hookexec(self.name, self.get_hookimpls(), kwargs, firstresult)
    INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    INTERNALERROR>   File ".../trio/__venv__/lib64/python3.11/site-packages/pluggy/_manager.py", line 80, in _hookexec
    INTERNALERROR>     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
    INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    INTERNALERROR>   File ".../trio/__venv__/lib64/python3.11/site-packages/pluggy/_callers.py", line 60, in _multicall
    INTERNALERROR>     return outcome.get_result()
    INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^
    INTERNALERROR>   File ".../trio/__venv__/lib64/python3.11/site-packages/pluggy/_result.py", line 60, in get_result
    INTERNALERROR>     raise ex[1].with_traceback(ex[2])
    INTERNALERROR>     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    INTERNALERROR>   File ".../trio/__venv__/lib64/python3.11/site-packages/pluggy/_callers.py", line 39, in _multicall
    INTERNALERROR>     res = hook_impl.function(*args)
    INTERNALERROR>           ^^^^^^^^^^^^^^^^^^^^^^^^^
    INTERNALERROR>   File ".../trio/__venv__/lib64/python3.11/site-packages/_pytest/runner.py", line 111, in pytest_runtest_protocol
    INTERNALERROR>     runtestprotocol(item, nextitem=nextitem)
    INTERNALERROR>     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    INTERNALERROR>   File ".../trio/__venv__/lib64/python3.11/site-packages/_pytest/runner.py", line 130, in runtestprotocol
    INTERNALERROR>     reports.append(call_and_report(item, "call", log))
    INTERNALERROR>                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    INTERNALERROR>   File ".../trio/__venv__/lib64/python3.11/site-packages/_pytest/runner.py", line 221, in call_and_report
    INTERNALERROR>     report: TestReport = hook.pytest_runtest_makereport(item=item, call=call)
    INTERNALERROR>                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    INTERNALERROR>   File ".../trio/__venv__/lib64/python3.11/site-packages/pluggy/_hooks.py", line 265, in __call__
    INTERNALERROR>     return self._hookexec(self.name, self.get_hookimpls(), kwargs, firstresult)
    INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    INTERNALERROR>   File ".../trio/__venv__/lib64/python3.11/site-packages/pluggy/_manager.py", line 80, in _hookexec
    INTERNALERROR>     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
    INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    INTERNALERROR>   File ".../trio/__venv__/lib64/python3.11/site-packages/pluggy/_callers.py", line 55, in _multicall
    INTERNALERROR>     gen.send(outcome)
    INTERNALERROR>     ^^^^^^^^^^^^^^^^^
    INTERNALERROR>   File ".../trio/__venv__/lib64/python3.11/site-packages/_pytest/skipping.py", line 265, in pytest_runtest_makereport
    INTERNALERROR>     rep = outcome.get_result()
    INTERNALERROR>           ^^^^^^^^^^^^^^^^^^^^
    INTERNALERROR>   File ".../trio/__venv__/lib64/python3.11/site-packages/pluggy/_result.py", line 60, in get_result
    INTERNALERROR>     raise ex[1].with_traceback(ex[2])
    INTERNALERROR>     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    INTERNALERROR>   File ".../trio/__venv__/lib64/python3.11/site-packages/pluggy/_callers.py", line 39, in _multicall
    INTERNALERROR>     res = hook_impl.function(*args)
    INTERNALERROR>           ^^^^^^^^^^^^^^^^^^^^^^^^^
    INTERNALERROR>   File ".../trio/__venv__/lib64/python3.11/site-packages/_pytest/runner.py", line 365, in pytest_runtest_makereport
    INTERNALERROR>     return TestReport.from_item_and_call(item, call)
    INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    INTERNALERROR>   File ".../trio/__venv__/lib64/python3.11/site-packages/_pytest/reports.py", line 345, in from_item_and_call
    INTERNALERROR>     longrepr = item.repr_failure(excinfo)
    INTERNALERROR>                ^^^^^^^^^^^^^^^^^^^^^^^^^^
    INTERNALERROR>   File ".../trio/__venv__/lib64/python3.11/site-packages/_pytest/python.py", line 1795, in repr_failure
    INTERNALERROR>     return self._repr_failure_py(excinfo, style=style)
    INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    INTERNALERROR>   File ".../trio/__venv__/lib64/python3.11/site-packages/_pytest/nodes.py", line 475, in _repr_failure_py
    INTERNALERROR>     return excinfo.getrepr(
    INTERNALERROR>            ^^^^^^^^^^^^^^^^
    INTERNALERROR>   File ".../trio/__venv__/lib64/python3.11/site-packages/_pytest/_code/code.py", line 666, in getrepr
    INTERNALERROR>     return fmt.repr_excinfo(self)
    INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^^^
    INTERNALERROR>   File ".../trio/__venv__/lib64/python3.11/site-packages/_pytest/_code/code.py", line 926, in repr_excinfo
    INTERNALERROR>     reprtraceback = self.repr_traceback(excinfo_)
    INTERNALERROR>                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    INTERNALERROR>   File ".../trio/__venv__/lib64/python3.11/site-packages/_pytest/_code/code.py", line 867, in repr_traceback
    INTERNALERROR>     reprentry = self.repr_traceback_entry(entry, einfo)
    INTERNALERROR>                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    INTERNALERROR>   File ".../trio/__venv__/lib64/python3.11/site-packages/_pytest/_code/code.py", line 818, in repr_traceback_entry
    INTERNALERROR>     s = self.get_source(source, line_index, excinfo, short=short)
    INTERNALERROR>         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    INTERNALERROR>   File ".../trio/__venv__/lib64/python3.11/site-packages/_pytest/_code/code.py", line 756, in get_source
    INTERNALERROR>     lines.extend(self.get_exconly(excinfo, indent=indent, markall=True))
    INTERNALERROR>                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    INTERNALERROR>   File ".../trio/__venv__/lib64/python3.11/site-packages/_pytest/_code/code.py", line 768, in get_exconly
    INTERNALERROR>     exlines = excinfo.exconly(tryshort=True).split("\n")
    INTERNALERROR>               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    INTERNALERROR>   File ".../trio/__venv__/lib64/python3.11/site-packages/_pytest/_code/code.py", line 585, in exconly
    INTERNALERROR>     lines = format_exception_only(self.type, self.value)
    INTERNALERROR>             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    INTERNALERROR>   File "/usr/lib64/python3.11/traceback.py", line 159, in format_exception_only
    INTERNALERROR>     te = TracebackException(type(value), value, None, compact=True)
    INTERNALERROR>          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    INTERNALERROR>   File ".../trio/trio/_core/_multierror.py", line 393, in traceback_exception_init
    INTERNALERROR>     traceback_exception_original_init(
    INTERNALERROR>     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    INTERNALERROR>   File "/usr/lib64/python3.11/traceback.py", line 718, in __init__
    INTERNALERROR>     cause = TracebackException(
    INTERNALERROR>             ^^^^^^^^^^^^^^^^^^^
    INTERNALERROR> TypeError: traceback_exception_init() got an unexpected keyword argument 'max_group_width'


Closes #2317