### PR TITLE
Add typing to `_tools/gen_exports.py`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ module = [
     "trio._ki",
     "trio._socket",
     "trio._sync",
+    "trio._tools.gen_exports",
     "trio._util",
 ]
 disallow_incomplete_defs = true

--- a/trio/_tools/gen_exports.py
+++ b/trio/_tools/gen_exports.py
@@ -9,7 +9,7 @@ import argparse
 import ast
 import os
 import sys
-from collections.abc import Generator, Iterable
+from collections.abc import Iterable, Iterator
 from pathlib import Path
 from textwrap import indent
 from typing import TYPE_CHECKING
@@ -63,7 +63,7 @@ def is_public(node: ast.AST) -> TypeGuard[ast.FunctionDef | ast.AsyncFunctionDef
 
 def get_public_methods(
     tree: ast.AST,
-) -> Generator[ast.FunctionDef | ast.AsyncFunctionDef, None, None]:
+) -> Iterator[ast.FunctionDef | ast.AsyncFunctionDef]:
     """Return a list of methods marked as public.
     The function walks the given tree and extracts
     all objects that are functions which are marked


### PR DESCRIPTION
This PR adds type annotations to `_tools/gen_exports.py`

I would love feedback and any comments on how this could be improved to be more accurate.