### PR TITLE
Ensure our autodeps workflow adds the new files

### DIFF
--- a/.github/workflows/autodeps.yml
+++ b/.github/workflows/autodeps.yml
@@ -49,6 +49,7 @@ jobs:
           git switch --force-create autodeps/bump_from_${GITHUB_SHA:0:6}
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add .
           git commit -am "Dependency updates"
           git push --force --set-upstream origin autodeps/bump_from_${GITHUB_SHA:0:6}
 


### PR DESCRIPTION
Currently it's failing because https://github.com/python-trio/trio/actions/runs/4853254871/jobs/8649206439#step:6:56

I think this fixes that? Not sure.