### PR TITLE
Add type annotations to `_depreciate.py`

### DIFF
--- a/trio/_deprecate.py
+++ b/trio/_deprecate.py
@@ -4,7 +4,7 @@ import sys
 import warnings
 from functools import wraps
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, Callable, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Callable, TypeVar, Union, cast
 
 if TYPE_CHECKING:
     from mypy_extensions import KwArg as _KwArg, VarArg as _VarArg
@@ -168,7 +168,7 @@ class _ModuleWithDeprecations(ModuleType):
 
 def enable_attribute_deprecations(module_name: str) -> None:
     module: ModuleType | _ModuleWithDeprecations = cast(
-        ModuleType | _ModuleWithDeprecations, sys.modules[module_name]
+        Union[ModuleType, _ModuleWithDeprecations], sys.modules[module_name]
     )
     module.__class__ = _ModuleWithDeprecations
     assert isinstance(module, _ModuleWithDeprecations)

--- a/trio/_tests/verify_types.json
+++ b/trio/_tests/verify_types.json
@@ -46,8 +46,8 @@
     ],
     "otherSymbolCounts": {
       "withAmbiguousType": 3,
-      "withKnownType": 574,
-      "withUnknownType": 76
+      "withKnownType": 576,
+      "withUnknownType": 74
     },
     "packageName": "trio",
     "symbols": [
@@ -85,10 +85,8 @@
       "trio._ssl.SSLStream.transport_stream",
       "trio._ssl.SSLStream.unwrap",
       "trio._ssl.SSLStream.wait_send_all_might_not_block",
-      "trio._subprocess.Process.__aenter__",
       "trio._subprocess.Process.__init__",
       "trio._subprocess.Process.__repr__",
-      "trio._subprocess.Process.aclose",
       "trio._subprocess.Process.args",
       "trio._subprocess.Process.encoding",
       "trio._subprocess.Process.errors",


### PR DESCRIPTION
This PR adds type annotations to `_depreciate.py`.

With mypy, everything is good except for one error in `deprecated_alias` at the moment that I'm not sure how to handle.

I would love feedback and any comments on how this could be improved to be more accurate.