### PR TITLE
Add py.typed in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include LICENSE LICENSE.MIT LICENSE.APACHE2
 include README.rst
 include CODE_OF_CONDUCT.md CONTRIBUTING.md
 include test-requirements.txt
+include trio/py.typed
 recursive-include trio/_tests/test_ssl_certs *.pem
 recursive-include docs *
 prune docs/build


### PR DESCRIPTION
#2775

`py.typed` was not included in distributions, so add it in `MANIFEST.in`.