### PR TITLE
Fix wrongly highlighted lines in reference-core.rst

### DIFF
--- a/docs/source/reference-core.rst
+++ b/docs/source/reference-core.rst
@@ -1174,7 +1174,7 @@ the previous version, and then exits cleanly. The only change is the
 addition of ``async with`` blocks inside the producer and consumer:
 
 .. literalinclude:: reference-core/channels-shutdown.py
-   :emphasize-lines: 11,17
+   :emphasize-lines: 12,18
 
 The really important thing here is the producer's ``async with`` .
 When the producer exits, this closes the ``send_channel``, and that


### PR DESCRIPTION
Fixes wrongly highlighted lines in reference-core.rst

In both versions of online documentation ([`stable`](https://trio.readthedocs.io/en/stable/reference-core.html#clean-shutdown-with-channels), [`latest`](https://trio.readthedocs.io/en/latest/reference-core.html#clean-shutdown-with-channels)), the lines in "Clean shutdown with channels" are wrongly highlighted.

Stable:
![stable](https://github.com/python-trio/trio/assets/79705170/67f63a35-36c7-4e1c-abff-459dd92d22ed)

Latest:
![latest](https://github.com/python-trio/trio/assets/79705170/f06d01fb-6be8-4c2f-ac9f-64850a76409f)
