### PR TITLE
change the "python" link back to /3 when Python 3.11 is released

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -84,9 +84,8 @@ extensions = [
     'local_customization',
 ]
 
-# FIXME: change the "python" link back to /3 when Python 3.11 is released
 intersphinx_mapping = {
-    "python": ('https://docs.python.org/3.11', None),
+    "python": ('https://docs.python.org/3', None),
     "outcome": ('https://outcome.readthedocs.io/en/latest/', None),
     "pyopenssl": ('https://www.pyopenssl.org/en/stable/', None),
 }


### PR DESCRIPTION
Draft for:
- [x] 3.11 _actually_ being released (oops)