### PR TITLE
Disable failing tests for Python 3.7 on Ubuntu

### DIFF
--- a/trio/tests/test_ssl.py
+++ b/trio/tests/test_ssl.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import re
 import sys

--- a/trio/tests/test_ssl.py
+++ b/trio/tests/test_ssl.py
@@ -68,11 +68,9 @@ if hasattr(ssl, "OP_IGNORE_UNEXPECTED_EOF"):
 TRIO_TEST_1_CERT.configure_cert(SERVER_CTX)
 
 
-# See: https://github.com/python-trio/trio/pull/2480#issuecomment-1330135171
-skip_on_python_37_linux: MarkDecorator = pytest.mark.skipif(
-    sys.platform == "linux",
-    sys.version_info < (3, 8),
-    reason="Certain SSL Tests are not passing on Ubuntu while running Python 3.7",
+skip_on_broken_openssl: MarkDecorator = pytest.mark.skipif(
+    sys.version_info < (3, 8) and ssl.OPENSSL_VERSION_INFO[0] > 1,
+    reason="Python 3.7 does not work with OpenSSL versions higher than 1.X",
 )
 
 

--- a/trio/tests/test_ssl.py
+++ b/trio/tests/test_ssl.py
@@ -822,7 +822,7 @@ async def test_send_all_empty_string(client_ctx):
         await s.aclose()
 
 
-@skip_on_python_37_linux
+@skip_on_broken_openssl
 @pytest.mark.parametrize("https_compatible", [False, True])
 async def test_SSLStream_generic(client_ctx, https_compatible):
     async def stream_maker():

--- a/trio/tests/test_ssl.py
+++ b/trio/tests/test_ssl.py
@@ -67,6 +67,8 @@ if hasattr(ssl, "OP_IGNORE_UNEXPECTED_EOF"):
 
 TRIO_TEST_1_CERT.configure_cert(SERVER_CTX)
 
+
+# See: https://github.com/python-trio/trio/pull/2480#issuecomment-1330135171
 skip_on_python_37_linux: MarkDecorator = pytest.mark.skipif(
     sys.platform == "linux",
     sys.version_info < (3, 8),

--- a/trio/tests/test_ssl.py
+++ b/trio/tests/test_ssl.py
@@ -1038,7 +1038,7 @@ async def test_ssl_bad_shutdown(client_ctx):
     await server.aclose()
 
 
-@skip_on_python_37_linux
+@skip_on_broken_openssl
 async def test_ssl_bad_shutdown_but_its_ok(client_ctx):
     client, server = ssl_memory_stream_pair(
         client_ctx,

--- a/trio/tests/test_ssl.py
+++ b/trio/tests/test_ssl.py
@@ -69,7 +69,7 @@ TRIO_TEST_1_CERT.configure_cert(SERVER_CTX)
 
 skip_on_python_37_linux: MarkDecorator = pytest.mark.skipif(
     sys.platform == "linux",
-    sys.version_info[0:2] == (3, 7),
+    sys.version_info < (3, 8),
     reason="Certain SSL Tests are not passing on Ubuntu while running Python 3.7",
 )
 

--- a/trio/tests/test_ssl.py
+++ b/trio/tests/test_ssl.py
@@ -1,6 +1,6 @@
 import os
-import re
 import sys
+from typing_extensions import Final
 
 import pytest
 
@@ -12,6 +12,7 @@ from functools import partial
 
 from OpenSSL import SSL
 import trustme
+from _pytest.mark import MarkDecorator
 
 import trio
 from .. import _core
@@ -35,7 +36,7 @@ from ..testing import (
 
 # We have two different kinds of echo server fixtures we use for testing. The
 # first is a real server written using the stdlib ssl module and blocking
-# sockets. It runs in a thread and we talk to it over a real socketpair(), to
+# sockets. It runs in a thread, and we talk to it over a real socketpair(), to
 # validate interoperability in a semi-realistic setting.
 #
 # The second is a very weird virtual echo server that lives inside a custom
@@ -45,20 +46,26 @@ from ..testing import (
 # the server-side TLS state engine to decrypt, then takes that data, feeds it
 # back through to get the encrypted response, and returns it from 'receive_some'. This
 # gives us full control and reproducibility. This server is written using
-# PyOpenSSL, so that we can trigger renegotiations on demand. It also allows
+# PyOpenSSL, so that we can trigger re-negotiations on demand. It also allows
 # us to insert random (virtual) delays, to really exercise all the weird paths
 # in SSLStream's state engine.
 #
 # Both present a certificate for "trio-test-1.example.org".
 
-TRIO_TEST_CA = trustme.CA()
-TRIO_TEST_1_CERT = TRIO_TEST_CA.issue_server_cert("trio-test-1.example.org")
+TRIO_TEST_CA: Final = trustme.CA()
+TRIO_TEST_1_CERT: Final = TRIO_TEST_CA.issue_server_cert("trio-test-1.example.org")
 
-SERVER_CTX = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+SERVER_CTX: Final = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
 if hasattr(ssl, "OP_IGNORE_UNEXPECTED_EOF"):
     SERVER_CTX.options &= ~ssl.OP_IGNORE_UNEXPECTED_EOF
 
 TRIO_TEST_1_CERT.configure_cert(SERVER_CTX)
+
+skip_on_python_37_linux: MarkDecorator = pytest.mark.skipif(
+    sys.platform == "linux",
+    sys.version_info[0:2] == (3, 7),
+    reason="Certain SSL Tests are not passing on Ubuntu while running Python 3.7",
+)
 
 
 # TLS 1.3 has a lot of changes from previous versions. So we want to run tests
@@ -68,7 +75,7 @@ TRIO_TEST_1_CERT.configure_cert(SERVER_CTX)
 # downgrade on the server side. "tls12" means we refuse to negotiate TLS
 # 1.3, so we'll almost certainly use TLS 1.2.
 @pytest.fixture(scope="module", params=["tls13", "tls12"])
-def client_ctx(request):
+def client_ctx(request) -> ssl.SSLContext:
     ctx = ssl.create_default_context()
 
     if hasattr(ssl, "OP_IGNORE_UNEXPECTED_EOF"):
@@ -85,7 +92,11 @@ def client_ctx(request):
 
 
 # The blocking socket server.
-def ssl_echo_serve_sync(sock, *, expect_fail=False):
+def ssl_echo_serve_sync(
+    sock: stdlib_socket.socket,
+    *,
+    expect_fail: bool = False,
+) -> None:
     try:
         wrapped = SERVER_CTX.wrap_socket(
             sock, server_side=True, suppress_ragged_eofs=False
@@ -96,7 +107,7 @@ def ssl_echo_serve_sync(sock, *, expect_fail=False):
                 data = wrapped.recv(4096)
                 if not data:
                     # other side has initiated a graceful shutdown; we try to
-                    # respond in kind but it's legal for them to have already
+                    # respond in kind, but it's legal for them to have already
                     # gone away.
                     exceptions = (BrokenPipeError, ssl.SSLZeroReturnError)
                     try:
@@ -107,7 +118,7 @@ def ssl_echo_serve_sync(sock, *, expect_fail=False):
                         # Under unclear conditions, CPython sometimes raises
                         # SSLWantWriteError here. This is a bug (bpo-32219),
                         # but it's not our bug.  Christian Heimes thinks
-                        # it's fixed in 'recent' CPython versions so we fail
+                        # it's fixed in 'recent' CPython versions, so we fail
                         # the test for those and ignore it for earlier
                         # versions.
                         if (
@@ -128,7 +139,7 @@ def ssl_echo_serve_sync(sock, *, expect_fail=False):
     # the OS to report a ECONNREST or even ECONNABORTED (which is just wrong,
     # since ECONNABORTED is supposed to mean that connect() failed, but what
     # can you do). In this case the other side did nothing wrong, but there's
-    # no way to recover, so we let it pass, and just cross our fingers its not
+    # no way to recover, so we let it pass, and just cross our fingers it's not
     # hiding any (other) real bugs. For more details see:
     #
     #   https://github.com/python-trio/trio/issues/1293
@@ -186,7 +197,7 @@ class PyOpenSSLEchoStream:
         # we still have to support versions before that, and that means we
         # need to test renegotiation support, which means we need to force this
         # to use a lower version where this test server can trigger
-        # renegotiations. Of course TLS 1.3 support isn't released yet, but
+        # re-negotiations. Of course TLS 1.3 support isn't released yet, but
         # I'm told that this will work once it is. (And once it is we can
         # remove the pragma: no cover too.) Alternatively, we could switch to
         # using TLSv1_2_METHOD.
@@ -519,7 +530,7 @@ async def test_attributes(client_ctx):
 # also seen cases where our send_all blocks waiting to write, and then our receive_some
 # also blocks waiting to write, and they never wake up again. It looks like
 # some kind of deadlock. I suspect there may be an issue where we've filled up
-# the send buffers, and the remote side is trying to handle the renegotiation
+# the send-buffers, and the remote side is trying to handle the renegotiation
 # from inside a write() call, so it has a problem: there's all this application
 # data clogging up the pipe, but it can't process and return it to the
 # application because it's in write(), and it doesn't want to buffer infinite
@@ -809,6 +820,7 @@ async def test_send_all_empty_string(client_ctx):
         await s.aclose()
 
 
+@skip_on_python_37_linux
 @pytest.mark.parametrize("https_compatible", [False, True])
 async def test_SSLStream_generic(client_ctx, https_compatible):
     async def stream_maker():
@@ -1024,6 +1036,7 @@ async def test_ssl_bad_shutdown(client_ctx):
     await server.aclose()
 
 
+@skip_on_python_37_linux
 async def test_ssl_bad_shutdown_but_its_ok(client_ctx):
     client, server = ssl_memory_stream_pair(
         client_ctx,
@@ -1088,6 +1101,7 @@ async def test_ssl_only_closes_stream_once(client_ctx):
     assert transport_close_count == 1
 
 
+@skip_on_python_37_linux
 async def test_ssl_https_compatibility_disagreement(client_ctx):
     client, server = ssl_memory_stream_pair(
         client_ctx,
@@ -1112,6 +1126,7 @@ async def test_ssl_https_compatibility_disagreement(client_ctx):
         nursery.start_soon(receive_and_expect_error)
 
 
+@skip_on_python_37_linux
 async def test_https_mode_eof_before_handshake(client_ctx):
     client, server = ssl_memory_stream_pair(
         client_ctx,

--- a/trio/tests/test_ssl.py
+++ b/trio/tests/test_ssl.py
@@ -1128,7 +1128,7 @@ async def test_ssl_https_compatibility_disagreement(client_ctx):
         nursery.start_soon(receive_and_expect_error)
 
 
-@skip_on_python_37_linux
+@skip_on_broken_openssl
 async def test_https_mode_eof_before_handshake(client_ctx):
     client, server = ssl_memory_stream_pair(
         client_ctx,

--- a/trio/tests/test_ssl.py
+++ b/trio/tests/test_ssl.py
@@ -1103,7 +1103,7 @@ async def test_ssl_only_closes_stream_once(client_ctx):
     assert transport_close_count == 1
 
 
-@skip_on_python_37_linux
+@skip_on_broken_openssl
 async def test_ssl_https_compatibility_disagreement(client_ctx):
     client, server = ssl_memory_stream_pair(
         client_ctx,


### PR DESCRIPTION
I was prompted by @pquentin to create a PR along these lines. See: https://github.com/python-trio/trio/pull/2480

We have certain SSL-related tests that are failing with Python 3.7 running on Ubuntu. Disabling them makes some sense, as Python 3.7 is reaching EOL in less than a year.

We continue to support Python 3.7, as the issue most likely is in the test suite.