### PR TITLE
Stop testing PyPy 3.7, start testing 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           # support this for PyPy presently so we get no help there.
           #
           # CPython -> 3.9.0-alpha - 3.9.X
-          # PyPy    -> pypy-3.7
+          # PyPy    -> pypy-3.9
           python-version: ${{ fromJSON(format('["{0}", "{1}"]', format('{0}.0-alpha - {0}.X', matrix.python), matrix.python))[startsWith(matrix.python, 'pypy')] }}
           architecture: '${{ matrix.arch }}'
           cache: pip
@@ -74,7 +74,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['pypy-3.7', 'pypy-3.8', '3.7', '3.8', '3.9', '3.10', '3.11-dev']
+        python: ['pypy-3.8', '3.7', '3.8', '3.9', '3.10', '3.11-dev']
         check_formatting: ['0']
         pypy_nightly_branch: ['']
         extra_name: ['']
@@ -82,17 +82,16 @@ jobs:
           - python: '3.8'
             check_formatting: '1'
             extra_name: ', check formatting'
-          - python: '3.7'  # <- not actually used
-            pypy_nightly_branch: 'py3.7'
-            extra_name: ', pypy 3.7 nightly'
           - python: '3.8'  # <- not actually used
             pypy_nightly_branch: 'py3.8'
             extra_name: ', pypy 3.8 nightly'
+          - python: '3.9'  # <- not actually used
+            pypy_nightly_branch: 'py3.9'
+            extra_name: ', pypy 3.9 nightly'
     continue-on-error: >-
       ${{
         (
           matrix.check_formatting == '1'
-          || matrix.pypy_nightly_branch == 'py3.7'
           || endsWith(matrix.python, '-dev')
         )
         && true


### PR DESCRIPTION
While revieweing https://github.com/python-trio/trio/pull/2488 from @harahu, I realized that the issue was in PyPy 3.7, not CPython. And given that PyPy has stopped supporting PyPy 3.7, I though a better fix could be to bump the PyPy versions we use. https://mail.python.org/archives/list/pypy-dev@python.org/thread/3W5HPNWKLYPVJSPFXJOSBHOIP3DCLSMY/

Let's try that!