### PR TITLE
Corrected Grammer

### DIFF
--- a/docs/source/reference-core.rst
+++ b/docs/source/reference-core.rst
@@ -748,8 +748,8 @@ callbacks::
             ...  # handle each IndexError
 
     with catch({
-        KeyError: handle_keyerror,
-        IndexError: handle_indexerror
+        KeyError: handle_keyerrors,
+        IndexError: handle_indexerrors
     }):
         async with trio.open_nursery() as nursery:
             nursery.start_soon(broken1)
@@ -764,7 +764,7 @@ inside the handler function(s) with the ``nonlocal`` keyword::
         myflag = True
 
     myflag = False
-    with catch({KeyError: handle_keyerror}):
+    with catch({KeyError: handle_keyerrors}):
         async with trio.open_nursery() as nursery:
             nursery.start_soon(broken1)
 


### PR DESCRIPTION
`handle_keyerror` and `handle_indexerror` should be represented with `(s)` e.g `handle_indexerrors`