### PR TITLE
Enable local partial types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ python_version = "3.8"
 ignore_missing_imports = true
 
 # Be strict about use of Mypy
+local_partial_types = true
 warn_unused_ignores = true
 warn_unused_configs = true
 warn_redundant_casts = true

--- a/trio/_core/_tests/test_multierror.py
+++ b/trio/_core/_tests/test_multierror.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gc
 import os
 import pickle
@@ -20,13 +22,13 @@ if sys.version_info < (3, 11):
 
 
 class NotHashableException(Exception):
-    code = None
+    code: int | None = None
 
-    def __init__(self, code):
+    def __init__(self, code: int) -> None:
         super().__init__()
         self.code = code
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if not isinstance(other, NotHashableException):
             return False
         return self.code == other.code

--- a/trio/_socket.py
+++ b/trio/_socket.py
@@ -12,6 +12,7 @@ from typing import (
     Any,
     Awaitable,
     Callable,
+    Literal,
     NoReturn,
     SupportsIndex,
     Tuple,
@@ -315,7 +316,7 @@ if sys.platform == "win32":
     TypeT: TypeAlias = int
     FamilyDefault = _stdlib_socket.AF_INET
 else:
-    FamilyDefault: TypeAlias = None
+    FamilyDefault: Literal[None] = None
     FamilyT: TypeAlias = Union[int, AddressFamily, None]
     TypeT: TypeAlias = Union[_stdlib_socket.socket, int]
 

--- a/trio/_socket.py
+++ b/trio/_socket.py
@@ -315,7 +315,7 @@ if sys.platform == "win32":
     TypeT: TypeAlias = int
     FamilyDefault = _stdlib_socket.AF_INET
 else:
-    FamilyDefault = None
+    FamilyDefault: TypeAlias = None
     FamilyT: TypeAlias = Union[int, AddressFamily, None]
     TypeT: TypeAlias = Union[_stdlib_socket.socket, int]
 


### PR DESCRIPTION
This PR enables mypy's local partial types option, because as mypy says,
> This is always implicitly enabled when using the [mypy daemon](https://mypy.readthedocs.io/en/stable/mypy_daemon.html#mypy-daemon).

leading to differences in reported errors if people like myself use the mypy daemon as a code editor extension.

https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-local-partial-types