### PR TITLE
Add name parameter to to_thread.run_sync [SQUASH]

### DIFF
--- a/newsfragments/1148.feature.rst
+++ b/newsfragments/1148.feature.rst
@@ -1,1 +1,1 @@
-Added support for naming threads created with `to_thread_run_sync`, requires pthreads so is only available on POSIX platforms with glibc installed.
+Added support for naming threads created with `trio.to_thread_run_sync`, requires pthreads so is only available on POSIX platforms with glibc installed.

--- a/newsfragments/1148.feature.rst
+++ b/newsfragments/1148.feature.rst
@@ -1,0 +1,1 @@
+Added support for naming threads created with `to_thread_run_sync`, requires pthreads so is only available on POSIX platforms with glibc installed.

--- a/newsfragments/1148.feature.rst
+++ b/newsfragments/1148.feature.rst
@@ -1,1 +1,1 @@
-Added support for naming threads created with `trio.to_thread_run_sync`, requires pthreads so is only available on POSIX platforms with glibc installed.
+Added support for naming threads created with `trio.to_thread.run_sync`, requires pthreads so is only available on POSIX platforms with glibc installed.

--- a/trio/_core/_thread_cache.py
+++ b/trio/_core/_thread_cache.py
@@ -30,15 +30,6 @@ def get_os_thread_name_func() -> Optional[Callable[[Optional[int], str], None]]:
     pthread_setname_np.restype = ctypes.c_int
 
     return partial(namefunc, pthread_setname_np)
-    ## set the name
-    # try:
-    #    bname = name.encode("ascii", "replace")
-    #    thread = threading.current_thread()
-    #    # if thread is not None:
-    #    thread.name = name
-    #    pthread_setname_np(thread.ident, bname[:15])
-    # except Exception:
-    #    return nofunc
 
 
 set_os_thread_name = get_os_thread_name_func()
@@ -95,8 +86,7 @@ class WorkerThread:
         self._worker_lock.acquire()
         self._default_name = f"Trio thread {next(name_counter)}"
 
-        self._thread = Thread(target=self._work, daemon=True)
-        self._thread.name = self._default_name
+        self._thread = Thread(target=self._work, name=self._default_name, daemon=True)
 
         if set_os_thread_name:
             set_os_thread_name(self._thread.ident, self._default_name)

--- a/trio/_threads.py
+++ b/trio/_threads.py
@@ -1,26 +1,22 @@
 # coding: utf-8
 
 import contextvars
-import threading
-import queue as stdlib_queue
 import functools
+import inspect
+import queue as stdlib_queue
+import threading
 from itertools import count
+from typing import Optional
 
 import attr
-import inspect
 import outcome
 from sniffio import current_async_library_cvar
 
 import trio
 
+from ._core import (RunVar, TrioToken, disable_ki_protection,
+                    enable_ki_protection, start_thread_soon)
 from ._sync import CapacityLimiter
-from ._core import (
-    enable_ki_protection,
-    disable_ki_protection,
-    RunVar,
-    TrioToken,
-    start_thread_soon,
-)
 from ._util import coroutine_or_error
 
 # Global due to Threading API, thread local storage for trio token
@@ -56,9 +52,6 @@ def current_default_thread_limiter():
 @attr.s(frozen=True, eq=False, hash=False)
 class ThreadPlaceholder:
     name = attr.ib()
-
-
-from typing import Optional
 
 
 @enable_ki_protection

--- a/trio/_threads.py
+++ b/trio/_threads.py
@@ -14,8 +14,13 @@ from sniffio import current_async_library_cvar
 
 import trio
 
-from ._core import (RunVar, TrioToken, disable_ki_protection,
-                    enable_ki_protection, start_thread_soon)
+from ._core import (
+    RunVar,
+    TrioToken,
+    disable_ki_protection,
+    enable_ki_protection,
+    start_thread_soon,
+)
 from ._sync import CapacityLimiter
 from ._util import coroutine_or_error
 

--- a/trio/_threads.py
+++ b/trio/_threads.py
@@ -89,7 +89,7 @@ async def to_thread_run_sync(
           if pthread.h is available (i.e. most POSIX installations).
           pthread names are limited to 15 characters, and can be read from
           ``/proc/<PID>/task/<SPID>/comm`` or with ``ps -eT``, among others.
-          Defaults to ``Thread for {trio.lowlevel.current_task().name}``.
+          Defaults to ``{sync_fn.__name__|None} from {trio.lowlevel.current_task().name}``.
       limiter (None, or CapacityLimiter-like object):
           An object used to limit the number of simultaneous threads. Most
           commonly this will be a `~trio.CapacityLimiter`, but it could be
@@ -178,8 +178,7 @@ async def to_thread_run_sync(
     current_trio_token = trio.lowlevel.current_trio_token()
 
     if thread_name is None:
-        # TODO, better default since it caps at 15 chars
-        thread_name = f"Thread for {trio.lowlevel.current_task().name}"
+        thread_name = f"{getattr(sync_fn, '__name__', None)} from {trio.lowlevel.current_task().name}"
 
     def worker_fn():
         current_async_library_cvar.set(None)

--- a/trio/_threads.py
+++ b/trio/_threads.py
@@ -86,7 +86,7 @@ async def to_thread_run_sync(
           arguments, use :func:`functools.partial`.
       cancellable (bool): Whether to allow cancellation of this operation. See
           discussion below.
-      name (str): Optional string to set the name of the thread.
+      thread_name (str): Optional string to set the name of the thread.
           Will always set `threading.Thread.name`, but only set the os name
           if pthread.h is available (i.e. most POSIX installations).
           pthread names are limited to 15 characters, and can be read from

--- a/trio/tests/test_threads.py
+++ b/trio/tests/test_threads.py
@@ -207,11 +207,9 @@ def _get_thread_name(ident: Optional[int] = None) -> Optional[str]:
     libpthread = ctypes.CDLL(libpthread_path)
 
     pthread_getname_np = getattr(libpthread, "pthread_getname_np", None)
-    # this should never fail afaik, but if so just switch the below lines
+
+    # this should never fail on any platforms afaik
     assert pthread_getname_np
-    # if not pthread_getname_np: # pragma: no cover
-    #    print(f"no pthread_getname_np on {sys.platform})")
-    #    return None
 
     # thankfully getname signature doesn't differ between platforms
     pthread_getname_np.argtypes = [


### PR DESCRIPTION
Fixes #1148

This doesn't work on windows, requiring an entirely separate mechanism (https://stackoverflow.com/a/16199587). It should be possible to get working on Mac (https://stackoverflow.com/a/7989973), but not having a mac machine I need the CI to test that for me. BSD variants also might need slightly different code, but I won't bother with that not having a way to test it. I haven't added a decorator on the test, so will probably see failed tests on other OS's for now.

The default in #1148 was suggested to be "Thread for {trio.lowlevel.current_task().name" by @njsmith - but pthread limits thread names to 15 characters so that's kind of a bad default. Wasn't sure what else to have though so that's the current default, but we probably want something else.

I currently set the thread name from within the thread, but it's possible to set it from the parent thread (although maybe not on mac) but the first way I found out of getting a thread id was with `threading.get_ident()` so I did it in the child.

Options for setting the name was `pthread`, `sys/prctl.h` and `libcap.so`. The first should be the one most commonly found on systems, being installed with `glibc` (on my Arch system), https://stackoverflow.com/a/51668422 says `prctl` depends on `libcap-dev` (though it's also bundled with `glibc` on mine), and `libcap.so` is for me dependent on `libcap` which itself depends on `glibc`.


Actually seeing the thread name in `ps` turned out to be flaky with everybody on SO saying different things, only `ps -eT` worked for me.


Making it a draft until it's been tested on other systems.

@Zac-HD 