### PR TITLE
fix typo and extra sleep in test_unsafe_cancellable_kwarg

### DIFF
--- a/trio/tests/test_threads.py
+++ b/trio/tests/test_threads.py
@@ -749,5 +749,4 @@ async def test_unsafe_cancellable_kwarg():
             raise NotImplementedError
 
     with pytest.raises(NotImplementedError):
-        with _core.CancelScope(deadline=_core.current_time() + 0.01):
-            await to_thread_run_sync(time.sleep(1), cancellable=BadBool())
+        await to_thread_run_sync(int, cancellable=BadBool())


### PR DESCRIPTION
removes a subtle early execution of a time.sleep call in the main thread. All the time and deadline stuff is not actually necessary in the happy path.