### PR TITLE
Fix crash due to runtime import of `typing_extensions`

### DIFF
--- a/trio/_unix_pipes.py
+++ b/trio/_unix_pipes.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 import os
 import errno
-from typing_extensions import Final as FinalType
+from typing import TYPE_CHECKING
 
 from ._abc import Stream
 from ._util import ConflictDetector, Final
 
 import trio
+
+if TYPE_CHECKING:
+    from typing_extensions import Final as FinalType
 
 if os.name != "posix":
     # We raise an error here rather than gating the import in lowlevel.py


### PR DESCRIPTION
hi!

#2502 added a runtime dependency on `typing_extensions` but did not update the packaging config to specify this dependency.

presently no runtime features of `typing_extensions` are being used, so it does not need to be a dependency at runtime.

(I have not included a changelog entry here since #2502 did not either and the bug this fixes was never user-facing.)