### PR TITLE
Render long description as ReST

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setup(
     version=__version__,
     description="A friendly Python library for async concurrency and I/O",
     long_description=LONG_DESC,
+    long_description_content_type="text/x-rst",
     author="Nathaniel J. Smith",
     author_email="njs@pobox.com",
     url="https://github.com/python-trio/trio",


### PR DESCRIPTION
Currently https://pypi.org/project/trio/ renders weirdly. I haven't tested this actually fixes it but I do believe it does.