### PR TITLE
Add missing type annotations to `_core/_mock_clock.py`

### DIFF
--- a/trio/_core/_mock_clock.py
+++ b/trio/_core/_mock_clock.py
@@ -62,7 +62,7 @@ class MockClock(Clock, metaclass=Final):
 
     """
 
-    def __init__(self, rate: float = 0.0, autojump_threshold: float = inf):
+    def __init__(self, rate: float = 0.0, autojump_threshold: float = inf) -> None:
         # when the real clock said 'real_base', the virtual time was
         # 'virtual_base', and since then it's advanced at 'rate' virtual
         # seconds per real second.
@@ -150,7 +150,7 @@ class MockClock(Clock, metaclass=Final):
         else:
             return 999999999
 
-    def jump(self, seconds) -> None:
+    def jump(self, seconds: float) -> None:
         """Manually advance the clock by the given number of seconds.
 
         Args:

--- a/trio/_core/_mock_clock.py
+++ b/trio/_core/_mock_clock.py
@@ -62,7 +62,7 @@ class MockClock(Clock, metaclass=Final):
 
     """
 
-    def __init__(self, rate: float = 0.0, autojump_threshold: float = inf) -> None:
+    def __init__(self, rate: float = 0.0, autojump_threshold: float = inf):
         # when the real clock said 'real_base', the virtual time was
         # 'virtual_base', and since then it's advanced at 'rate' virtual
         # seconds per real second.

--- a/trio/_tests/verify_types.json
+++ b/trio/_tests/verify_types.json
@@ -7,11 +7,11 @@
     "warningCount": 0
   },
   "typeCompleteness": {
-    "completenessScore": 0.9154704944178629,
+    "completenessScore": 0.9170653907496013,
     "exportedSymbolCounts": {
       "withAmbiguousType": 0,
-      "withKnownType": 574,
-      "withUnknownType": 53
+      "withKnownType": 575,
+      "withUnknownType": 52
     },
     "ignoreUnknownTypesFromImports": true,
     "missingClassDocStringCount": 1,
@@ -46,12 +46,11 @@
     ],
     "otherSymbolCounts": {
       "withAmbiguousType": 3,
-      "withKnownType": 600,
-      "withUnknownType": 63
+      "withKnownType": 602,
+      "withUnknownType": 61
     },
     "packageName": "trio",
     "symbols": [
-      "trio._core._mock_clock.MockClock.jump",
       "trio._core._run.Nursery.start",
       "trio._core._run.Nursery.start_soon",
       "trio._core._run.TaskStatus.__repr__",


### PR DESCRIPTION
This PR adds missing type annotations to `_core/_mock_clock.py`.