### PR TITLE
Fix typo in reference-core.rst

### DIFF
--- a/docs/source/reference-core.rst
+++ b/docs/source/reference-core.rst
@@ -693,7 +693,7 @@ Errors in multiple child tasks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Normally, in Python, only one thing happens at a time, which means
-that only one thing can wrong at a time. Trio has no such
+that only one thing can go wrong at a time. Trio has no such
 limitation. Consider code like::
 
     async def broken1():


### PR DESCRIPTION
Normally I wouldn't make such a trivial PR, but this is such an excellent quote that I think it deserves to be fixed.