### PR TITLE
Modernize codebase to python 3.7+ standard

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 #
 # Trio documentation build configuration file, created by
 # sphinx-quickstart on Sat Jan 21 19:11:14 2017.
@@ -19,17 +18,20 @@
 #
 import os
 import sys
+
 # For our local_customization module
-sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath("."))
 # For trio itself
-sys.path.insert(0, os.path.abspath('../..'))
+sys.path.insert(0, os.path.abspath("../.."))
 
 # https://docs.readthedocs.io/en/stable/builds.html#build-environment
 if "READTHEDOCS" in os.environ:
     import glob
+
     if glob.glob("../../newsfragments/*.*.rst"):
         print("-- Found newsfragments; running towncrier --", flush=True)
         import subprocess
+
         subprocess.run(
             ["towncrier", "--yes", "--date", "not released yet"],
             cwd="../..",
@@ -66,6 +68,7 @@ default_role = "obj"
 def setup(app):
     app.add_css_file("hackrtd.css")
 
+
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
@@ -76,38 +79,38 @@ def setup(app):
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.intersphinx',
-    'sphinx.ext.coverage',
-    'sphinx.ext.napoleon',
-    'sphinxcontrib_trio',
-    'local_customization',
+    "sphinx.ext.autodoc",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.coverage",
+    "sphinx.ext.napoleon",
+    "sphinxcontrib_trio",
+    "local_customization",
 ]
 
 intersphinx_mapping = {
-    "python": ('https://docs.python.org/3', None),
-    "outcome": ('https://outcome.readthedocs.io/en/latest/', None),
-    "pyopenssl": ('https://www.pyopenssl.org/en/stable/', None),
+    "python": ("https://docs.python.org/3", None),
+    "outcome": ("https://outcome.readthedocs.io/en/latest/", None),
+    "pyopenssl": ("https://www.pyopenssl.org/en/stable/", None),
 }
 
 autodoc_member_order = "bysource"
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #
 # source_suffix = ['.rst', '.md']
-source_suffix = '.rst'
+source_suffix = ".rst"
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = "index"
 
 # General information about the project.
-project = 'Trio'
-copyright = '2017, Nathaniel J. Smith'
-author = 'Nathaniel J. Smith'
+project = "Trio"
+copyright = "2017, Nathaniel J. Smith"
+author = "Nathaniel J. Smith"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -115,6 +118,7 @@ author = 'Nathaniel J. Smith'
 #
 # The short X.Y version.
 import trio
+
 version = trio.__version__
 # The full version, including alpha/beta/rc tags.
 release = version
@@ -136,9 +140,9 @@ language = None
 exclude_patterns = []
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'default'
+pygments_style = "default"
 
-highlight_language = 'python3'
+highlight_language = "python3"
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
@@ -153,13 +157,14 @@ suppress_warnings = ["epub.unknown_project_files"]
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-#html_theme = 'alabaster'
+# html_theme = 'alabaster'
 
 # We have to set this ourselves, not only because it's useful for local
 # testing, but also because if we don't then RTD will throw away our
 # html_theme_options.
 import sphinx_rtd_theme
-html_theme = 'sphinx_rtd_theme'
+
+html_theme = "sphinx_rtd_theme"
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
@@ -174,19 +179,19 @@ html_theme_options = {
     # versions/settings...
     "navigation_depth": 4,
     "logo_only": True,
-    'prev_next_buttons_location': 'both'
+    "prev_next_buttons_location": "both",
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 
 # -- Options for HTMLHelp output ------------------------------------------
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'Triodoc'
+htmlhelp_basename = "Triodoc"
 
 
 # -- Options for LaTeX output ---------------------------------------------
@@ -195,15 +200,12 @@ latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
     #
     # 'papersize': 'letterpaper',
-
     # The font size ('10pt', '11pt' or '12pt').
     #
     # 'pointsize': '10pt',
-
     # Additional stuff for the LaTeX preamble.
     #
     # 'preamble': '',
-
     # Latex figure (float) alignment
     #
     # 'figure_align': 'htbp',
@@ -213,8 +215,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'Trio.tex', 'Trio Documentation',
-     'Nathaniel J. Smith', 'manual'),
+    (master_doc, "Trio.tex", "Trio Documentation", "Nathaniel J. Smith", "manual"),
 ]
 
 
@@ -222,10 +223,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [
-    (master_doc, 'trio', 'Trio Documentation',
-     [author], 1)
-]
+man_pages = [(master_doc, "trio", "Trio Documentation", [author], 1)]
 
 
 # -- Options for Texinfo output -------------------------------------------
@@ -234,7 +232,13 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'Trio', 'Trio Documentation',
-     author, 'Trio', 'One line description of project.',
-     'Miscellaneous'),
+    (
+        master_doc,
+        "Trio",
+        "Trio Documentation",
+        author,
+        "Trio",
+        "One line description of project.",
+        "Miscellaneous",
+    ),
 ]

--- a/docs/source/local_customization.py
+++ b/docs/source/local_customization.py
@@ -2,7 +2,10 @@ from docutils.parsers.rst import directives
 from sphinx import addnodes
 from sphinx.domains.python import PyClasslike
 from sphinx.ext.autodoc import (
-    FunctionDocumenter, MethodDocumenter, ClassLevelDocumenter, Options,
+    FunctionDocumenter,
+    MethodDocumenter,
+    ClassLevelDocumenter,
+    Options,
 )
 
 """
@@ -13,13 +16,15 @@ from sphinx.ext.autodoc import (
 
 """
 
+
 class Interface(PyClasslike):
     def handle_signature(self, sig, signode):
         signode += addnodes.desc_name(sig, sig)
         return sig, ""
 
     def get_index_text(self, modname, name_cls):
-        return "{} (interface in {})".format(name_cls[0], modname)
+        return f"{name_cls[0]} (interface in {modname})"
+
 
 def setup(app):
     app.add_directive_to_domain("py", "interface", Interface)

--- a/docs/source/reference-core/channels-backpressure.py
+++ b/docs/source/reference-core/channels-backpressure.py
@@ -4,6 +4,7 @@
 import trio
 import math
 
+
 async def producer(send_channel):
     count = 0
     while True:
@@ -14,6 +15,7 @@ async def producer(send_channel):
         print("Sent message:", count)
         count += 1
 
+
 async def consumer(receive_channel):
     async for value in receive_channel:
         print("Received message:", value)
@@ -21,10 +23,12 @@ async def consumer(receive_channel):
         # takes 1 second
         await trio.sleep(1)
 
+
 async def main():
     send_channel, receive_channel = trio.open_memory_channel(math.inf)
     async with trio.open_nursery() as nursery:
         nursery.start_soon(producer, send_channel)
         nursery.start_soon(consumer, receive_channel)
+
 
 trio.run(main)

--- a/docs/source/reference-core/channels-mpmc-broken.py
+++ b/docs/source/reference-core/channels-mpmc-broken.py
@@ -3,6 +3,7 @@
 import trio
 import random
 
+
 async def main():
     async with trio.open_nursery() as nursery:
         send_channel, receive_channel = trio.open_memory_channel(0)
@@ -13,6 +14,7 @@ async def main():
         nursery.start_soon(consumer, "X", receive_channel)
         nursery.start_soon(consumer, "Y", receive_channel)
 
+
 async def producer(name, send_channel):
     async with send_channel:
         for i in range(3):
@@ -20,11 +22,13 @@ async def producer(name, send_channel):
             # Random sleeps help trigger the problem more reliably
             await trio.sleep(random.random())
 
+
 async def consumer(name, receive_channel):
     async with receive_channel:
         async for value in receive_channel:
             print(f"consumer {name} got value {value!r}")
             # Random sleeps help trigger the problem more reliably
             await trio.sleep(random.random())
+
 
 trio.run(main)

--- a/docs/source/reference-core/channels-mpmc-fixed.py
+++ b/docs/source/reference-core/channels-mpmc-fixed.py
@@ -1,6 +1,7 @@
 import trio
 import random
 
+
 async def main():
     async with trio.open_nursery() as nursery:
         send_channel, receive_channel = trio.open_memory_channel(0)
@@ -12,6 +13,7 @@ async def main():
             nursery.start_soon(consumer, "X", receive_channel.clone())
             nursery.start_soon(consumer, "Y", receive_channel.clone())
 
+
 async def producer(name, send_channel):
     async with send_channel:
         for i in range(3):
@@ -19,11 +21,13 @@ async def producer(name, send_channel):
             # Random sleeps help trigger the problem more reliably
             await trio.sleep(random.random())
 
+
 async def consumer(name, receive_channel):
     async with receive_channel:
         async for value in receive_channel:
             print(f"consumer {name} got value {value!r}")
             # Random sleeps help trigger the problem more reliably
             await trio.sleep(random.random())
+
 
 trio.run(main)

--- a/docs/source/reference-core/channels-shutdown.py
+++ b/docs/source/reference-core/channels-shutdown.py
@@ -1,19 +1,23 @@
 import trio
 
+
 async def main():
     async with trio.open_nursery() as nursery:
         send_channel, receive_channel = trio.open_memory_channel(0)
         nursery.start_soon(producer, send_channel)
         nursery.start_soon(consumer, receive_channel)
 
+
 async def producer(send_channel):
     async with send_channel:
         for i in range(3):
             await send_channel.send(f"message {i}")
 
+
 async def consumer(receive_channel):
     async with receive_channel:
         async for value in receive_channel:
             print(f"got value {value!r}")
+
 
 trio.run(main)

--- a/docs/source/reference-core/channels-simple.py
+++ b/docs/source/reference-core/channels-simple.py
@@ -1,5 +1,6 @@
 import trio
 
+
 async def main():
     async with trio.open_nursery() as nursery:
         # Open a channel:
@@ -9,15 +10,18 @@ async def main():
         nursery.start_soon(producer, send_channel)
         nursery.start_soon(consumer, receive_channel)
 
+
 async def producer(send_channel):
     # Producer sends 3 messages
     for i in range(3):
         # The producer sends using 'await send_channel.send(...)'
         await send_channel.send(f"message {i}")
 
+
 async def consumer(receive_channel):
     # The consumer uses an 'async for' loop to receive the values:
     async for value in receive_channel:
         print(f"got value {value!r}")
+
 
 trio.run(main)

--- a/docs/source/reference-testing/across-realtime.py
+++ b/docs/source/reference-testing/across-realtime.py
@@ -6,6 +6,7 @@ import trio.testing
 
 YEAR = 365 * 24 * 60 * 60  # seconds
 
+
 async def task1():
     start = trio.current_time()
 
@@ -13,15 +14,15 @@ async def task1():
     await trio.sleep(YEAR)
 
     duration = trio.current_time() - start
-    print("task1: woke up; clock says I've slept {} years"
-          .format(duration / YEAR))
+    print(f"task1: woke up; clock says I've slept {duration / YEAR} years")
 
     print("task1: sleeping for 1 year, 100 times")
     for _ in range(100):
         await trio.sleep(YEAR)
 
     duration = trio.current_time() - start
-    print("task1: slept {} years total".format(duration / YEAR))
+    print(f"task1: slept {duration / YEAR} years total")
+
 
 async def task2():
     start = trio.current_time()
@@ -30,25 +31,27 @@ async def task2():
     await trio.sleep(5 * YEAR)
 
     duration = trio.current_time() - start
-    print("task2: woke up; clock says I've slept {} years"
-          .format(duration / YEAR))
+    print(f"task2: woke up; clock says I've slept {duration / YEAR} years")
 
     print("task2: sleeping for 500 years")
     await trio.sleep(500 * YEAR)
 
     duration = trio.current_time() - start
-    print("task2: slept {} years total".format(duration / YEAR))
+    print(f"task2: slept {duration / YEAR} years total")
+
 
 async def main():
     async with trio.open_nursery() as nursery:
         nursery.start_soon(task1)
         nursery.start_soon(task2)
 
+
 def run_example(clock):
     real_start = time.perf_counter()
     trio.run(main, clock=clock)
     real_duration = time.perf_counter() - real_start
-    print("Total real time elapsed: {} seconds".format(real_duration))
+    print(f"Total real time elapsed: {real_duration} seconds")
+
 
 print("Clock where time passes at 100 years per second:\n")
 run_example(trio.testing.MockClock(rate=100 * YEAR))

--- a/docs/source/tutorial/echo-client.py
+++ b/docs/source/tutorial/echo-client.py
@@ -9,6 +9,7 @@ import trio
 # - must match what we set in our echo server
 PORT = 12345
 
+
 async def sender(client_stream):
     print("sender: started!")
     while True:
@@ -17,12 +18,14 @@ async def sender(client_stream):
         await client_stream.send_all(data)
         await trio.sleep(1)
 
+
 async def receiver(client_stream):
     print("receiver: started!")
     async for data in client_stream:
         print(f"receiver: got data {data!r}")
     print("receiver: connection closed")
     sys.exit()
+
 
 async def parent():
     print(f"parent: connecting to 127.0.0.1:{PORT}")
@@ -34,5 +37,6 @@ async def parent():
 
             print("parent: spawning receiver...")
             nursery.start_soon(receiver, client_stream)
+
 
 trio.run(parent)

--- a/docs/source/tutorial/echo-server.py
+++ b/docs/source/tutorial/echo-server.py
@@ -11,6 +11,7 @@ PORT = 12345
 
 CONNECTION_COUNTER = count()
 
+
 async def echo_server(server_stream):
     # Assign each connection a unique number to make our debug prints easier
     # to understand when there are multiple simultaneous connections.

--- a/docs/source/tutorial/tasks-intro.py
+++ b/docs/source/tutorial/tasks-intro.py
@@ -2,15 +2,18 @@
 
 import trio
 
+
 async def child1():
     print("  child1: started! sleeping now...")
     await trio.sleep(1)
     print("  child1: exiting!")
 
+
 async def child2():
     print("  child2: started! sleeping now...")
     await trio.sleep(1)
     print("  child2: exiting!")
+
 
 async def parent():
     print("parent: started!")
@@ -24,5 +27,6 @@ async def parent():
         print("parent: waiting for children to finish...")
         # -- we exit the nursery block here --
     print("parent: all done!")
+
 
 trio.run(parent)

--- a/docs/source/tutorial/tasks-with-trace.py
+++ b/docs/source/tutorial/tasks-with-trace.py
@@ -2,15 +2,18 @@
 
 import trio
 
+
 async def child1():
     print("  child1: started! sleeping now...")
     await trio.sleep(1)
     print("  child1: exiting!")
 
+
 async def child2():
     print("  child2 started! sleeping now...")
     await trio.sleep(1)
     print("  child2 exiting!")
+
 
 async def parent():
     print("parent: started!")
@@ -24,6 +27,7 @@ async def parent():
         print("parent: waiting for children to finish...")
         # -- we exit the nursery block here --
     print("parent: all done!")
+
 
 class Tracer(trio.abc.Instrument):
     def before_run(self):
@@ -62,5 +66,6 @@ class Tracer(trio.abc.Instrument):
 
     def after_run(self):
         print("!!! run finished")
+
 
 trio.run(parent, instruments=[Tracer()])

--- a/trio/_abc.py
+++ b/trio/_abc.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 from abc import ABCMeta, abstractmethod
 from typing import Generic, TypeVar
 import trio

--- a/trio/_core/_asyncgens.py
+++ b/trio/_core/_asyncgens.py
@@ -78,9 +78,9 @@ class AsyncGenerators:
                 # ignored, since we're running in GC context.)
                 warnings.warn(
                     f"Async generator {agen_name!r} was garbage collected before it "
-                    f"had been exhausted. Surround its use in 'async with "
-                    f"aclosing(...):' to ensure that it gets cleaned up as soon as "
-                    f"you're done using it.",
+                    "had been exhausted. Surround its use in 'async with "
+                    "aclosing(...):' to ensure that it gets cleaned up as soon as "
+                    "you're done using it.",
                     ResourceWarning,
                     stacklevel=2,
                     source=agen,
@@ -106,8 +106,8 @@ class AsyncGenerators:
                         # error than the default "async generator ignored GeneratorExit"
                         raise RuntimeError(
                             f"Non-Trio async generator {agen_name!r} awaited something "
-                            f"during finalization; install a finalization hook to "
-                            f"support this, or wrap it in 'async with aclosing(...):'"
+                            "during finalization; install a finalization hook to "
+                            "support this, or wrap it in 'async with aclosing(...):'"
                         )
 
         self.prev_hooks = sys.get_asyncgen_hooks()

--- a/trio/_core/_local.py
+++ b/trio/_core/_local.py
@@ -92,4 +92,4 @@ class RunVar(metaclass=Final):
         token.redeemed = True
 
     def __repr__(self):
-        return "<RunVar name={!r}>".format(self._name)
+        return f"<RunVar name={self._name!r}>"

--- a/trio/_core/_multierror.py
+++ b/trio/_core/_multierror.py
@@ -217,7 +217,7 @@ class MultiError(BaseExceptionGroup):
         return ", ".join(repr(exc) for exc in self.exceptions)
 
     def __repr__(self):
-        return "<MultiError: {}>".format(self)
+        return f"<MultiError: {self}>"
 
     def derive(self, __excs):
         # We use _collapse=False here to get ExceptionGroup semantics, since derive()

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -606,7 +606,7 @@ class CancelScope(metaclass=Final):
                     "from now" if self._deadline >= now else "ago",
                 )
 
-        return "<trio.CancelScope at {:#x}, {}{}>".format(id(self), binding, state)
+        return f"<trio.CancelScope at {id(self):#x}, {binding}{state}>"
 
     @contextmanager
     @enable_ki_protection
@@ -756,7 +756,7 @@ class _TaskStatus:
     _value = attr.ib(default=None)
 
     def __repr__(self):
-        return "<Task status object at {:#x}>".format(id(self))
+        return f"<Task status object at {id(self):#x}>"
 
     def started(self, value=None):
         if self._called_started:
@@ -1148,7 +1148,7 @@ class Task(metaclass=NoPublicConstructor):
     _schedule_points = attr.ib(default=0)
 
     def __repr__(self):
-        return "<Task {!r} at {:#x}>".format(self.name, id(self))
+        return f"<Task {self.name!r} at {id(self):#x}>"
 
     @property
     def parent_nursery(self):
@@ -1518,7 +1518,6 @@ class Runner:
     def spawn_impl(
         self, async_fn, args, nursery, name, *, system_task=False, context=None
     ):
-
         ######
         # Make sure the nursery is in working order
         ######
@@ -1543,7 +1542,7 @@ class Runner:
             name = name.func
         if not isinstance(name, str):
             try:
-                name = "{}.{}".format(name.__module__, name.__qualname__)
+                name = f"{name.__module__}.{name.__qualname__}"
             except AttributeError:
                 name = repr(name)
 

--- a/trio/_core/_unbounded_queue.py
+++ b/trio/_core/_unbounded_queue.py
@@ -54,7 +54,7 @@ class UnboundedQueue(metaclass=Final):
         self._can_get = False
 
     def __repr__(self):
-        return "<UnboundedQueue holding {} items>".format(len(self._data))
+        return f"<UnboundedQueue holding {len(self._data)} items>"
 
     def qsize(self):
         """Returns the number of items currently in the queue."""

--- a/trio/_core/tests/test_asyncgen.py
+++ b/trio/_core/tests/test_asyncgen.py
@@ -226,7 +226,7 @@ def test_last_minute_gc_edge_case():
             break
     else:  # pragma: no cover
         pytest.fail(
-            f"Didn't manage to hit the trailing_finalizer_asyncgens case "
+            "Didn't manage to hit the trailing_finalizer_asyncgens case "
             f"despite trying {attempt} times"
         )
 

--- a/trio/_core/tests/test_io.py
+++ b/trio/_core/tests/test_io.py
@@ -43,7 +43,7 @@ def using_fileno(fn):
     def fileno_wrapper(fileobj):
         return fn(fileobj.fileno())
 
-    name = "<{} on fileno>".format(fn.__name__)
+    name = f"<{fn.__name__} on fileno>"
     fileno_wrapper.__name__ = fileno_wrapper.__qualname__ = name
     return fileno_wrapper
 
@@ -417,7 +417,7 @@ async def test_can_survive_unnotified_close():
     # handle_io context rather than abort context.
     a, b = stdlib_socket.socketpair()
     with a, b, a.dup() as a2:  # noqa: F841
-        print("a={}, b={}, a2={}".format(a.fileno(), b.fileno(), a2.fileno()))
+        print(f"a={a.fileno()}, b={b.fileno()}, a2={a2.fileno()}")
         a.setblocking(False)
         b.setblocking(False)
         fill_socket(a)

--- a/trio/_core/tests/test_mock_clock.py
+++ b/trio/_core/tests/test_mock_clock.py
@@ -64,14 +64,14 @@ async def test_mock_clock_autojump(mock_clock):
 
     virtual_start = _core.current_time()
     for i in range(10):
-        print("sleeping {} seconds".format(10 * i))
+        print(f"sleeping {10 * i} seconds")
         await sleep(10 * i)
         print("woke up!")
         assert virtual_start + 10 * i == _core.current_time()
         virtual_start = _core.current_time()
 
     real_duration = time.perf_counter() - real_start
-    print("Slept {} seconds in {} seconds".format(10 * sum(range(10)), real_duration))
+    print(f"Slept {10 * sum(range(10))} seconds in {real_duration} seconds")
     assert real_duration < 1
 
     mock_clock.autojump_threshold = 0.02

--- a/trio/_core/tests/test_multierror.py
+++ b/trio/_core/tests/test_multierror.py
@@ -77,7 +77,6 @@ def get_tb(raiser):
 
 
 def test_concat_tb():
-
     tb1 = get_tb(raiser1)
     tb2 = get_tb(raiser2)
 

--- a/trio/_core/tests/test_parking_lot.py
+++ b/trio/_core/tests/test_parking_lot.py
@@ -10,9 +10,9 @@ async def test_parking_lot_basic():
     record = []
 
     async def waiter(i, lot):
-        record.append("sleep {}".format(i))
+        record.append(f"sleep {i}")
         await lot.park()
-        record.append("wake {}".format(i))
+        record.append(f"wake {i}")
 
     async with _core.open_nursery() as nursery:
         lot = ParkingLot()
@@ -76,13 +76,13 @@ async def test_parking_lot_basic():
 async def cancellable_waiter(name, lot, scopes, record):
     with _core.CancelScope() as scope:
         scopes[name] = scope
-        record.append("sleep {}".format(name))
+        record.append(f"sleep {name}")
         try:
             await lot.park()
         except _core.Cancelled:
-            record.append("cancelled {}".format(name))
+            record.append(f"cancelled {name}")
         else:
-            record.append("wake {}".format(name))
+            record.append(f"wake {name}")
 
 
 async def test_parking_lot_cancel():

--- a/trio/_core/tests/test_run.py
+++ b/trio/_core/tests/test_run.py
@@ -2245,7 +2245,6 @@ async def test_cancel_scope_exit_doesnt_create_cyclic_garbage():
 
     old_flags = gc.get_debug()
     try:
-
         with pytest.raises(ValueError), _core.CancelScope() as outer:
             async with _core.open_nursery() as nursery:
                 gc.collect()

--- a/trio/_deprecate.py
+++ b/trio/_deprecate.py
@@ -30,24 +30,24 @@ class TrioDeprecationWarning(FutureWarning):
 
 
 def _url_for_issue(issue):
-    return "https://github.com/python-trio/trio/issues/{}".format(issue)
+    return f"https://github.com/python-trio/trio/issues/{issue}"
 
 
 def _stringify(thing):
     if hasattr(thing, "__module__") and hasattr(thing, "__qualname__"):
-        return "{}.{}".format(thing.__module__, thing.__qualname__)
+        return f"{thing.__module__}.{thing.__qualname__}"
     return str(thing)
 
 
 def warn_deprecated(thing, version, *, issue, instead, stacklevel=2):
     stacklevel += 1
-    msg = "{} is deprecated since Trio {}".format(_stringify(thing), version)
+    msg = f"{_stringify(thing)} is deprecated since Trio {version}"
     if instead is None:
         msg += " with no replacement"
     else:
-        msg += "; use {} instead".format(_stringify(instead))
+        msg += f"; use {_stringify(instead)} instead"
     if issue is not None:
-        msg += " ({})".format(_url_for_issue(issue))
+        msg += f" ({_url_for_issue(issue)})"
     warnings.warn(TrioDeprecationWarning(msg), stacklevel=stacklevel)
 
 
@@ -72,9 +72,9 @@ def deprecated(version, *, thing=None, issue, instead):
             doc = wrapper.__doc__
             doc = doc.rstrip()
             doc += "\n\n"
-            doc += ".. deprecated:: {}\n".format(version)
+            doc += f".. deprecated:: {version}\n"
             if instead is not None:
-                doc += "   Use {} instead.\n".format(_stringify(instead))
+                doc += f"   Use {_stringify(instead)} instead.\n"
             if issue is not None:
                 doc += "   For details, see `issue #{} <{}>`__.\n".format(
                     issue, _url_for_issue(issue)
@@ -116,7 +116,7 @@ class _ModuleWithDeprecations(ModuleType):
             instead = info.instead
             if instead is DeprecatedAttribute._not_set:
                 instead = info.value
-            thing = "{}.{}".format(self.__name__, name)
+            thing = f"{self.__name__}.{name}"
             warn_deprecated(thing, info.version, issue=info.issue, instead=instead)
             return info.value
 

--- a/trio/_highlevel_open_tcp_listeners.py
+++ b/trio/_highlevel_open_tcp_listeners.py
@@ -90,7 +90,7 @@ async def open_tcp_listeners(port, *, host=None, backlog=None):
     # doesn't:
     #   http://klickverbot.at/blog/2012/01/getaddrinfo-edge-case-behavior-on-windows-linux-and-osx/
     if not isinstance(port, int):
-        raise TypeError("port must be an int not {!r}".format(port))
+        raise TypeError(f"port must be an int not {port!r}")
 
     backlog = _compute_backlog(backlog)
 

--- a/trio/_highlevel_open_tcp_stream.py
+++ b/trio/_highlevel_open_tcp_stream.py
@@ -147,9 +147,9 @@ def reorder_for_rfc_6555_section_5_4(targets):
 def format_host_port(host, port):
     host = host.decode("ascii") if isinstance(host, bytes) else host
     if ":" in host:
-        return "[{}]:{}".format(host, port)
+        return f"[{host}]:{port}"
     else:
-        return "{}:{}".format(host, port)
+        return f"{host}:{port}"
 
 
 # Twisted's HostnameEndpoint has a good set of configurables:
@@ -251,7 +251,7 @@ async def open_tcp_stream(
     if host is None:
         raise ValueError("host cannot be None")
     if not isinstance(port, int):
-        raise TypeError("port must be int, not {!r}".format(port))
+        raise TypeError(f"port must be int, not {port!r}")
 
     if happy_eyeballs_delay is None:
         happy_eyeballs_delay = DEFAULT_DELAY

--- a/trio/_highlevel_socket.py
+++ b/trio/_highlevel_socket.py
@@ -30,9 +30,7 @@ def _translate_socket_errors_to_stream_errors():
         if exc.errno in _closed_stream_errnos:
             raise trio.ClosedResourceError("this socket was already closed") from None
         else:
-            raise trio.BrokenResourceError(
-                "socket connection broken: {}".format(exc)
-            ) from exc
+            raise trio.BrokenResourceError(f"socket connection broken: {exc}") from exc
 
 
 class SocketStream(HalfCloseableStream, metaclass=Final):

--- a/trio/_path.py
+++ b/trio/_path.py
@@ -166,7 +166,7 @@ class Path(metaclass=AsyncAutoWrapperType):
         return super().__dir__() + self._forward
 
     def __repr__(self):
-        return "trio.Path({})".format(repr(str(self)))
+        return f"trio.Path({repr(str(self))})"
 
     def __fspath__(self):
         return os.fspath(self._wrapped)

--- a/trio/_ssl.py
+++ b/trio/_ssl.py
@@ -402,9 +402,7 @@ class SSLStream(Stream, metaclass=Final):
     def __getattr__(self, name):
         if name in self._forwarded:
             if name in self._after_handshake and not self._handshook.done:
-                raise NeedHandshakeError(
-                    "call do_handshake() before calling {!r}".format(name)
-                )
+                raise NeedHandshakeError(f"call do_handshake() before calling {name!r}")
 
             return getattr(self._ssl_object, name)
         else:

--- a/trio/_subprocess.py
+++ b/trio/_subprocess.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 import os
 import subprocess
 import sys
@@ -152,13 +150,13 @@ class Process(AsyncResource, metaclass=NoPublicConstructor):
     def __repr__(self):
         returncode = self.returncode
         if returncode is None:
-            status = "running with PID {}".format(self.pid)
+            status = f"running with PID {self.pid}"
         else:
             if returncode < 0:
-                status = "exited with signal {}".format(-returncode)
+                status = f"exited with signal {-returncode}"
             else:
-                status = "exited with status {}".format(returncode)
-        return "<trio.Process {!r}: {}>".format(self.args, status)
+                status = f"exited with status {returncode}"
+        return f"<trio.Process {self.args!r}: {status}>"
 
     @property
     def returncode(self):
@@ -430,8 +428,8 @@ async def _posix_deliver_cancel(p):
         warnings.warn(
             RuntimeWarning(
                 f"process {p!r} ignored SIGTERM for 5 seconds. "
-                f"(Maybe you should pass a custom deliver_cancel?) "
-                f"Trying SIGKILL."
+                "(Maybe you should pass a custom deliver_cancel?) "
+                "Trying SIGKILL."
             )
         )
         p.kill()

--- a/trio/_sync.py
+++ b/trio/_sync.py
@@ -245,8 +245,7 @@ class CapacityLimiter(AsyncContextManagerMixin, metaclass=Final):
         """
         if borrower in self._borrowers:
             raise RuntimeError(
-                "this borrower is already holding one of this "
-                "CapacityLimiter's tokens"
+                "this borrower is already holding one of this CapacityLimiter's tokens"
             )
         if len(self._borrowers) < self._total_tokens and not self._lot:
             self._borrowers.add(borrower)
@@ -396,7 +395,7 @@ class Semaphore(AsyncContextManagerMixin, metaclass=Final):
         if self._max_value is None:
             max_value_str = ""
         else:
-            max_value_str = ", max_value={}".format(self._max_value)
+            max_value_str = f", max_value={self._max_value}"
         return "<trio.Semaphore({}{}) at {:#x}>".format(
             self._value, max_value_str, id(self)
         )
@@ -484,7 +483,7 @@ class _LockImpl(AsyncContextManagerMixin):
     def __repr__(self):
         if self.locked():
             s1 = "locked"
-            s2 = " with {} waiters".format(len(self._lot))
+            s2 = f" with {len(self._lot)} waiters"
         else:
             s1 = "unlocked"
             s2 = ""

--- a/trio/_threads.py
+++ b/trio/_threads.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 import contextvars
 import threading
 import queue as stdlib_queue

--- a/trio/_tools/gen_exports.py
+++ b/trio/_tools/gen_exports.py
@@ -1,5 +1,4 @@
 #! /usr/bin/env python3
-# -*- coding: utf-8 -`-
 """
 Code generation script for class methods
 to be exported as public API
@@ -134,7 +133,7 @@ def matches_disk_files(new_files):
     for new_path, new_source in new_files.items():
         if not os.path.exists(new_path):
             return False
-        with open(new_path, "r", encoding="utf-8") as old_file:
+        with open(new_path, encoding="utf-8") as old_file:
             old_source = old_file.read()
         if old_source != new_source:
             return False

--- a/trio/_util.py
+++ b/trio/_util.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 # Little utilities we use internally
 
 from abc import ABCMeta
@@ -288,7 +286,8 @@ class Final(ABCMeta):
         for base in bases:
             if isinstance(base, Final):
                 raise TypeError(
-                    f"{base.__module__}.{base.__qualname__} does not support subclassing"
+                    f"{base.__module__}.{base.__qualname__} does not support"
+                    " subclassing"
                 )
         return super().__new__(cls, name, bases, cls_namespace)
 
@@ -333,7 +332,7 @@ def name_asyncgen(agen):
     try:
         module = agen.ag_frame.f_globals["__name__"]
     except (AttributeError, KeyError):
-        module = "<{}>".format(agen.ag_code.co_filename)
+        module = f"<{agen.ag_code.co_filename}>"
     try:
         qualname = agen.__qualname__
     except AttributeError:

--- a/trio/_wait_for_object.py
+++ b/trio/_wait_for_object.py
@@ -53,7 +53,7 @@ async def WaitForSingleObject(obj):
 def WaitForMultipleObjects_sync(*handles):
     """Wait for any of the given Windows handles to be signaled."""
     n = len(handles)
-    handle_arr = ffi.new("HANDLE[{}]".format(n))
+    handle_arr = ffi.new(f"HANDLE[{n}]")
     for i in range(n):
         handle_arr[i] = handles[i]
     timeout = 0xFFFFFFFF  # INFINITE

--- a/trio/testing/_check_streams.py
+++ b/trio/testing/_check_streams.py
@@ -31,7 +31,7 @@ def _assert_raises(exc):
     except exc:
         pass
     else:
-        raise AssertionError("expected exception: {}".format(exc))
+        raise AssertionError(f"expected exception: {exc}")
 
 
 async def check_one_way_stream(stream_maker, clogged_stream_maker):

--- a/trio/testing/_sequencer.py
+++ b/trio/testing/_sequencer.py
@@ -61,7 +61,7 @@ class Sequencer(metaclass=_util.Final):
     @asynccontextmanager
     async def __call__(self, position: int):
         if position in self._claimed:
-            raise RuntimeError("Attempted to re-use sequence point {}".format(position))
+            raise RuntimeError(f"Attempted to re-use sequence point {position}")
         if self._broken:
             raise RuntimeError("sequence broken!")
         self._claimed.add(position)

--- a/trio/tests/test_channel.py
+++ b/trio/tests/test_channel.py
@@ -346,7 +346,6 @@ async def test_statistics():
 
 
 async def test_channel_fairness():
-
     # We can remove an item we just sent, and send an item back in after, if
     # no-one else is waiting.
     s, r = open_memory_channel(1)

--- a/trio/tests/test_dtls.py
+++ b/trio/tests/test_dtls.py
@@ -50,7 +50,7 @@ async def dtls_echo_server(*, autocancel=True, mtu=None, ipv6=False):
 
             async def echo_handler(dtls_channel):
                 print(
-                    f"echo handler started: "
+                    "echo handler started: "
                     f"server {dtls_channel.endpoint.socket.getsockname()} "
                     f"client {dtls_channel.peer_address}"
                 )
@@ -148,7 +148,8 @@ async def test_handshake_over_terrible_network(autojump_clock):
                     else:
                         assert op == "deliver"
                         print(
-                            f"{packet.source} -> {packet.destination}: delivered {packet.payload.hex()}"
+                            f"{packet.source} -> {packet.destination}: delivered"
+                            f" {packet.payload.hex()}"
                         )
                         fn.deliver_packet(packet)
                         break
@@ -446,7 +447,6 @@ async def test_invalid_cookie_rejected(autojump_clock):
     from trio._dtls import decode_client_hello_untrusted, BadPacket
 
     with trio.CancelScope() as cscope:
-
         # the first 11 bytes of ClientHello aren't protected by the cookie, so only test
         # corrupting bytes after that.
         offset_to_corrupt = count(11)

--- a/trio/tests/test_exports.py
+++ b/trio/tests/test_exports.py
@@ -93,7 +93,7 @@ def test_static_tool_sees_all_symbols(tool, modname):
         import jedi
 
         # Simulate typing "import trio; trio.<TAB>"
-        script = jedi.Script("import {}; {}.".format(modname, modname))
+        script = jedi.Script(f"import {modname}; {modname}.")
         completions = script.complete()
         static_names = no_underscores(c.name for c in completions)
     else:  # pragma: no cover
@@ -107,10 +107,10 @@ def test_static_tool_sees_all_symbols(tool, modname):
     # So we check that the runtime names are a subset of the static names.
     missing_names = runtime_names - static_names
     if missing_names:  # pragma: no cover
-        print("{} can't see the following names in {}:".format(tool, modname))
+        print(f"{tool} can't see the following names in {modname}:")
         print()
         for name in sorted(missing_names):
-            print("    {}".format(name))
+            print(f"    {name}")
         assert False
 
 

--- a/trio/tests/test_file_io.py
+++ b/trio/tests/test_file_io.py
@@ -27,7 +27,7 @@ def async_file(wrapped):
 
 def test_wrap_invalid():
     with pytest.raises(TypeError):
-        trio.wrap_file(str())
+        trio.wrap_file("")
 
 
 def test_wrap_non_iobase():

--- a/trio/tests/test_highlevel_open_tcp_listeners.py
+++ b/trio/tests/test_highlevel_open_tcp_listeners.py
@@ -288,7 +288,7 @@ async def test_open_tcp_listeners_socket_fails_not_afnosupport():
 async def test_open_tcp_listeners_backlog():
     fsf = FakeSocketFactory(99)
     tsocket.set_custom_socket_factory(fsf)
-    for (given, expected) in [
+    for given, expected in [
         (None, 0xFFFF),
         (99999999, 0xFFFF),
         (10, 10),

--- a/trio/tests/test_highlevel_open_tcp_stream.py
+++ b/trio/tests/test_highlevel_open_tcp_stream.py
@@ -55,11 +55,11 @@ def test_reorder_for_rfc_6555_section_5_4():
             SOCK_STREAM,
             IPPROTO_TCP,
             "",
-            ("10.0.0.{}".format(i), 80),
+            (f"10.0.0.{i}", 80),
         )
 
     def fake6(i):
-        return (AF_INET6, SOCK_STREAM, IPPROTO_TCP, "", ("::{}".format(i), 80))
+        return (AF_INET6, SOCK_STREAM, IPPROTO_TCP, "", (f"::{i}", 80))
 
     for fake in fake4, fake6:
         # No effect on homogeneous lists

--- a/trio/tests/test_path.py
+++ b/trio/tests/test_path.py
@@ -104,7 +104,6 @@ async def test_async_method_signature(path):
 
 @pytest.mark.parametrize("method_name", ["is_dir", "is_file"])
 async def test_compare_async_stat_methods(method_name):
-
     method, async_method = method_pair(".", method_name)
 
     result = method()
@@ -120,7 +119,6 @@ async def test_invalid_name_not_wrapped(path):
 
 @pytest.mark.parametrize("method_name", ["absolute", "resolve"])
 async def test_async_methods_rewrap(method_name):
-
     method, async_method = method_pair(".", method_name)
 
     result = method()

--- a/trio/tests/test_socket.py
+++ b/trio/tests/test_socket.py
@@ -46,7 +46,7 @@ class MonkeypatchedGAI:
         elif bound[-1] & stdlib_socket.AI_NUMERICHOST:
             return self._orig_getaddrinfo(*args, **kwargs)
         else:
-            raise RuntimeError("gai called with unexpected arguments {}".format(bound))
+            raise RuntimeError(f"gai called with unexpected arguments {bound}")
 
 
 @pytest.fixture
@@ -965,7 +965,7 @@ async def test_unix_domain_socket():
     # Can't use tmpdir fixture, because we can exceed the maximum AF_UNIX path
     # length on macOS.
     with tempfile.TemporaryDirectory() as tmpdir:
-        path = "{}/sock".format(tmpdir)
+        path = f"{tmpdir}/sock"
         await check_AF_UNIX(path)
 
     try:

--- a/trio/tests/test_subprocess.py
+++ b/trio/tests/test_subprocess.py
@@ -45,7 +45,7 @@ CAT = python("sys.stdout.buffer.write(sys.stdin.buffer.read())")
 if posix:
     SLEEP = lambda seconds: ["/bin/sleep", str(seconds)]
 else:
-    SLEEP = lambda seconds: python("import time; time.sleep({})".format(seconds))
+    SLEEP = lambda seconds: python(f"import time; time.sleep({seconds})")
 
 
 def got_signal(proc, sig):
@@ -224,7 +224,6 @@ async def test_interactive(background_process):
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     ) as proc:
-
         newline = b"\n" if posix else b"\r\n"
 
         async def expect(idx, request):
@@ -233,9 +232,7 @@ async def test_interactive(background_process):
                 async def drain_one(stream, count, digit):
                     while count > 0:
                         result = await stream.receive_some(count)
-                        assert result == (
-                            "{}".format(digit).encode("utf-8") * len(result)
-                        )
+                        assert result == (f"{digit}".encode() * len(result))
                         count -= len(result)
                     assert count == 0
                     assert await stream.receive_some(len(newline)) == newline

--- a/trio/tests/test_testing.py
+++ b/trio/tests/test_testing.py
@@ -213,7 +213,7 @@ async def test_Sequencer_cancel():
                 async with seq(i):
                     pass  # pragma: no cover
             except RuntimeError:
-                record.append("seq({}) RuntimeError".format(i))
+                record.append(f"seq({i}) RuntimeError")
 
     async with _core.open_nursery() as nursery:
         nursery.start_soon(child, 1)
@@ -651,7 +651,7 @@ async def test_open_stream_to_socket_listener():
         # can't use pytest's tmpdir; if we try then macOS says "OSError:
         # AF_UNIX path too long"
         with tempfile.TemporaryDirectory() as tmpdir:
-            path = "{}/sock".format(tmpdir)
+            path = f"{tmpdir}/sock"
             await sock.bind(path)
             sock.listen(10)
             await check(SocketListener(sock))

--- a/trio/tests/test_threads.py
+++ b/trio/tests/test_threads.py
@@ -509,9 +509,10 @@ async def test_trio_to_thread_run_sync_contextvars():
     sniffio_outer_value = current_async_library_cvar.get()
     assert parent_value == "main"
     assert inner_value == "worker"
-    assert (
-        current_value == "main"
-    ), "The contextvar value set on the worker would not propagate back to the main thread"
+    assert current_value == "main", (
+        "The contextvar value set on the worker would not propagate back to the main"
+        " thread"
+    )
     assert sniffio_cvar_value is None
     assert sniffio_outer_value == "trio"
 
@@ -741,7 +742,6 @@ async def test_trio_token_weak_referenceable():
 
 
 async def test_unsafe_cancellable_kwarg():
-
     # This is a stand in for a numpy ndarray or other objects
     # that (maybe surprisingly) lack a notion of truthiness
     class BadBool:

--- a/trio/tests/tools/test_gen_exports.py
+++ b/trio/tests/tools/test_gen_exports.py
@@ -49,7 +49,7 @@ def test_create_pass_through_args():
         ),
     ]
 
-    for (funcdef, expected) in testcases:
+    for funcdef, expected in testcases:
         func_node = ast.parse(funcdef + ":\n  pass").body[0]
         assert isinstance(func_node, ast.FunctionDef)
         assert create_passthrough_args(func_node) == expected


### PR DESCRIPTION
This PR is the result of a one-off run of `pyupgrade` on the trio code base.

For future reference, this was done by running the following command from the project root:

```sh
find . -name '*.py' -exec pyupgrade --py3-only --py37-plus {} +
```

I also ran black in preview mode (`black --preview`), which mainly results in string cleanup.