### PR TITLE
Partially revert "Bump certifi from 2023.5.7 to 2023.7.22"

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -14,7 +14,7 @@ attrs==23.1.0
     #   outcome
 babel==2.12.1
     # via sphinx
-certifi==2023.7.22
+certifi==2023.5.7
     # via requests
 cffi==1.15.1
     # via cryptography
@@ -42,6 +42,10 @@ imagesize==1.4.1
     # via sphinx
 immutables==0.19
     # via -r docs-requirements.in
+importlib-metadata==6.8.0
+    # via sphinx
+importlib-resources==6.0.0
+    # via towncrier
 incremental==22.10.0
     # via towncrier
 jinja2==3.0.3
@@ -61,6 +65,8 @@ pygments==2.15.1
     # via sphinx
 pyopenssl==23.2.0
     # via -r docs-requirements.in
+pytz==2023.3
+    # via babel
 requests==2.31.0
     # via sphinx
 sniffio==1.3.0
@@ -93,7 +99,13 @@ sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
 sphinxcontrib-trio==1.1.2
     # via -r docs-requirements.in
+tomli==2.0.1
+    # via towncrier
 towncrier==23.6.0
     # via -r docs-requirements.in
 urllib3==2.0.3
     # via requests
+zipp==3.16.2
+    # via
+    #   importlib-metadata
+    #   importlib-resources

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -14,7 +14,7 @@ attrs==23.1.0
     #   outcome
 babel==2.12.1
     # via sphinx
-certifi==2023.5.7
+certifi==2023.7.22
     # via requests
 cffi==1.15.1
     # via cryptography


### PR DESCRIPTION
Partially reverts python-trio/trio#2715, which was merged with failing tests as it wiped out a bunch of lines from `docs-requirements.txt`