### PR TITLE
Require static checks to pass in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,8 +104,7 @@ jobs:
     continue-on-error: >-
       ${{
         (
-          matrix.check_formatting == '1'
-          || endsWith(matrix.python, '-dev')
+          endsWith(matrix.python, '-dev')
           || endsWith(matrix.python, '-nightly')
         )
         && true


### PR DESCRIPTION
Recently the static checks do more than just black and isort. Recent errors like #2783 and #2777 would be caught this way, and it would make it less error prone to rebase some old PRs that lack typing.

Notably this PR won't pass until #2783 and maybe others are fixed. Whenever master shows green on status checks, someone needs to tickle the update and merge buttons.