### PR TITLE
Introduce a gate/check GHA job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,16 @@ jobs:
           - python: '3.8'  # <- not actually used
             pypy_nightly_branch: 'py3.8'
             extra_name: ', pypy 3.8 nightly'
+    continue-on-error: >-
+      ${{
+        (
+          matrix.check_formatting == '1'
+          || matrix.pypy_nightly_branch == 'py3.7'
+          || endsWith(matrix.python, '-dev')
+        )
+        && true
+        || false
+      }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -138,3 +148,21 @@ jobs:
         env:
           # Should match 'name:' up above
           JOB_NAME: 'macOS (${{ matrix.python }})'
+
+  # https://github.com/marketplace/actions/alls-green#why
+  check:  # This job does nothing and is only used for the branch protection
+
+    if: always()
+
+    needs:
+      - Windows
+      - Ubuntu
+      - macOS
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
This adds a GHA job that reliably determines if all the required dependencies have succeeded or not.

It also allows to reduce the list of required branch protection CI statuses to just one — `check`. This reduces the maintenance burden by a lot and have been battle-tested across a small bunch of projects in its action form and in-house implementations of other people.

It is now in use in aiohttp (and other aio-libs projects), CherryPy, attrs, coveragepy, some of the Ansible repositories, pip-tools, pydantic, spaceship-prompt, Towncrier, all of the jaraco's projects (like `setuptools`, `importlib_metadata`), some PyCQA, PyCA, PyPA and pytest projects, a few AWS Labs projects.

The story behind this is explained in more detail at https://github.com/marketplace/actions/alls-green#why.