### PR TITLE
Fix crash due to runtime import of `typing_extensions`

### DIFF
--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -23,9 +23,6 @@ from outcome import Error, Outcome, Value, capture
 from sniffio import current_async_library_cvar
 from sortedcontainers import SortedDict
 
-# An unfortunate name collision here with trio._util.Final
-from typing_extensions import Final as FinalT
-
 from .. import _core
 from .._util import Final, NoPublicConstructor, coroutine_or_error
 from ._asyncgens import AsyncGenerators
@@ -46,6 +43,10 @@ from ._traps import (
 
 if sys.version_info < (3, 11):
     from exceptiongroup import BaseExceptionGroup
+
+if TYPE_CHECKING:
+    # An unfortunate name collision here with trio._util.Final
+    from typing_extensions import Final as FinalT
 
 DEADLINE_HEAP_MIN_PRUNE_THRESHOLD: FinalT = 1000
 


### PR DESCRIPTION
hi! the issue fixed in #2507 was re-introduced when #2477 was merged.