### PR TITLE
Add comment and assertion to `pidfd_open` workaround

### DIFF
--- a/trio/_subprocess.py
+++ b/trio/_subprocess.py
@@ -49,6 +49,12 @@ else:
         from os import pidfd_open
     except ImportError:
         if sys.platform == "linux":
+            # pidfd_open is defined in 3.9+, so this workaround can be removed when
+            # removing support for 3.8
+            assert sys.version_info < (3, 9), (
+                "pidfd_open should be defined in 3.9+, please open an issue in the"
+                " github repo if this assert fails"
+            )
             import ctypes
 
             _cdll_for_pidfd_open = ctypes.CDLL(None, use_errno=True)
@@ -69,7 +75,7 @@ else:
 
             def pidfd_open(fd: int, flags: int) -> int:
                 result = _cdll_for_pidfd_open.syscall(__NR_pidfd_open, fd, flags)
-                if result < 0:
+                if result < 0:  # pragma: no cover
                     err = ctypes.get_errno()
                     raise OSError(err, os.strerror(err))
                 return result

--- a/trio/_subprocess.py
+++ b/trio/_subprocess.py
@@ -49,12 +49,8 @@ else:
         from os import pidfd_open
     except ImportError:
         if sys.platform == "linux":
-            # pidfd_open is defined in 3.9+, so this workaround can be removed when
-            # removing support for 3.8
-            assert sys.version_info < (3, 9), (
-                "pidfd_open should be defined in 3.9+, please open an issue in the"
-                " github repo if this assert fails"
-            )
+            # This workaround is only needed on 3.8 and pypy
+            assert sys.version_info < (3, 9) or sys.implementation_name != "cpython"
             import ctypes
 
             _cdll_for_pidfd_open = ctypes.CDLL(None, use_errno=True)

--- a/trio/_subprocess.py
+++ b/trio/_subprocess.py
@@ -50,7 +50,7 @@ else:
     except ImportError:
         if sys.platform == "linux":
             # This workaround is only needed on 3.8 and pypy
-            assert sys.version_info < (3, 9) or sys.implementation_name != "cpython"
+            assert sys.version_info < (3, 9) or sys.implementation.name != "cpython"
             import ctypes
 
             _cdll_for_pidfd_open = ctypes.CDLL(None, use_errno=True)


### PR DESCRIPTION
EDIT: assumptions were wrong

Ended up researching this during discussion in #2792, and thought I might as well add a comment (and an assertion to double-check assumptions). Also cleared up a coverage miss for an error that shouldn't trigger in test runs.

One could possibly raise a warning instead of the assertion to be *extra* defensive, but afaict it *really* shouldn't trigger on 3.9+ so the assertion+message is already very defensive IMO.

https://docs.python.org/3/library/os.html#os.pidfd_open