### PR TITLE
add trio-level timeout to test_dtls.test_handshake_over_terrible_network

### DIFF
--- a/trio/tests/test_dtls.py
+++ b/trio/tests/test_dtls.py
@@ -108,9 +108,8 @@ async def test_handshake_over_terrible_network(autojump_clock):
     fn = FakeNet()
     fn.enable()
 
-    async with dtls_echo_server() as (_, address):
-        async with trio.open_nursery() as nursery:
-
+    with trio.fail_after(10):
+        async with dtls_echo_server() as (_, address), trio.open_nursery() as nursery:
             async def route_packet(packet):
                 while True:
                     op = r.choices(


### PR DESCRIPTION
Hopefully will reveal insight into intermittent timeout failures in CI, which are not isolated to pypy:

https://github.com/python-trio/trio/actions/runs/4392870655/jobs/7692906224#step:4:985

