### PR TITLE
Fix wrongly highlighted lines in reference-core.rst

### DIFF
--- a/docs/source/reference-core.rst
+++ b/docs/source/reference-core.rst
@@ -1174,7 +1174,7 @@ the previous version, and then exits cleanly. The only change is the
 addition of ``async with`` blocks inside the producer and consumer:
 
 .. literalinclude:: reference-core/channels-shutdown.py
-   :emphasize-lines: 11,17
+   :emphasize-lines: 12,18
 
 The really important thing here is the producer's ``async with`` .
 When the producer exits, this closes the ``send_channel``, and that


### PR DESCRIPTION
In the reference-core docs in the "Clean shutdown with channels" section the changed lines are highlighted wrongly

Both `stable` and `latest` versions of online docs are affected: [stable link](https://trio.readthedocs.io/en/stable/reference-core.html#clean-shutdown-with-channels), [latest link](https://trio.readthedocs.io/en/latest/reference-core.html#clean-shutdown-with-channels). The wrongly highlighted lines differ between the versions.

`stable` version of online docs with wrongly highlighted lines:
![wrongly highlighted lines in online docs](https://github.com/python-trio/trio/assets/146097716/0907cf41-588f-48cc-b360-246310cab5b9)
