### PR TITLE
enable skip_covered in coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -16,6 +16,7 @@ parallel=True
 
 [report]
 precision = 1
+skip_covered = True
 exclude_lines =
   pragma: no cover
   abc.abstractmethod


### PR DESCRIPTION
As suggested by @Zac-HD in https://github.com/python-trio/trio/pull/2702#issuecomment-1705865851

Maybe not as necessary with #2772 and I personally view coverage diffs on `app.coverage.io`, but I don't see any reason not to enable this.