### PR TITLE
Update `contributing.rst` to talk about pre-commit

### DIFF
--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -323,7 +323,7 @@ in-place.)
 
 
 Additionally, in some cases it is necessary to disable isort changing the
-order of imports. To do so you can add ``# isort: skip`` comments.
+order of imports. To do so you can add ``# isort: split`` comments.
 For more information, please see `isort's docs <https://pycqa.github.io/isort/docs/configuration/action_comments.html>`__.
 
 

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -322,6 +322,11 @@ If you want to see what changes black will make, you can use::
 in-place.)
 
 
+Additionally, in some cases it is necessary to disable isort changing the
+order of imports. To do so you can add ``# isort: skip`` comments.
+For more information, please see `isort's docs <https://pycqa.github.io/isort/docs/configuration/action_comments.html>`__.
+
+
 .. _pull-request-release-notes:
 
 Release notes

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -286,19 +286,30 @@ Code formatting
 ~~~~~~~~~~~~~~~
 
 Instead of wasting time arguing about code formatting, we use `black
-<https://github.com/psf/black>`__ to automatically format all our
-code to a standard style. While you're editing code you can be as
-sloppy as you like about whitespace; and then before you commit, just
-run::
+<https://github.com/psf/black>`__ as well as other tools to automatically
+format all our code to a standard style. While you're editing code you
+can be as sloppy as you like about whitespace; and then before you commit,
+just run::
 
-    pip install -U black
-    black setup.py trio
+    pip install -U pre-commit
+    pre-commit
 
 to fix it up. (And don't worry if you forget – when you submit a pull
 request then we'll automatically check and remind you.) Hopefully this
 will let you focus on more important style issues like choosing good
 names, writing useful comments, and making sure your docstrings are
 nicely formatted. (black doesn't reformat comments or docstrings.)
+
+If you would like, you can even have pre-commit run before you commit by
+running::
+
+    pre-commit install
+
+and now pre-commit will run before git commits. You can uninstall the
+pre-commit hook at any time by running::
+
+    pre-commit uninstall
+
 
 Very occasionally, you'll want to override black formatting. To do so,
 you can can add ``# fmt: off`` and ``# fmt: on`` comments.


### PR DESCRIPTION
Follow up to #2744, this PR updates the documentation to talk about using pre-commit for code formatting instead of only talking about using black.