### PR TITLE
Release 0.22.1

### DIFF
--- a/docs/source/history.rst
+++ b/docs/source/history.rst
@@ -5,6 +5,36 @@ Release history
 
 .. towncrier release notes start
 
+Trio 0.22.1 (2023-07-02)
+------------------------
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+- Timeout functions now raise `ValueError` if passed `math.nan`. This includes `trio.sleep`, `trio.sleep_until`, `trio.move_on_at`, `trio.move_on_after`, `trio.fail_at` and `trio.fail_after`. (`#2493 <https://github.com/python-trio/trio/issues/2493>`__)
+
+
+Features
+~~~~~~~~
+
+- Added support for naming threads created with `trio.to_thread.run_sync`, requires pthreads so is only available on POSIX platforms with glibc installed. (`#1148 <https://github.com/python-trio/trio/issues/1148>`__)
+- `trio.socket.socket` now prints the address it tried to connect to upon failure. (`#1810 <https://github.com/python-trio/trio/issues/1810>`__)
+
+
+Bugfixes
+~~~~~~~~
+
+- Fixed a crash that can occur when running Trio within an embedded Python interpreter, by handling the `TypeError` that is raised when trying to (re-)install a C signal handler. (`#2333 <https://github.com/python-trio/trio/issues/2333>`__)
+- Fix :func:`sniffio.current_async_library` when Trio tasks are spawned from a non-Trio context (such as when using trio-asyncio). Previously, a regular Trio task would inherit the non-Trio library name, and spawning a system task would cause the non-Trio caller to start thinking it was Trio. (`#2462 <https://github.com/python-trio/trio/issues/2462>`__)
+- Issued a new release as in the git tag for 0.22.0, ``trio.__version__`` is incorrectly set to 0.21.0+dev. (`#2485 <https://github.com/python-trio/trio/issues/2485>`__)
+
+
+Improved documentation
+~~~~~~~~~~~~~~~~~~~~~~
+
+- Documented that :obj:`Nursery.start_soon` does not guarantee task ordering. (`#970 <https://github.com/python-trio/trio/issues/970>`__)
+
+
 Trio 0.22.0 (2022-09-28)
 ------------------------
 

--- a/newsfragments/1148.feature.rst
+++ b/newsfragments/1148.feature.rst
@@ -1,1 +1,0 @@
-Added support for naming threads created with `trio.to_thread.run_sync`, requires pthreads so is only available on POSIX platforms with glibc installed.

--- a/newsfragments/1810.feature.rst
+++ b/newsfragments/1810.feature.rst
@@ -1,1 +1,0 @@
-`trio.socket.socket` now prints the address it tried to connect to upon failure.

--- a/newsfragments/2333.bugfix.rst
+++ b/newsfragments/2333.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed a crash that can occur when running Trio within an embedded Python interpreter, by handling the `TypeError` that is raised when trying to (re-)install a C signal handler.

--- a/newsfragments/2462.bugfix.rst
+++ b/newsfragments/2462.bugfix.rst
@@ -1,1 +1,0 @@
-Fix :func:`sniffio.current_async_library` when Trio tasks are spawned from a non-Trio context (such as when using trio-asyncio). Previously, a regular Trio task would inherit the non-Trio library name, and spawning a system task would cause the non-Trio caller to start thinking it was Trio.

--- a/newsfragments/2493.breaking.rst
+++ b/newsfragments/2493.breaking.rst
@@ -1,1 +1,0 @@
-Timeout functions now raise `ValueError` if passed `math.nan`. This includes `trio.sleep`, `trio.sleep_until`, `trio.move_on_at`, `trio.move_on_after`, `trio.fail_at` and `trio.fail_after`.

--- a/newsfragments/970.doc.rst
+++ b/newsfragments/970.doc.rst
@@ -1,1 +1,0 @@
-Documented that :obj:`Nursery.start_soon` does not guarantee task ordering.

--- a/trio/_version.py
+++ b/trio/_version.py
@@ -1,3 +1,3 @@
 # This file is imported from __init__.py and exec'd from setup.py
 
-__version__ = "0.22.0+dev"
+__version__ = "0.22.1"

--- a/trio/_version.py
+++ b/trio/_version.py
@@ -1,3 +1,3 @@
 # This file is imported from __init__.py and exec'd from setup.py
 
-__version__ = "0.22.1"
+__version__ = "0.22.1+dev"

--- a/trio/tests.py
+++ b/trio/tests.py
@@ -7,7 +7,7 @@ from ._deprecate import warn_deprecated
 
 warn_deprecated(
     "trio.tests",
-    "0.24.0",
+    "0.22.1",
     instead="trio._tests",
     issue="https://github.com/python-trio/trio/issues/274",
 )
@@ -21,7 +21,7 @@ class TestsDeprecationWrapper:
     def __getattr__(self, attr: str) -> Any:
         warn_deprecated(
             f"trio.tests.{attr}",
-            "0.24.0",
+            "0.22.1",
             instead=f"trio._tests.{attr}",
             issue="https://github.com/python-trio/trio/issues/274",
         )


### PR DESCRIPTION
- Fixes https://github.com/python-trio/trio/issues/2655
- Fixes https://github.com/python-trio/trio/issues/2485 (and duplicate https://github.com/python-trio/trio/issues/2583)