### PR TITLE
Revert "docs: fix bug in NotVeryGoodLock example"

### DIFF
--- a/docs/source/reference-lowlevel.rst
+++ b/docs/source/reference-lowlevel.rst
@@ -464,10 +464,10 @@ this does serve to illustrate the basic structure of the
            while self._held:
                # Someone else has the lock, so we have to wait.
                task = trio.lowlevel.current_task()
+               self._blocked_tasks.append(task)
                def abort_fn(_):
                    self._blocked_tasks.remove(task)
                    return trio.lowlevel.Abort.SUCCEEDED
-               self._blocked_tasks.append(task)
                await trio.lowlevel.wait_task_rescheduled(abort_fn)
                # At this point the lock was released -- but someone else
                # might have swooped in and taken it again before we

--- a/docs/source/reference-lowlevel.rst
+++ b/docs/source/reference-lowlevel.rst
@@ -460,7 +460,7 @@ this does serve to illustrate the basic structure of the
            self._held = False
 
        async def acquire(self):
-           if self._held:
+           while self._held:
                task = trio.lowlevel.current_task()
                self._blocked_tasks.append(task)
                def abort_fn(_):


### PR DESCRIPTION
Reverts python-trio/trio#2414 per https://gitter.im/python-trio/general?at=631490ca11a6a83d049a8631

also, clarify the code with a comment and by minimizing the scope of acquire's "retry"