### PR TITLE
Update old style type hints

### DIFF
--- a/trio/_core/_ki.py
+++ b/trio/_core/_ki.py
@@ -1,13 +1,16 @@
+from __future__ import annotations
+
 import inspect
 import signal
 import sys
 from functools import wraps
+from typing import TYPE_CHECKING
 
 import attr
 
 from .._util import is_main_thread
 
-if False:
+if TYPE_CHECKING:
     from typing import Any, TypeVar, Callable
 
     F = TypeVar("F", bound=Callable[..., Any])
@@ -54,7 +57,7 @@ if False:
 #
 #   If this raises a KeyboardInterrupt, it might be because the coroutine got
 #   interrupted and has unwound... or it might be the KeyboardInterrupt
-#   arrived just *after* 'send' returned, so the coroutine is still running
+#   arrived just *after* 'send' returned, so the coroutine is still running,
 #   but we just lost the message it sent. (And worse, in our actual task
 #   runner, the send is hidden inside a utility function etc.)
 #

--- a/trio/_core/_ki.py
+++ b/trio/_core/_ki.py
@@ -170,10 +170,10 @@ def _ki_protection_decorator(enabled):
     return decorator
 
 
-enable_ki_protection = _ki_protection_decorator(True)  # type: Callable[[F], F]
+enable_ki_protection: Callable[[F], F] = _ki_protection_decorator(True)
 enable_ki_protection.__name__ = "enable_ki_protection"
 
-disable_ki_protection = _ki_protection_decorator(False)  # type: Callable[[F], F]
+disable_ki_protection: Callable[[F], F] = _ki_protection_decorator(False)
 disable_ki_protection.__name__ = "disable_ki_protection"
 
 

--- a/trio/_subprocess.py
+++ b/trio/_subprocess.py
@@ -121,11 +121,11 @@ class Process(AsyncResource, metaclass=NoPublicConstructor):
 
     def __init__(self, popen, stdin, stdout, stderr):
         self._proc = popen
-        self.stdin = stdin  # type: Optional[SendStream]
-        self.stdout = stdout  # type: Optional[ReceiveStream]
-        self.stderr = stderr  # type: Optional[ReceiveStream]
+        self.stdin: Optional[SendStream] = stdin
+        self.stdout: Optional[ReceiveStream] = stdout
+        self.stderr: Optional[ReceiveStream] = stderr
 
-        self.stdio = None  # type: Optional[StapledStream]
+        self.stdio: Optional[StapledStream] = None
         if self.stdin is not None and self.stdout is not None:
             self.stdio = StapledStream(self.stdin, self.stdout)
 
@@ -368,9 +368,9 @@ async def open_process(
                 "on UNIX systems"
             )
 
-    trio_stdin = None  # type: Optional[ClosableSendStream]
-    trio_stdout = None  # type: Optional[ClosableReceiveStream]
-    trio_stderr = None  # type: Optional[ClosableReceiveStream]
+    trio_stdin: Optional[ClosableSendStream] = None
+    trio_stdout: Optional[ClosableReceiveStream] = None
+    trio_stderr: Optional[ClosableReceiveStream] = None
     # Close the parent's handle for each child side of a pipe; we want the child to
     # have the only copy, so that when it exits we can read EOF on our side. The
     # trio ends of pipes will be transferred to the Process object, which will be

--- a/trio/testing/_sequencer.py
+++ b/trio/testing/_sequencer.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 from collections import defaultdict
 from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING
 
 import attr
 
@@ -7,8 +10,8 @@ from .. import _core
 from .. import _util
 from .. import Event
 
-if False:
-    from typing import DefaultDict, Set
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
 
 
 @attr.s(eq=False, hash=False)
@@ -52,14 +55,14 @@ class Sequencer(metaclass=_util.Final):
 
     """
 
-    _sequence_points = attr.ib(
+    _sequence_points: defaultdict[int, Event] = attr.ib(
         factory=lambda: defaultdict(Event), init=False
-    )  # type: DefaultDict[int, Event]
-    _claimed = attr.ib(factory=set, init=False)  # type: Set[int]
-    _broken = attr.ib(default=False, init=False)
+    )
+    _claimed: set[int] = attr.ib(factory=set, init=False)
+    _broken: bool = attr.ib(default=False, init=False)
 
     @asynccontextmanager
-    async def __call__(self, position: int):
+    async def __call__(self, position: int) -> AsyncIterator[None]:
         if position in self._claimed:
             raise RuntimeError("Attempted to re-use sequence point {}".format(position))
         if self._broken:

--- a/trio/tests/test_windows_pipes.py
+++ b/trio/tests/test_windows_pipes.py
@@ -3,6 +3,9 @@ import select
 
 import os
 import sys
+from typing import Any
+from typing import Tuple
+
 import pytest
 
 from .._core.tests.tutil import gc_collect_harder
@@ -15,12 +18,12 @@ if sys.platform == "win32":
     from asyncio.windows_utils import pipe
 else:
     pytestmark = pytest.mark.skip(reason="windows only")
-    pipe = None  # type: Any
-    PipeSendStream = None  # type: Any
-    PipeReceiveStream = None  # type: Any
+    pipe: Any = None
+    PipeSendStream: Any = None
+    PipeReceiveStream: Any = None
 
 
-async def make_pipe() -> "Tuple[PipeSendStream, PipeReceiveStream]":
+async def make_pipe() -> Tuple[PipeSendStream, PipeReceiveStream]:
     """Makes a new pair of pipes."""
     (r, w) = pipe()
     return PipeSendStream(w), PipeReceiveStream(r)


### PR DESCRIPTION
Came across a few type hints embedded in comments. I figured it was a good idea to update these.

I leverage postponed evaluation of annotations in a few places. This allows me to get away with fewer imports from `Typing`, since I can use a more modern annotation style. Look for:

```py
from __future__ import annotations
```