### PR TITLE
avoid cancel_handle close race with weakref.finalize

### DIFF
--- a/trio/_core/_io_windows.py
+++ b/trio/_core/_io_windows.py
@@ -20,6 +20,7 @@ from ._windows_cffi import (
     INVALID_HANDLE_VALUE,
     raise_winerror,
     _handle,
+    _check,
     ErrorCodes,
     FileFlags,
     AFDPollFlags,
@@ -178,12 +179,6 @@ class CKeys(enum.IntEnum):
     LATE_CANCEL = 2
     FORCE_WAKEUP = 3
     USER_DEFINED = 4  # and above
-
-
-def _check(success):
-    if not success:
-        raise_winerror()
-    return success
 
 
 def _get_underlying_socket(sock, *, which=WSAIoctls.SIO_BASE_HANDLE):

--- a/trio/_core/_windows_cffi.py
+++ b/trio/_core/_windows_cffi.py
@@ -321,3 +321,9 @@ def raise_winerror(winerror=None, *, filename=None, filename2=None):
         _, msg = ffi.getwinerror(winerror)
     # https://docs.python.org/3/library/exceptions.html#OSError
     raise OSError(0, msg, filename, winerror, filename2)
+
+
+def _check(success):
+    if not success:
+        raise_winerror()
+    return success

--- a/trio/_wait_for_object.py
+++ b/trio/_wait_for_object.py
@@ -60,9 +60,9 @@ async def WaitForSingleObject(obj):
             cancellable=True,
             limiter=trio.CapacityLimiter(1),
         )
-    except trio.Cancelled:
-        # Clean up our thread. We get here because this task was cancelled,
-        # so we also want to set the cancel handle to stop the thread.
+    finally:
+        # Clean up our thread. If we get here because this task was cancelled,
+        # we also want to set the cancel handle to stop the thread.
         _check(kernel32.SetEvent(cancel_handle))
 
 

--- a/trio/_wait_for_object.py
+++ b/trio/_wait_for_object.py
@@ -23,7 +23,6 @@ async def WaitForSingleObject(obj):
       OSError: If the handle is invalid, e.g. when it is already closed.
 
     """
-    await trio.lowlevel.checkpoint_if_cancelled()
     # Allow ints or whatever we can convert to a win handle
     handle = _handle(obj)
 
@@ -34,7 +33,7 @@ async def WaitForSingleObject(obj):
     if retcode == ErrorCodes.WAIT_FAILED:
         raise_winerror()
     elif retcode != ErrorCodes.WAIT_TIMEOUT:
-        await trio.lowlevel.cancel_shielded_checkpoint()
+        await trio.lowlevel.checkpoint()
         return
 
     # Wait for a thread that waits for two handles: the handle plus a handle

--- a/trio/tests/test_wait_for_object.py
+++ b/trio/tests/test_wait_for_object.py
@@ -211,8 +211,9 @@ async def test_WaitForSingleObject_slow():
     handle = kernel32.CreateEventA(ffi.NULL, True, False, ffi.NULL)
     t0 = _core.current_time()
 
-    with _timeouts.move_on_after(TIMEOUT):
+    with _timeouts.move_on_after(TIMEOUT) as cs:
         await WaitForSingleObject(handle)
+    assert cs.cancelled_caught
 
     kernel32.CloseHandle(handle)
     t1 = _core.current_time()


### PR DESCRIPTION
Fixes #1271. This is essentially the reference counting scheme from that issue, but python is doing the refcounting. I've also made sure the "nonblocking" case is a full checkpoint, win32 errors don't pass silently, and the logic is protected from `KeyboardInterrupt`.

I wrote this in response to https://github.com/python-trio/trio/pull/1834#issuecomment-1174512119 where @honglei seemed more interested in the bugfix than the features of #1834. (Hopefully you can test this branch in your application?)

Ideally, if someone reviews this they would also have a look at #1834 so I can either close or merge that one.