### PR TITLE
Fix tokenless uploads by hardcoding token...

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,8 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           directory: empty
-          name: 'Windows (${{ matrix.python }}, ${{ matrix.arch }}${{ matrix.extra_name }})'
+          token: 87cefb17-c44b-4f2f-8b30-1fff5769ce46
+          name: Windows (${{ matrix.python }}, ${{ matrix.arch }}${{ matrix.extra_name }})
           flags: Windows,${{ matrix.python }}
 
   Ubuntu:
@@ -131,7 +132,8 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           directory: empty
-          name: 'Ubuntu (${{ matrix.python }}${{ matrix.extra_name }})'
+          token: 87cefb17-c44b-4f2f-8b30-1fff5769ce46
+          name: Ubuntu (${{ matrix.python }}${{ matrix.extra_name }})
           flags: Ubuntu,${{ matrix.python }}
 
   macOS:
@@ -166,7 +168,8 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           directory: empty
-          name: 'macOS (${{ matrix.python }})'
+          token: 87cefb17-c44b-4f2f-8b30-1fff5769ce46
+          name: macOS (${{ matrix.python }})
           flags: macOS,${{ matrix.python }}
 
   # https://github.com/marketplace/actions/alls-green#why


### PR DESCRIPTION
This is recommended by codecov themselves: https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954

While this *sucks*, I don't think there's a better alternative. I believe codecov operates the following way for "tokenless" uploads:
 - the action notifies the core service that it's done
 - the core service uses github's API to verify that the action is actually who it claims to be

Now, you may go "hey! tokenless? sounds like pypi's tokenless publishing! how's pypi doing it but not codecov?!?!?"

Basically, pypi uses the `id-token` permission to do some fancy OpenIDConnect nonsense. codecov's action *could* require this permission, but then it would only work for PRs not from forks: the [maximum permission level for PRs from forks for `id-token` is `read`](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token), whereas you need `write` permissions to actually do the nonsense.

A similar restriction accompanies secrets, meaning that I need to hardcode this for PRs from forks to work.

---

tl;dr what codecov offers is the best way they can offer tokenless publishing, but it runs into github rate limits. we don't want to have flakey codecov like that, meaning that we gotta use the token to tell codecov "yes I am who I claim to be". this token needs to be hardcoded as:

> Due to the dangers inherent to automatic processing of PRs, GitHub’s standard pull_request workflow trigger by default prevents write permissions and secrets access to the target repository.

https://securitylab.github.com/research/github-actions-preventing-pwn-requests/