### PR TITLE
xfail test_nursery_cancel_doesnt_create_cyclic_garbage on 3.12

### DIFF
--- a/trio/_core/_tests/test_run.py
+++ b/trio/_core/_tests/test_run.py
@@ -2279,6 +2279,10 @@ async def test_cancel_scope_exit_doesnt_create_cyclic_garbage():
         gc.garbage.clear()
 
 
+@pytest.mark.xfail(
+    sys.version_info >= (3, 12),
+    reason="Waiting on https://github.com/python/cpython/issues/100964",
+)
 @pytest.mark.skipif(
     sys.implementation.name != "cpython", reason="Only makes sense with refcounting GC"
 )


### PR DESCRIPTION
Marks the remaining fail in #2646 as xfail so CI tests can fully "succeed" and status goes back to indicating whether tests passed or not.

Also removes a couple unused imports in the file