### PR TITLE
Make setuptools license field SPDX-compliant

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
     author="Nathaniel J. Smith",
     author_email="njs@pobox.com",
     url="https://github.com/python-trio/trio",
-    license="MIT -or- Apache License 2.0",
+    license="MIT OR Apache-2.0",
     packages=find_packages(),
     install_requires=[
         "attrs >= 19.2.0",  # for eq


### PR DESCRIPTION
https://spdx.org/licenses/
https://spdx.github.io/spdx-spec/SPDX-license-expressions/#d42-disjunctive-or-operator

As approved by @njsmith here: https://gitter.im/python-trio/general?at=6299a6fb4e38f759e29ffb3c