### PR TITLE
Fix KI protection decorator

### DIFF
--- a/trio/_core/_ki.py
+++ b/trio/_core/_ki.py
@@ -6,13 +6,13 @@ import sys
 import types
 from collections.abc import Callable
 from functools import wraps
-from typing import TYPE_CHECKING, Any, Final, Protocol, TypeVar
+from typing import TYPE_CHECKING, Final, Protocol, TypeVar
 
 import attr
 
 from .._util import is_main_thread
 
-CallableT = TypeVar("CallableT", bound="Callable[..., Any]")
+CallableT = TypeVar("CallableT", bound="Callable[..., object]")
 RetT = TypeVar("RetT")
 
 if TYPE_CHECKING:

--- a/trio/_core/_ki.py
+++ b/trio/_core/_ki.py
@@ -6,7 +6,7 @@ import sys
 import types
 from collections.abc import Callable
 from functools import wraps
-from typing import TYPE_CHECKING, Final, TypeVar
+from typing import TYPE_CHECKING, Final, TypeVar, Protocol
 
 import attr
 
@@ -182,15 +182,16 @@ def _ki_protection_decorator(
 
     return decorator
 
+# pyright work around: https://github.com/microsoft/pyright/issues/5866
+class KIProtectionSignature(Protocol):
+    def __call__(self, f: Callable[ArgsT, RetT], /) -> Callable[ArgsT, RetT]:
+        pass
 
-enable_ki_protection: Callable[
-    [Callable[ArgsT, RetT]], Callable[ArgsT, RetT]
-] = _ki_protection_decorator(True)
+
+enable_ki_protection: KIProtectionSignature = _ki_protection_decorator(True)
 enable_ki_protection.__name__ = "enable_ki_protection"
 
-disable_ki_protection: Callable[
-    [Callable[ArgsT, RetT]], Callable[ArgsT, RetT]
-] = _ki_protection_decorator(False)
+disable_ki_protection: KIProtectionSignature = _ki_protection_decorator(False)
 disable_ki_protection.__name__ = "disable_ki_protection"
 
 

--- a/trio/_core/_ki.py
+++ b/trio/_core/_ki.py
@@ -16,7 +16,7 @@ CallableT = TypeVar("CallableT", bound=Callable[..., Any])
 RetT = TypeVar("RetT")
 
 if TYPE_CHECKING:
-    from typing_extensions import TypeGuard
+    from typing_extensions import ParamSpec, TypeGuard
 
     ArgsT = ParamSpec("ArgsT")
 

--- a/trio/_core/_ki.py
+++ b/trio/_core/_ki.py
@@ -6,7 +6,7 @@ import sys
 import types
 from collections.abc import Callable
 from functools import wraps
-from typing import TYPE_CHECKING, Final, TypeVar, Protocol
+from typing import TYPE_CHECKING, Final, Protocol, TypeVar
 
 import attr
 
@@ -182,8 +182,11 @@ def _ki_protection_decorator(
 
     return decorator
 
+
 # pyright work around: https://github.com/microsoft/pyright/issues/5866
 class KIProtectionSignature(Protocol):
+    __name__: str
+
     def __call__(self, f: Callable[ArgsT, RetT], /) -> Callable[ArgsT, RetT]:
         pass
 

--- a/trio/_core/_ki.py
+++ b/trio/_core/_ki.py
@@ -12,7 +12,7 @@ import attr
 
 from .._util import is_main_thread
 
-CallableT = TypeVar("CallableT", bound=Callable[..., Any])
+CallableT = TypeVar("CallableT", bound="Callable[..., Any]")
 RetT = TypeVar("RetT")
 
 if TYPE_CHECKING:
@@ -192,10 +192,11 @@ class KIProtectionSignature(Protocol):
         pass
 
 
-enable_ki_protection: KIProtectionSignature = _ki_protection_decorator(True)
+# the following `type: ignore`s are because we use ParamSpec internally, but want to allow overloads
+enable_ki_protection: KIProtectionSignature = _ki_protection_decorator(True)  # type: ignore[assignment]
 enable_ki_protection.__name__ = "enable_ki_protection"
 
-disable_ki_protection: KIProtectionSignature = _ki_protection_decorator(False)
+disable_ki_protection: KIProtectionSignature = _ki_protection_decorator(False)  # type: ignore[assignment]
 disable_ki_protection.__name__ = "disable_ki_protection"
 
 

--- a/trio/_core/_ki.py
+++ b/trio/_core/_ki.py
@@ -6,16 +6,17 @@ import sys
 import types
 from collections.abc import Callable
 from functools import wraps
-from typing import TYPE_CHECKING, Final, Protocol, TypeVar
+from typing import TYPE_CHECKING, Any, Final, Protocol, TypeVar
 
 import attr
 
 from .._util import is_main_thread
 
+CallableT = TypeVar("CallableT", bound=Callable[..., Any])
 RetT = TypeVar("RetT")
 
 if TYPE_CHECKING:
-    from typing_extensions import ParamSpec, TypeGuard
+    from typing_extensions import TypeGuard
 
     ArgsT = ParamSpec("ArgsT")
 
@@ -183,11 +184,11 @@ def _ki_protection_decorator(
     return decorator
 
 
-# pyright work around: https://github.com/microsoft/pyright/issues/5866
+# pyright workaround: https://github.com/microsoft/pyright/issues/5866
 class KIProtectionSignature(Protocol):
     __name__: str
 
-    def __call__(self, f: Callable[ArgsT, RetT], /) -> Callable[ArgsT, RetT]:
+    def __call__(self, f: CallableT, /) -> CallableT:
         pass
 
 

--- a/trio/_tests/verify_types_darwin.json
+++ b/trio/_tests/verify_types_darwin.json
@@ -76,7 +76,7 @@
     ],
     "otherSymbolCounts": {
       "withAmbiguousType": 0,
-      "withKnownType": 680,
+      "withKnownType": 683,
       "withUnknownType": 0
     },
     "packageName": "trio"

--- a/trio/_tests/verify_types_darwin.json
+++ b/trio/_tests/verify_types_darwin.json
@@ -76,7 +76,7 @@
     ],
     "otherSymbolCounts": {
       "withAmbiguousType": 0,
-      "withKnownType": 683,
+      "withKnownType": 686,
       "withUnknownType": 0
     },
     "packageName": "trio"

--- a/trio/_tests/verify_types_linux.json
+++ b/trio/_tests/verify_types_linux.json
@@ -64,7 +64,7 @@
     ],
     "otherSymbolCounts": {
       "withAmbiguousType": 0,
-      "withKnownType": 680,
+      "withKnownType": 683,
       "withUnknownType": 0
     },
     "packageName": "trio"

--- a/trio/_tests/verify_types_linux.json
+++ b/trio/_tests/verify_types_linux.json
@@ -64,7 +64,7 @@
     ],
     "otherSymbolCounts": {
       "withAmbiguousType": 0,
-      "withKnownType": 683,
+      "withKnownType": 686,
       "withUnknownType": 0
     },
     "packageName": "trio"

--- a/trio/_tests/verify_types_windows.json
+++ b/trio/_tests/verify_types_windows.json
@@ -180,7 +180,7 @@
     ],
     "otherSymbolCounts": {
       "withAmbiguousType": 0,
-      "withKnownType": 674,
+      "withKnownType": 677,
       "withUnknownType": 0
     },
     "packageName": "trio"

--- a/trio/_tests/verify_types_windows.json
+++ b/trio/_tests/verify_types_windows.json
@@ -180,7 +180,7 @@
     ],
     "otherSymbolCounts": {
       "withAmbiguousType": 0,
-      "withKnownType": 671,
+      "withKnownType": 674,
       "withUnknownType": 0
     },
     "packageName": "trio"


### PR DESCRIPTION
This should fix the `trio.Lock` issue in https://github.com/python-trio/trio/issues/2775.