### PR TITLE
Add some low-effort type annotations

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,4 @@
 [mypy]
-show_error_codes = True
-
 # Be flexible about dependencies that don't have stubs yet (like pytest)
 ignore_missing_imports = True
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,5 @@
 [mypy]
-# TODO: run mypy against several OS/version combos in CI
-# https://mypy.readthedocs.io/en/latest/command_line.html#platform-configuration
+show_error_codes = True
 
 # Be flexible about dependencies that don't have stubs yet (like pytest)
 ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,7 @@
 [mypy]
+# TODO: run mypy against several OS/version combos in CI
+# https://mypy.readthedocs.io/en/latest/command_line.html#platform-configuration
+
 # Be flexible about dependencies that don't have stubs yet (like pytest)
 ignore_missing_imports = True
 

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -76,7 +76,7 @@ def _count_context_run_tb_frames() -> int:
     try:
         ctx.run(function_with_unique_name_xyzzy)
     except ZeroDivisionError as exc:
-        tb = cast(TracebackType, exc.__traceback__)
+        tb = exc.__traceback__
         # Skip the frame where we caught it
         tb = tb.tb_next
         count = 0

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -12,7 +12,8 @@ import enum
 from contextvars import copy_context
 from math import inf
 from time import perf_counter
-from typing import Callable, Final, NoReturn, TYPE_CHECKING
+from typing import Callable, NoReturn, TYPE_CHECKING
+from typing_extensions import Final
 
 from sniffio import current_async_library_cvar
 

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -1910,8 +1910,8 @@ def run(
     *args,
     clock=None,
     instruments=(),
-    restrict_keyboard_interrupt_to_checkpoints=False,
-    strict_exception_groups=False,
+    restrict_keyboard_interrupt_to_checkpoints: bool = False,
+    strict_exception_groups: bool = False,
 ):
     """Run a Trio-flavored async function, and return the result.
 
@@ -2016,11 +2016,11 @@ def start_guest_run(
     run_sync_soon_threadsafe,
     done_callback,
     run_sync_soon_not_threadsafe=None,
-    host_uses_signal_set_wakeup_fd=False,
+    host_uses_signal_set_wakeup_fd: bool = False,
     clock=None,
     instruments=(),
-    restrict_keyboard_interrupt_to_checkpoints=False,
-    strict_exception_groups=False,
+    restrict_keyboard_interrupt_to_checkpoints: bool = False,
+    strict_exception_groups: bool = False,
 ):
     """Start a "guest" run of Trio on top of some other "host" event loop.
 
@@ -2107,7 +2107,7 @@ _MAX_TIMEOUT = 24 * 60 * 60
 # mode", where our core event loop gets unrolled into a series of callbacks on
 # the host loop. If you're doing a regular trio.run then this gets run
 # straight through.
-def unrolled_run(runner, async_fn, args, host_uses_signal_set_wakeup_fd=False):
+def unrolled_run(runner, async_fn, args, host_uses_signal_set_wakeup_fd: bool = False):
     locals()[LOCALS_KEY_KI_PROTECTION_ENABLED] = True
     __tracebackhide__ = True
 

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -51,7 +51,7 @@ DEADLINE_HEAP_MIN_PRUNE_THRESHOLD: FinalT = 1000
 
 _NO_SEND: FinalT = object()
 
-FnT = TypeVar("FnT", bound=Callable[..., Any])
+FnT = TypeVar("FnT", bound="Callable[..., Any]")
 
 # Decorator to mark methods public. This does nothing by itself, but
 # trio/_tools/gen_exports.py looks for it.

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -12,9 +12,10 @@ import enum
 from contextvars import copy_context
 from math import inf
 from time import perf_counter
-from typing import Callable, NoReturn, TYPE_CHECKING
+from typing import Callable, NoReturn, TypeVar, TYPE_CHECKING
 from typing import Deque
 
+# An unfortunate name collision here with trio._util.Final
 from typing_extensions import Final as FinalT
 
 from sniffio import current_async_library_cvar
@@ -49,6 +50,8 @@ from .._util import Final, NoPublicConstructor, coroutine_or_error
 if sys.version_info < (3, 11):
     from exceptiongroup import BaseExceptionGroup
 
+T = TypeVar("T")
+
 DEADLINE_HEAP_MIN_PRUNE_THRESHOLD: FinalT = 1000
 
 _NO_SEND: FinalT = object()
@@ -56,7 +59,7 @@ _NO_SEND: FinalT = object()
 
 # Decorator to mark methods public. This does nothing by itself, but
 # trio/_tools/gen_exports.py looks for it.
-def _public(fn):
+def _public(fn: T) -> T:
     return fn
 
 
@@ -86,7 +89,7 @@ def _count_context_run_tb_frames() -> int:
             1 / 0
         except ZeroDivisionError:
             raise
-        else:
+        else:  # pragma: no cover
             raise TrioInternalError(
                 "A ZeroDivisionError should have been raised, but it wasn't."
             )
@@ -103,7 +106,7 @@ def _count_context_run_tb_frames() -> int:
             tb = tb.tb_next  # type: ignore[union-attr]
             count += 1
         return count
-    else:
+    else:  # pragma: no cover
         raise TrioInternalError(
             f"The purpose of {function_with_unique_name_xyzzy.__name__} is "
             "to raise a ZeroDivisionError, but it didn't."


### PR DESCRIPTION
This PR adds some uncontroversial annotations to the central `trio.run` method. From my perspective, it is mainly intended as an experiment into whether a gradual, opportunistic approach to adding types to this project is feasible.