### PR TITLE
ConflictDetector: kill both tasks

### DIFF
--- a/trio/_util.py
+++ b/trio/_util.py
@@ -180,15 +180,20 @@ class ConflictDetector:
     def __init__(self, msg):
         self._msg = msg
         self._held = False
-
+        self._conflicted = False
+    
     def __enter__(self):
         if self._held:
+            self._conflicted = True
             raise trio.BusyResourceError(self._msg)
         else:
             self._held = True
-
+    
     def __exit__(self, *args):
         self._held = False
+        if self._conflicted:
+            self._conflicted = False
+            raise trio.BusyResourceError(self._msg)
 
 
 def async_wraps(cls, wrapped_cls, attr_name):


### PR DESCRIPTION
It's not always obvious which task is the "bad guy" when a conflict occurs. If the "legitimate" task crashes and the buggy one, i.e. the one that forgot to take the lock, does not, the backtrace is not helpful.

Thus, kill them both.