### PR TITLE
fix deadlock when deliver raises

### DIFF
--- a/trio/_core/_thread_cache.py
+++ b/trio/_core/_thread_cache.py
@@ -1,3 +1,5 @@
+import sys
+import traceback
 from threading import Thread, Lock
 import outcome
 from itertools import count
@@ -67,7 +69,11 @@ class WorkerThread:
         # 'deliver' triggers a new job, it can be assigned to us
         # instead of spawning a new thread.
         self._thread_cache._idle_workers[self] = None
-        deliver(result)
+        try:
+            deliver(result)
+        except BaseException as e:
+            print("Exception while delivering result of thread", file=sys.stderr)
+            traceback.print_exception(type(e), e, e.__traceback__)
 
     def _work(self):
         while True:


### PR DESCRIPTION
I guess I'm building a reputation for finding trio bugs by writing embarrassingly bad code! Raising an exception in `deliver` argument to `start_thread_soon` will cause the next usage of the thread cache to deadlock, since the thread has stopped running but the cache thinks it can still assign jobs to it.

Printing out the traceback and carrying on is the obvious thing to do, but I'm open to suggestions on alternatives!