### PR TITLE
Add address in error message from trio.socket.socket upon connection failure

### DIFF
--- a/newsfragments/1810.feature.rst
+++ b/newsfragments/1810.feature.rst
@@ -1,0 +1,1 @@
+`trio.socket.socket` now prints the address it tried to connect to upon failure.

--- a/trio/_socket.py
+++ b/trio/_socket.py
@@ -688,7 +688,7 @@ class _SocketType(SocketType):
         # Okay, the connect finished, but it might have failed:
         err = self._sock.getsockopt(_stdlib_socket.SOL_SOCKET, _stdlib_socket.SO_ERROR)
         if err != 0:
-            raise OSError(err, "Error in connect: " + os.strerror(err))
+            raise OSError(err, f"Error connecting to {address}: {os.strerror(err)}")
 
     ################################################################
     # recv

--- a/trio/tests/test_socket.py
+++ b/trio/tests/test_socket.py
@@ -723,6 +723,16 @@ async def test_SocketType_connect_paths():
             await sock.connect(("127.0.0.1", 2))
 
 
+# Fix issue #1810
+async def test_address_in_socket_error():
+    address = "127.0.0.1"
+    with tsocket.socket() as sock:
+        try:
+            await sock.connect((address, 2))
+        except OSError as e:
+            assert any(address in str(arg) for arg in e.args)
+
+
 async def test_resolve_address_exception_in_connect_closes_socket():
     # Here we are testing issue 247, any cancellation will leave the socket closed
     with _core.CancelScope() as cancel_scope:


### PR DESCRIPTION
Fixes #1810 (at least the second part, the first I can't reproduce).
Small and easy fix.