### PR TITLE
Guard rail cancellable argument of thread dispatch

### DIFF
--- a/trio/_threads.py
+++ b/trio/_threads.py
@@ -138,6 +138,7 @@ async def to_thread_run_sync(sync_fn, *args, cancellable=False, limiter=None):
 
     """
     await trio.lowlevel.checkpoint_if_cancelled()
+    cancellable = bool(cancellable)  # raise early if cancellable.__bool__ raises
     if limiter is None:
         limiter = current_default_thread_limiter()
 

--- a/trio/tests/test_threads.py
+++ b/trio/tests/test_threads.py
@@ -738,3 +738,16 @@ async def test_trio_token_weak_referenceable():
     assert isinstance(token, TrioToken)
     weak_reference = weakref.ref(token)
     assert token is weak_reference()
+
+
+async def test_unsafe_cancellable_kwarg():
+
+    # This is a stand in for a numpy ndarray or other objects
+    # that (maybe surprisingly) lack a notion of truthiness
+    class BadBool:
+        def __bool__(self):
+            raise NotImplementedError
+
+    with pytest.raises(NotImplementedError):
+        with _core.CancelScope(deadline=_core.current_time() + 0.01):
+            await to_thread_run_sync(time.sleep(1), cancellable=BadBool())


### PR DESCRIPTION
The cancellable argument is typed bool but at runtime will work with any object with truthiness. However, if someone passes something like an numpy ndarray, with no notion of truthiness, the error is raised in an abort function and causes a TrioInternalError.

There are other unguarded uses of user arguments in abort functions, but they are in the lowlevel namespace, and aren't expected to have robust guardrails.