### PR TITLE
replace Queue with SimpleQueue in thread dispatch

### DIFF
--- a/trio/_threads.py
+++ b/trio/_threads.py
@@ -240,7 +240,7 @@ def _run_fn_as_system_task(cb, fn, *args, context, trio_token=None):
     else:
         raise RuntimeError("this is a blocking function; call it from a thread")
 
-    q = stdlib_queue.Queue()
+    q = stdlib_queue.SimpleQueue()
     trio_token.run_sync_soon(context.run, cb, q, fn, args)
     return q.get().unwrap()
 


### PR DESCRIPTION
Considering this queue exists just to block and receive one object and be destroyed, the more lightweight object should be preferred. It could have been used in the first place except that SimpleQueue was not implemented until python 3.7, and we have only recently dropped 3.6 support.