### PR TITLE
Docs: Fix line numbers on tutorial.rst

### DIFF
--- a/docs/source/reference-core.rst
+++ b/docs/source/reference-core.rst
@@ -1167,7 +1167,7 @@ the previous version, and then exits cleanly. The only change is the
 addition of ``async with`` blocks inside the producer and consumer:
 
 .. literalinclude:: reference-core/channels-shutdown.py
-   :emphasize-lines: 10,15
+   :emphasize-lines: 11,17
 
 The really important thing here is the producer's ``async with`` .
 When the producer exits, this closes the ``send_channel``, and that
@@ -1246,7 +1246,7 @@ Fortunately, there's a better way! Here's a fixed version of our
 program above:
 
 .. literalinclude:: reference-core/channels-mpmc-fixed.py
-   :emphasize-lines: 7, 9, 10, 12, 13
+   :emphasize-lines: 8, 10, 11, 13, 14
 
 This example demonstrates using the `MemorySendChannel.clone` and
 `MemoryReceiveChannel.clone` methods. What these do is create copies

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -436,15 +436,15 @@ Now that we understand ``async with``, let's look at ``parent`` again:
    :end-at: all done!
 
 There are only 4 lines of code that really do anything here. On line
-17, we use :func:`trio.open_nursery` to get a "nursery" object, and
+20, we use :func:`trio.open_nursery` to get a "nursery" object, and
 then inside the ``async with`` block we call ``nursery.start_soon`` twice,
-on lines 19 and 22. There are actually two ways to call an async
+on lines 22 and 25. There are actually two ways to call an async
 function: the first one is the one we already saw, using ``await
 async_fn()``; the new one is ``nursery.start_soon(async_fn)``: it asks Trio
 to start running this async function, *but then returns immediately
 without waiting for the function to finish*. So after our two calls to
 ``nursery.start_soon``, ``child1`` and ``child2`` are now running in the
-background. And then at line 25, the commented line, we hit the end of
+background. And then at line 28, the commented line, we hit the end of
 the ``async with`` block, and the nursery's ``__aexit__`` function
 runs. What this does is force ``parent`` to stop here and wait for all
 the children in the nursery to exit. This is why you have to use


### PR DESCRIPTION
Issue: Documentation doesn't aligns with the code block's line number.

In image format:
![image](https://github.com/python-trio/trio/assets/63696279/546f2ebf-481f-4a95-a22a-036412d6239a)
![image](https://github.com/python-trio/trio/assets/63696279/1f3e8f3f-559c-4773-badb-74aa4fa67644)

