### PR TITLE
Document that new tasks from `nursery.start_soon()` may start in any order

### DIFF
--- a/docs/source/code-of-conduct.rst
+++ b/docs/source/code-of-conduct.rst
@@ -19,7 +19,7 @@ If you see a Code of Conduct violation, follow these steps:
    them to stop and/or edit their message(s) or commits.
 2. That person should immediately stop the behavior and correct the
    issue.
-3. If this doesn’t happen, or if you're uncomfortable speaking up,
+3. If this doesn't happen, or if you're uncomfortable speaking up,
    :ref:`contact the maintainers <coc-contacting-maintainers>`.
 4. As soon as possible, a maintainer will look into the issue, and take
    :ref:`further action (see below) <coc-further-enforcement>`, starting with

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -556,7 +556,8 @@ then we'll figure something out.
 .. Possible references for future additions:
 
    """
-   Jumping into an unfamiliar codebase (or any for that matter) for the first time can be scary. Plus, if it’s your first time contributing to open source, it can even be scarier!
+   Jumping into an unfamiliar codebase (or any for that matter) for the first time can be scary.
+   Plus, if it's your first time contributing to open source, it can even be scarier!
 
    But, we at webpack believe:
 

--- a/newsfragments/970.doc.rst
+++ b/newsfragments/970.doc.rst
@@ -1,0 +1,1 @@
+Documented that :obj:`Nursery.start_soon` does not guarantee task ordering.

--- a/trio/_core/_run.py
+++ b/trio/_core/_run.py
@@ -1022,18 +1022,17 @@ class Nursery(metaclass=NoPublicConstructor):
     def start_soon(self, async_fn, *args, name=None):
         """Creates a child task, scheduling ``await async_fn(*args)``.
 
-        This and :meth:`start` are the two fundamental methods for
+        If you want to run a function and immediately wait for its result,
+        then you don't need a nursery; just use ``await async_fn(*args)``.
+        If you want to wait for the task to initialize itself before
+        continuing, see :meth:`start`, the other fundamental method for
         creating concurrent tasks in Trio.
 
         Note that this is *not* an async function and you don't use await
         when calling it. It sets up the new task, but then returns
-        immediately, *before* it has a chance to run. The new task won’t
-        actually get a chance to do anything until some later point when
-        you execute a checkpoint and the scheduler decides to run it.
-        If you want to run a function and immediately wait for its result,
-        then you don't need a nursery; just use ``await async_fn(*args)``.
-        If you want to wait for the task to initialize itself before
-        continuing, see :meth:`start`.
+        immediately, *before* the new task has a chance to do anything.
+        New tasks may start running in any order, and at any checkpoint the
+        scheduler chooses - at latest when the nursery is waiting to exit.
 
         It's possible to pass a nursery object into another task, which
         allows that task to start new child tasks in the first task's
@@ -1076,9 +1075,9 @@ class Nursery(metaclass=NoPublicConstructor):
         The conventional way to define ``async_fn`` is like::
 
             async def async_fn(arg1, arg2, *, task_status=trio.TASK_STATUS_IGNORED):
-                ...
+                ...  # Caller is blocked waiting for this code to run
                 task_status.started()
-                ...
+                ...  # This async code can be interleaved with the caller
 
         :attr:`trio.TASK_STATUS_IGNORED` is a special global object with
         a do-nothing ``started`` method. This way your function supports


### PR DESCRIPTION
Closes #970, rebased and refined from #972.

Also replaces two unrelated `’` 'smart' singlequotes with `'` ascii singlequotes, since there was one in the docstring I edited.