### PR TITLE
remove async_generator as dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,6 @@ setup(
     install_requires=[
         "attrs >= 19.2.0",  # for eq
         "sortedcontainers",
-        "async_generator >= 1.9",
         "idna",
         "outcome",
         "sniffio",

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -1,6 +1,7 @@
 # For tests
 pytest >= 5.0         # for faulthandler in core
 pytest-cov >= 2.6.0
+async_generator >= 1.9
 # ipython 7.x is the last major version supporting Python 3.7
 ipython < 7.32        # for the IPython traceback integration tests
 pyOpenSSL >= 22.0.0   # for the ssl + DTLS tests
@@ -26,9 +27,7 @@ typing-extensions; implementation_name == "cpython"
 cffi; os_name == "nt"
 attrs >= 19.2.0
 sortedcontainers
-async_generator >= 1.9
 idna
 outcome
 sniffio
 exceptiongroup >= 1.0.0rc9; python_version < "3.11"
-

--- a/trio/_core/tests/test_asyncgen.py
+++ b/trio/_core/tests/test_asyncgen.py
@@ -1,13 +1,15 @@
 import sys
 import weakref
 import pytest
+import contextlib
 from math import inf
 from functools import partial
-from async_generator import aclosing
+
 from ... import _core
 from .tutil import gc_collect_harder, buggy_pypy_asyncgens, restore_unraisablehook
 
 
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="no aclosing() in stdlib<3.10")
 def test_asyncgen_basics():
     collected = []
 
@@ -46,7 +48,7 @@ def test_asyncgen_basics():
         assert collected.pop() == "abandoned"
 
         # aclosing() ensures it's cleaned up at point of use
-        async with aclosing(example("exhausted 1")) as aiter:
+        async with contextlib.aclosing(example("exhausted 1")) as aiter:
             assert 42 == await aiter.asend(None)
         assert collected.pop() == "exhausted 1"
 
@@ -58,7 +60,7 @@ def test_asyncgen_basics():
         gc_collect_harder()
 
         # No problems saving the geniter when using either of these patterns
-        async with aclosing(example("exhausted 3")) as aiter:
+        async with contextlib.aclosing(example("exhausted 3")) as aiter:
             saved.append(aiter)
             assert 42 == await aiter.asend(None)
         assert collected.pop() == "exhausted 3"

--- a/trio/_util.py
+++ b/trio/_util.py
@@ -11,8 +11,7 @@ from functools import wraps, update_wrapper
 import typing as t
 import threading
 import collections
-
-from async_generator import isasyncgen
+import inspect
 
 import trio
 
@@ -143,6 +142,7 @@ def coroutine_or_error(async_fn, *args):
     # for things like functools.partial objects wrapping an async
     # function. So we have to just call it and then check whether the
     # return value is a coroutine object.
+    # Note: will not be necessary on python>=3.8, see https://bugs.python.org/issue34890
     if not isinstance(coro, collections.abc.Coroutine):
         # Give good error for: nursery.start_soon(func_returning_future)
         if _return_value_looks_like_wrong_library(coro):
@@ -152,7 +152,7 @@ def coroutine_or_error(async_fn, *args):
                 "That won't work without some sort of compatibility shim.".format(coro)
             )
 
-        if isasyncgen(coro):
+        if inspect.isasyncgen(coro):
             raise TypeError(
                 "start_soon expected an async function but got an async "
                 "generator {!r}".format(coro)

--- a/trio/testing/_sequencer.py
+++ b/trio/testing/_sequencer.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
+from contextlib import asynccontextmanager
 
 import attr
-from async_generator import asynccontextmanager
 
 from .. import _core
 from .. import _util

--- a/trio/tests/test_dtls.py
+++ b/trio/tests/test_dtls.py
@@ -4,7 +4,7 @@ import trio.testing
 from trio import DTLSEndpoint
 import random
 import attr
-from async_generator import asynccontextmanager
+from contextlib import asynccontextmanager
 from itertools import count
 
 import trustme

--- a/trio/tests/test_ssl.py
+++ b/trio/tests/test_ssl.py
@@ -7,12 +7,11 @@ import pytest
 import threading
 import socket as stdlib_socket
 import ssl
-from contextlib import contextmanager
+from contextlib import asynccontextmanager, contextmanager
 from functools import partial
 
 from OpenSSL import SSL
 import trustme
-from async_generator import asynccontextmanager
 
 import trio
 from .. import _core

--- a/trio/tests/test_subprocess.py
+++ b/trio/tests/test_subprocess.py
@@ -3,11 +3,11 @@ import random
 import signal
 import subprocess
 import sys
+from contextlib import asynccontextmanager
 from functools import partial
 from pathlib import Path as SyncPath
 
 import pytest
-from async_generator import asynccontextmanager
 
 from .. import (
     ClosedResourceError,


### PR DESCRIPTION
Moved to the section of test dependencies in `test-requirenments.in` but all tests that require it are also guarded with skips. I didn't regenerate `test-requirements.txt` as that led to a couple changes irrelevant to this PR.

I considered giving a deprecation warning if it detects usage of `@async_generator`, but since aclosing() is only available on >=3.10 and trio supports >=3.7 there are still legitimate uses of it.

Thanks to @belm0 for giving the suggestion of handling checking for `@async_generator` that I ultimately went with.

Fixes #2458 