### PR TITLE
split highly permissioned dependabot autoformatter into separate job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,12 +71,6 @@ jobs:
     name: 'Ubuntu (${{ matrix.python }}${{ matrix.extra_name }})'
     timeout-minutes: 10
     runs-on: 'ubuntu-latest'
-    # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#changing-github_token-permissions
-    permissions:
-      pull-requests: write
-      issues: write
-      repository-projects: write
-      contents: write
     strategy:
       fail-fast: false
       matrix:
@@ -126,9 +120,33 @@ jobs:
           CHECK_FORMATTING: '${{ matrix.check_formatting }}'
           # Should match 'name:' up above
           JOB_NAME: 'Ubuntu (${{ matrix.python }}${{ matrix.extra_name }})'
+
+  autofmt:
+    name: Autoformat dependabot PR
+    timeout-minutes: 10
+    if: github.actor == 'dependabot[bot]'
+    runs-on: 'ubuntu-latest'
+    # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#changing-github_token-permissions
+    permissions:
+      pull-requests: write
+      issues: write
+      repository-projects: write
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+      - name: Check formatting
+        run: |
+          python -m pip install -r test-requirements.txt
+          source check.sh
       - name: Commit autoformatter changes
-        continue-on-error: true
-        if: failure() && matrix.check_formatting == '1' && github.actor == 'dependabot[bot]'
+        if: failure()
         run: |
           black setup.py trio
           git config user.name 'github-actions[bot]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
       - name: Check formatting
         run: |
           python -m pip install -r test-requirements.txt
-          source check.sh
+          ./check.sh
       - name: Commit autoformatter changes
         if: failure()
         run: |


### PR DESCRIPTION
We don't need every ubuntu job to have high permissions or checkout the head ref, only those issued by dependabot.

Unfortunately, we can't know if it fixes dependabot until merging!