### PR TITLE
Clear some cruft from 3.6

### DIFF
--- a/docs-requirements.in
+++ b/docs-requirements.in
@@ -9,7 +9,6 @@ towncrier
 
 # Trio's own dependencies
 cffi; os_name == "nt"
-contextvars; python_version < "3.7"
 attrs >= 19.2.0
 sortedcontainers
 async_generator >= 1.9

--- a/trio/_socket.py
+++ b/trio/_socket.py
@@ -324,13 +324,6 @@ _SOCK_TYPE_MASK = ~(
 )
 
 
-# This function will modify the given socket to match the behavior in python
-# 3.7. This will become unnecessary and can be removed when support for versions
-# older than 3.7 is dropped.
-def real_socket_type(type_num):
-    return type_num & _SOCK_TYPE_MASK
-
-
 def _make_simple_sock_method_wrapper(methname, wait_fn, maybe_avail=False):
     fn = getattr(_stdlib_socket.socket, methname)
 
@@ -496,10 +489,7 @@ class _SocketType(SocketType):
 
     @property
     def type(self):
-        # Modify the socket type do match what is done on python 3.7. When
-        # support for versions older than 3.7 is dropped, this can be updated
-        # to just return self._sock.type
-        return real_socket_type(self._sock.type)
+        return self._sock.type
 
     @property
     def proto(self):

--- a/trio/_tests/test_socket.py
+++ b/trio/_tests/test_socket.py
@@ -356,7 +356,7 @@ async def test_SocketType_basics():
     # type family proto
     stdlib_sock = stdlib_socket.socket()
     sock = tsocket.from_stdlib_socket(stdlib_sock)
-    assert sock.type == _tsocket.real_socket_type(stdlib_sock.type)
+    assert sock.type == stdlib_sock.type
     assert sock.family == stdlib_sock.family
     assert sock.proto == stdlib_sock.proto
     sock.close()


### PR DESCRIPTION
I see we have an extra dependency in `docs-requirements.in` (`async_generator`). But I'm not sure if I should include that in this. I'm leaning towards no.