### PR TITLE
Enable flake8-async rule

### DIFF
--- a/notes-to-self/loopy.py
+++ b/notes-to-self/loopy.py
@@ -6,7 +6,7 @@ import trio
 async def loopy():
     try:
         while True:
-            time.sleep(0.01)
+            time.sleep(0.01)  # noqa: ASYNC101  # OS sleep so no CPU fire
             await trio.sleep(0)
     except KeyboardInterrupt:
         print("KI!")

--- a/notes-to-self/loopy.py
+++ b/notes-to-self/loopy.py
@@ -6,7 +6,9 @@ import trio
 async def loopy():
     try:
         while True:
-            time.sleep(0.01)  # noqa: ASYNC101  # OS sleep so no CPU fire
+            time.sleep(  # noqa: ASYNC101  # synchronous sleep to avoid maxing out CPU
+                0.01
+            )
             await trio.sleep(0)
     except KeyboardInterrupt:
         print("KI!")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ select = [
   "F",  # pyflakes
   "I",  # isort
   "YTT",  # flake8-2020
+  "ASYNC",  # flake8-async
 ]
 extend-ignore = [
     'F403',  # undefined-local-with-import-star

--- a/trio/_core/_tests/test_run.py
+++ b/trio/_core/_tests/test_run.py
@@ -266,7 +266,7 @@ async def test_current_time() -> None:
     t1 = _core.current_time()
     # Windows clock is pretty low-resolution -- appveyor tests fail unless we
     # sleep for a bit here.
-    time.sleep(time.get_clock_info("perf_counter").resolution)
+    time.sleep(time.get_clock_info("perf_counter").resolution)  # noqa: ASYNC101
     t2 = _core.current_time()
     assert t1 < t2
 

--- a/trio/_core/_tests/test_windows.py
+++ b/trio/_core/_tests/test_windows.py
@@ -110,7 +110,9 @@ async def test_readinto_overlapped() -> None:
 
     with tempfile.TemporaryDirectory() as tdir:
         tfile = os.path.join(tdir, "numbers.txt")
-        with open(tfile, "wb") as fp:
+        with open(  # noqa: ASYNC101  # This is a test, synchronous is ok
+            tfile, "wb"
+        ) as fp:
             fp.write(data)
             fp.flush()
 
@@ -216,7 +218,7 @@ async def test_too_late_to_cancel() -> None:
             # Note: not trio.sleep! We're making sure the OS level
             # ReadFile completes, before Trio has a chance to execute
             # another checkpoint and notice it completed.
-            time.sleep(1)
+            time.sleep(1)  # noqa: ASYNC101
             nursery.cancel_scope.cancel()
         assert target[:6] == b"test1\n"
 

--- a/trio/_tests/test_threads.py
+++ b/trio/_tests/test_threads.py
@@ -331,7 +331,7 @@ async def test_run_in_worker_thread_cancellation():
     # Put the thread out of its misery:
     q.put(None)
     while register[0] != "finished":
-        time.sleep(0.01)
+        time.sleep(0.01)  # noqa: ASYNC101  # Need to wait for OS thread
 
     # This one can't be cancelled
     record = []

--- a/trio/_tests/type_tests/check_wraps.py
+++ b/trio/_tests/type_tests/check_wraps.py
@@ -1,8 +1,7 @@
 # https://github.com/python-trio/trio/issues/2775#issuecomment-1702267589
 # (except platform independent...)
-import typing_extensions
-
 import trio
+import typing_extensions
 
 
 async def fn(s: trio.SocketStream) -> None:


### PR DESCRIPTION
This PR enables the flake8-async rule and fixes all the existing issues that were raised.