### PR TITLE
Attempt to fix multierror typing

### DIFF
--- a/trio/_core/_multierror.py
+++ b/trio/_core/_multierror.py
@@ -265,7 +265,7 @@ class MultiError(_BaseExceptionGroup):
     def derive(self, excs: Sequence[Exception], /) -> NonBaseMultiError:
         ...
 
-    @overload  # type: ignore[override]  # 'BaseException' != '_BaseExceptionT'
+    @overload
     def derive(self, excs: Sequence[BaseException], /) -> MultiError:
         ...
 

--- a/trio/_core/_multierror.py
+++ b/trio/_core/_multierror.py
@@ -261,11 +261,11 @@ class MultiError(_BaseExceptionGroup):
     def __repr__(self) -> str:
         return f"<MultiError: {self}>"
 
-    @overload
+    @overload  # type: ignore[override]  # 'Exception' != '_ExceptionT'
     def derive(self, excs: Sequence[Exception], /) -> NonBaseMultiError:
         ...
 
-    @overload
+    @overload  # type: ignore[override]  # 'BaseException' != '_BaseExceptionT'
     def derive(self, excs: Sequence[BaseException], /) -> MultiError:
         ...
 


### PR DESCRIPTION
At the moment, this is only ignoring generics not matching properly in the subclass. If anyone has any better ideas on how to handle this, feel free to try it out.