### PR TITLE
use autojump_threshold in test_handshake_over_terrible_network

### DIFF
--- a/trio/tests/test_dtls.py
+++ b/trio/tests/test_dtls.py
@@ -103,10 +103,12 @@ async def test_smoke(ipv6):
 @slow
 async def test_handshake_over_terrible_network(autojump_clock):
     # PyPy is not fast enough
-    HANDSHAKES = 500 if sys.implementation.name == "pypy" else 1000
+    HANDSHAKES = 50 if sys.implementation.name == "pypy" else 100
     r = random.Random(0)
     fn = FakeNet()
     fn.enable()
+    # avoid spurious timeouts on slow machines
+    autojump_clock.autojump_threshold = 0.001
 
     async with dtls_echo_server() as (_, address):
         async with trio.open_nursery() as nursery:

--- a/trio/tests/test_dtls.py
+++ b/trio/tests/test_dtls.py
@@ -3,7 +3,6 @@ import trio
 import trio.testing
 from trio import DTLSEndpoint
 import random
-import sys
 import attr
 from contextlib import asynccontextmanager
 from itertools import count
@@ -102,8 +101,7 @@ async def test_smoke(ipv6):
 
 @slow
 async def test_handshake_over_terrible_network(autojump_clock):
-    # PyPy is not fast enough
-    HANDSHAKES = 50 if sys.implementation.name == "pypy" else 100
+    HANDSHAKES = 100
     r = random.Random(0)
     fn = FakeNet()
     fn.enable()


### PR DESCRIPTION
observation: any autojump threshold over 0 takes MUCH longer than 0
hypothesis: 10 second timeout cscope at the end of test is spuriously cancelling attempts on slow machines
experiment: set a minimal threshold and scale back # of handshakes to finish in a reasonable time, check if CI timeouts are avoided