### PR TITLE
Add type annotations for windows_pipes and its test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,9 +83,6 @@ disallow_untyped_calls = false
 # files not yet fully typed
 [[tool.mypy.overrides]]
 module = [
-# internal
-"trio/_windows_pipes",
-
 # tests
 "trio/testing/_fake_net",
 "trio/_core/_tests/test_guest_mode",
@@ -116,7 +113,6 @@ module = [
 "trio/_tests/test_tracing",
 "trio/_tests/test_util",
 "trio/_tests/test_wait_for_object",
-"trio/_tests/test_windows_pipes",
 "trio/_tests/tools/test_gen_exports",
 ]
 check_untyped_defs = false

--- a/trio/_tests/test_windows_pipes.py
+++ b/trio/_tests/test_windows_pipes.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sys
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -20,12 +20,6 @@ if sys.platform == "win32":
 
     from .._core._windows_cffi import _handle, kernel32
     from .._windows_pipes import PipeReceiveStream, PipeSendStream
-else:
-    pipe = Any
-    _handle = Any
-    kernel32 = Any
-    PipeReceiveStream = Any
-    PipeSendStream = Any
 
 
 async def make_pipe() -> tuple[PipeSendStream, PipeReceiveStream]:

--- a/trio/_tests/test_windows_pipes.py
+++ b/trio/_tests/test_windows_pipes.py
@@ -14,6 +14,8 @@ if sys.platform == "win32":
 else:
     pytestmark = pytest.mark.skip(reason="windows only")
     pipe: Any = None
+    _handle: Any = None
+    kernel32: Any = None
     PipeSendStream: Any = None
     PipeReceiveStream: Any = None
 
@@ -26,9 +28,9 @@ async def make_pipe() -> Tuple[PipeSendStream, PipeReceiveStream]:
 
 async def test_pipe_typecheck() -> None:
     with pytest.raises(TypeError):
-        PipeSendStream(1.0)
+        PipeSendStream(1.0)  # type: ignore[arg-type]
     with pytest.raises(TypeError):
-        PipeReceiveStream(None)
+        PipeReceiveStream(None)  # type: ignore[arg-type]
 
 
 async def test_pipe_error_on_close() -> None:

--- a/trio/_tests/test_windows_pipes.py
+++ b/trio/_tests/test_windows_pipes.py
@@ -24,14 +24,14 @@ async def make_pipe() -> Tuple[PipeSendStream, PipeReceiveStream]:
     return PipeSendStream(w), PipeReceiveStream(r)
 
 
-async def test_pipe_typecheck():
+async def test_pipe_typecheck() -> None:
     with pytest.raises(TypeError):
         PipeSendStream(1.0)
     with pytest.raises(TypeError):
         PipeReceiveStream(None)
 
 
-async def test_pipe_error_on_close():
+async def test_pipe_error_on_close() -> None:
     # Make sure we correctly handle a failure from kernel32.CloseHandle
     r, w = pipe()
 
@@ -47,18 +47,18 @@ async def test_pipe_error_on_close():
         await receive_stream.aclose()
 
 
-async def test_pipes_combined():
+async def test_pipes_combined() -> None:
     write, read = await make_pipe()
     count = 2**20
     replicas = 3
 
-    async def sender():
+    async def sender() -> None:
         async with write:
             big = bytearray(count)
             for _ in range(replicas):
                 await write.send_all(big)
 
-    async def reader():
+    async def reader() -> None:
         async with read:
             await wait_all_tasks_blocked()
             total_received = 0
@@ -76,7 +76,7 @@ async def test_pipes_combined():
         n.start_soon(reader)
 
 
-async def test_async_with():
+async def test_async_with() -> None:
     w, r = await make_pipe()
     async with w, r:
         pass
@@ -87,11 +87,11 @@ async def test_async_with():
         await r.receive_some(10)
 
 
-async def test_close_during_write():
+async def test_close_during_write() -> None:
     w, r = await make_pipe()
     async with _core.open_nursery() as nursery:
 
-        async def write_forever():
+        async def write_forever() -> None:
             with pytest.raises(_core.ClosedResourceError) as excinfo:
                 while True:
                     await w.send_all(b"x" * 4096)
@@ -102,7 +102,7 @@ async def test_close_during_write():
         await w.aclose()
 
 
-async def test_pipe_fully():
+async def test_pipe_fully() -> None:
     # passing make_clogged_pipe tests wait_send_all_might_not_block, and we
     # can't implement that on Windows
     await check_one_way_stream(make_pipe, None)

--- a/trio/_tests/test_windows_pipes.py
+++ b/trio/_tests/test_windows_pipes.py
@@ -14,10 +14,11 @@ pytestmark = pytest.mark.skipif(not on_windows, reason="windows only")
 
 assert on_windows or not TYPE_CHECKING  # Skip type checking when not on Windows
 
-from asyncio.windows_utils import pipe
+if sys.platform == "win32":
+    from asyncio.windows_utils import pipe
 
-from .._core._windows_cffi import _handle, kernel32
-from .._windows_pipes import PipeReceiveStream, PipeSendStream
+    from .._core._windows_cffi import _handle, kernel32
+    from .._windows_pipes import PipeReceiveStream, PipeSendStream
 
 
 async def make_pipe() -> tuple[PipeSendStream, PipeReceiveStream]:

--- a/trio/_tests/test_windows_pipes.py
+++ b/trio/_tests/test_windows_pipes.py
@@ -20,7 +20,7 @@ else:
     kernel32: Any = None
     from .._abc import ReceiveStream, SendStream
 
-    class _fake_recieve(ReceiveStream):
+    class PipeReceiveStream(ReceiveStream):
         def __init__(self, _: int) -> None:
             ...
 
@@ -30,7 +30,7 @@ else:
         async def aclose(self) -> None:
             ...
 
-    class _fake_send(SendStream):
+    class PipeSendStream(SendStream):
         def __init__(self, _: int) -> None:
             ...
 
@@ -42,9 +42,6 @@ else:
 
         async def aclose(self) -> None:
             ...
-
-    PipeReceiveStream = _fake_recieve
-    PipeSendStream = _fake_send
 
 
 async def make_pipe() -> tuple[PipeSendStream, PipeReceiveStream]:

--- a/trio/_tests/test_windows_pipes.py
+++ b/trio/_tests/test_windows_pipes.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import sys
-from typing import Any, Tuple
+from typing import Any
 
 import pytest
 
@@ -45,7 +47,7 @@ else:
     PipeSendStream = _fake_send
 
 
-async def make_pipe() -> Tuple[PipeSendStream, PipeReceiveStream]:
+async def make_pipe() -> tuple[PipeSendStream, PipeReceiveStream]:
     """Makes a new pair of pipes."""
     (r, w) = pipe()
     return PipeSendStream(w), PipeReceiveStream(r)

--- a/trio/_tests/test_windows_pipes.py
+++ b/trio/_tests/test_windows_pipes.py
@@ -8,11 +8,12 @@ import pytest
 from .. import _core
 from ..testing import check_one_way_stream, wait_all_tasks_blocked
 
-on_windows = sys.platform == "win32"
 # Mark all the tests in this file as being windows-only
-pytestmark = pytest.mark.skipif(not on_windows, reason="windows only")
+pytestmark = pytest.mark.skipif(sys.platform != "win32", reason="windows only")
 
-assert on_windows or not TYPE_CHECKING  # Skip type checking when not on Windows
+assert (
+    sys.platform == "win32" or not TYPE_CHECKING
+)  # Skip type checking when not on Windows
 
 if sys.platform == "win32":
     from asyncio.windows_utils import pipe

--- a/trio/_tests/test_windows_pipes.py
+++ b/trio/_tests/test_windows_pipes.py
@@ -11,9 +11,9 @@ from ..testing import check_one_way_stream, wait_all_tasks_blocked
 # Mark all the tests in this file as being windows-only
 pytestmark = pytest.mark.skipif(sys.platform != "win32", reason="windows only")
 
-assert (
+assert (  # Skip type checking when not on Windows
     sys.platform == "win32" or not TYPE_CHECKING
-)  # Skip type checking when not on Windows
+)
 
 if sys.platform == "win32":
     from asyncio.windows_utils import pipe

--- a/trio/_tests/test_windows_pipes.py
+++ b/trio/_tests/test_windows_pipes.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sys
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
@@ -19,6 +19,12 @@ if sys.platform == "win32":
 
     from .._core._windows_cffi import _handle, kernel32
     from .._windows_pipes import PipeReceiveStream, PipeSendStream
+else:
+    pipe = Any
+    _handle = Any
+    kernel32 = Any
+    PipeReceiveStream = Any
+    PipeSendStream = Any
 
 
 async def make_pipe() -> tuple[PipeSendStream, PipeReceiveStream]:

--- a/trio/_tests/test_windows_pipes.py
+++ b/trio/_tests/test_windows_pipes.py
@@ -16,8 +16,33 @@ else:
     pipe: Any = None
     _handle: Any = None
     kernel32: Any = None
-    PipeSendStream: Any = None
-    PipeReceiveStream: Any = None
+    from .._abc import ReceiveStream, SendStream
+
+    class _fake_recieve(ReceiveStream):
+        def __init__(self, _: int) -> None:
+            ...
+
+        async def receive_some(self, max_bytes: int | None = None) -> bytes | bytearray:
+            return b""
+
+        async def aclose(self) -> None:
+            ...
+
+    class _fake_send(SendStream):
+        def __init__(self, _: int) -> None:
+            ...
+
+        async def send_all(self, data: bytes | bytearray | memoryview) -> None:
+            ...
+
+        async def wait_send_all_might_not_block(self) -> None:
+            ...
+
+        async def aclose(self) -> None:
+            ...
+
+    PipeReceiveStream = _fake_recieve
+    PipeSendStream = _fake_send
 
 
 async def make_pipe() -> Tuple[PipeSendStream, PipeReceiveStream]:

--- a/trio/_windows_pipes.py
+++ b/trio/_windows_pipes.py
@@ -23,10 +23,10 @@ class _HandleHolder:
         _core.register_with_iocp(self.handle)
 
     @property
-    def closed(self):
+    def closed(self) -> bool:
         return self.handle == -1
 
-    def close(self):
+    def close(self) -> None:
         if self.closed:
             return
         handle = self.handle
@@ -34,7 +34,7 @@ class _HandleHolder:
         if not kernel32.CloseHandle(_handle(handle)):
             raise_winerror()
 
-    def __del__(self):
+    def __del__(self) -> None:
         self.close()
 
 
@@ -76,10 +76,10 @@ class PipeSendStream(SendStream):
             # not implemented yet, and probably not needed
             await _core.checkpoint()
 
-    def close(self):
+    def close(self) -> None:
         self._handle_holder.close()
 
-    async def aclose(self):
+    async def aclose(self) -> None:
         self.close()
         await _core.checkpoint()
 
@@ -94,7 +94,7 @@ class PipeReceiveStream(ReceiveStream):
             "another task is currently using this pipe"
         )
 
-    async def receive_some(self, max_bytes=None) -> bytes:
+    async def receive_some(self, max_bytes: int | None = None) -> bytes:
         with self._conflict_detector:
             if self._handle_holder.closed:
                 raise _core.ClosedResourceError("this pipe is already closed")
@@ -133,9 +133,9 @@ class PipeReceiveStream(ReceiveStream):
                 del buffer[size:]
                 return buffer
 
-    def close(self):
+    def close(self) -> None:
         self._handle_holder.close()
 
-    async def aclose(self):
+    async def aclose(self) -> None:
         self.close()
         await _core.checkpoint()

--- a/trio/_windows_pipes.py
+++ b/trio/_windows_pipes.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 from typing import TYPE_CHECKING
 
@@ -50,7 +52,7 @@ class PipeSendStream(SendStream):
             "another task is currently using this pipe"
         )
 
-    async def send_all(self, data: bytes):
+    async def send_all(self, data: bytes) -> None:
         with self._conflict_detector:
             if self._handle_holder.closed:
                 raise _core.ClosedResourceError("this pipe is already closed")


### PR DESCRIPTION
This PR adds type annotations for `_windows_pipes.py` and `_tests/test_windows_pipes.py`.