### PR TITLE
Enable flake8-pyi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ select = [
   "F",  # pyflakes
   "I",  # isort
   "YTT",  # flake8-2020
+  "PYI",  # flake8-pyi
 ]
 extend-ignore = [
     'F403',  # undefined-local-with-import-star

--- a/trio/_channel.py
+++ b/trio/_channel.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 
 
 def _open_memory_channel(
-    max_buffer_size: float,
+    max_buffer_size: int | float,  # noqa: PYI041
 ) -> tuple[MemorySendChannel[T], MemoryReceiveChannel[T]]:
     """Open a channel for passing objects between tasks within a process.
 
@@ -95,11 +95,11 @@ if TYPE_CHECKING:
     # Need to use Tuple instead of tuple due to CI check running on 3.8
     class open_memory_channel(Tuple[MemorySendChannel[T], MemoryReceiveChannel[T]]):
         def __new__(  # type: ignore[misc]  # "must return a subtype"
-            cls, max_buffer_size: float
+            cls, max_buffer_size: int | float  # noqa: PYI041
         ) -> tuple[MemorySendChannel[T], MemoryReceiveChannel[T]]:
             return _open_memory_channel(max_buffer_size)
 
-        def __init__(self, max_buffer_size: float):
+        def __init__(self, max_buffer_size: int | float):  # noqa: PYI041
             ...
 
 else:
@@ -111,7 +111,7 @@ else:
 @attr.s(frozen=True, slots=True)
 class MemoryChannelStats:
     current_buffer_used: int = attr.ib()
-    max_buffer_size: float = attr.ib()
+    max_buffer_size: int | float = attr.ib()
     open_send_channels: int = attr.ib()
     open_receive_channels: int = attr.ib()
     tasks_waiting_send: int = attr.ib()
@@ -120,7 +120,7 @@ class MemoryChannelStats:
 
 @attr.s(slots=True)
 class MemoryChannelState(Generic[T]):
-    max_buffer_size: float = attr.ib()
+    max_buffer_size: int | float = attr.ib()
     data: deque[T] = attr.ib(factory=deque)
     # Counts of open endpoints using this state
     open_send_channels: int = attr.ib(default=0)

--- a/trio/_channel.py
+++ b/trio/_channel.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 
 
 def _open_memory_channel(
-    max_buffer_size: int | float,
+    max_buffer_size: float,
 ) -> tuple[MemorySendChannel[T], MemoryReceiveChannel[T]]:
     """Open a channel for passing objects between tasks within a process.
 
@@ -95,11 +95,11 @@ if TYPE_CHECKING:
     # Need to use Tuple instead of tuple due to CI check running on 3.8
     class open_memory_channel(Tuple[MemorySendChannel[T], MemoryReceiveChannel[T]]):
         def __new__(  # type: ignore[misc]  # "must return a subtype"
-            cls, max_buffer_size: int | float
+            cls, max_buffer_size: float
         ) -> tuple[MemorySendChannel[T], MemoryReceiveChannel[T]]:
             return _open_memory_channel(max_buffer_size)
 
-        def __init__(self, max_buffer_size: int | float):
+        def __init__(self, max_buffer_size: float):
             ...
 
 else:
@@ -111,7 +111,7 @@ else:
 @attr.s(frozen=True, slots=True)
 class MemoryChannelStats:
     current_buffer_used: int = attr.ib()
-    max_buffer_size: int | float = attr.ib()
+    max_buffer_size: float = attr.ib()
     open_send_channels: int = attr.ib()
     open_receive_channels: int = attr.ib()
     tasks_waiting_send: int = attr.ib()
@@ -120,7 +120,7 @@ class MemoryChannelStats:
 
 @attr.s(slots=True)
 class MemoryChannelState(Generic[T]):
-    max_buffer_size: int | float = attr.ib()
+    max_buffer_size: float = attr.ib()
     data: deque[T] = attr.ib(factory=deque)
     # Counts of open endpoints using this state
     open_send_channels: int = attr.ib(default=0)

--- a/trio/_core/_multierror.py
+++ b/trio/_core/_multierror.py
@@ -237,7 +237,7 @@ class MultiError(_BaseExceptionGroup):
             # In an earlier version of the code, we didn't define __init__ and
             # simply set the `exceptions` attribute directly on the new object.
             # However, linters expect attributes to be initialized in __init__.
-            from_class: type[Self] | type[NonBaseMultiError] = cls
+            from_class: type[Self | NonBaseMultiError] = cls
             if all(isinstance(exc, Exception) for exc in exceptions):
                 from_class = NonBaseMultiError
 

--- a/trio/_core/_parking_lot.py
+++ b/trio/_core/_parking_lot.py
@@ -146,7 +146,7 @@ class ParkingLot:
 
         await _core.wait_task_rescheduled(abort_fn)
 
-    def _pop_several(self, count: int | float) -> Iterator[Task]:
+    def _pop_several(self, count: float) -> Iterator[Task]:
         if isinstance(count, float):
             if math.isinf(count):
                 count = len(self._parked)
@@ -159,7 +159,7 @@ class ParkingLot:
             yield task
 
     @_core.enable_ki_protection
-    def unpark(self, *, count: int | float = 1) -> list[Task]:
+    def unpark(self, *, count: float = 1) -> list[Task]:
         """Unpark one or more tasks.
 
         This wakes up ``count`` tasks that are blocked in :meth:`park`. If
@@ -180,7 +180,7 @@ class ParkingLot:
         return self.unpark(count=len(self))
 
     @_core.enable_ki_protection
-    def repark(self, new_lot: ParkingLot, *, count: int | float = 1) -> None:
+    def repark(self, new_lot: ParkingLot, *, count: float = 1) -> None:
         """Move parked tasks from one :class:`ParkingLot` object to another.
 
         This dequeues ``count`` tasks from one lot, and requeues them on

--- a/trio/_core/_parking_lot.py
+++ b/trio/_core/_parking_lot.py
@@ -146,7 +146,7 @@ class ParkingLot:
 
         await _core.wait_task_rescheduled(abort_fn)
 
-    def _pop_several(self, count: float) -> Iterator[Task]:
+    def _pop_several(self, count: int | float) -> Iterator[Task]:  # noqa: PYI041
         if isinstance(count, float):
             if math.isinf(count):
                 count = len(self._parked)
@@ -159,7 +159,7 @@ class ParkingLot:
             yield task
 
     @_core.enable_ki_protection
-    def unpark(self, *, count: float = 1) -> list[Task]:
+    def unpark(self, *, count: int | float = 1) -> list[Task]:  # noqa: PYI041
         """Unpark one or more tasks.
 
         This wakes up ``count`` tasks that are blocked in :meth:`park`. If
@@ -180,7 +180,9 @@ class ParkingLot:
         return self.unpark(count=len(self))
 
     @_core.enable_ki_protection
-    def repark(self, new_lot: ParkingLot, *, count: float = 1) -> None:
+    def repark(
+        self, new_lot: ParkingLot, *, count: int | float = 1  # noqa: PYI041
+    ) -> None:
         """Move parked tasks from one :class:`ParkingLot` object to another.
 
         This dequeues ``count`` tasks from one lot, and requeues them on

--- a/trio/_dtls.py
+++ b/trio/_dtls.py
@@ -648,7 +648,7 @@ _T = TypeVar("_T")
 
 
 class _Queue(Generic[_T]):
-    def __init__(self, incoming_packets_buffer: int | float):
+    def __init__(self, incoming_packets_buffer: float):
         self.s, self.r = trio.open_memory_channel[_T](incoming_packets_buffer)
 
 

--- a/trio/_dtls.py
+++ b/trio/_dtls.py
@@ -648,7 +648,7 @@ _T = TypeVar("_T")
 
 
 class _Queue(Generic[_T]):
-    def __init__(self, incoming_packets_buffer: float):
+    def __init__(self, incoming_packets_buffer: int | float):  # noqa: PYI041
         self.s, self.r = trio.open_memory_channel[_T](incoming_packets_buffer)
 
 

--- a/trio/_highlevel_open_tcp_listeners.py
+++ b/trio/_highlevel_open_tcp_listeners.py
@@ -41,7 +41,7 @@ if sys.version_info < (3, 11):
 # so this is unnecessary -- we can just pass in "infinity" and get the maximum
 # that way. (Verified on Windows, Linux, macOS using
 # notes-to-self/measure-listen-backlog.py)
-def _compute_backlog(backlog: int | float | None) -> int:
+def _compute_backlog(backlog: float | None) -> int:
     # Many systems (Linux, BSDs, ...) store the backlog in a uint16 and are
     # missing overflow protection, so we apply our own overflow protection.
     # https://github.com/golang/go/issues/5030
@@ -57,7 +57,7 @@ def _compute_backlog(backlog: int | float | None) -> int:
 
 
 async def open_tcp_listeners(
-    port: int, *, host: str | bytes | None = None, backlog: int | float | None = None
+    port: int, *, host: str | bytes | None = None, backlog: float | None = None
 ) -> list[trio.SocketListener]:
     """Create :class:`SocketListener` objects to listen for TCP connections.
 
@@ -169,7 +169,7 @@ async def serve_tcp(
     port: int,
     *,
     host: str | bytes | None = None,
-    backlog: int | float | None = None,
+    backlog: float | None = None,
     handler_nursery: trio.Nursery | None = None,
     task_status: TaskStatus[list[trio.SocketListener]] = trio.TASK_STATUS_IGNORED,
 ) -> None:

--- a/trio/_highlevel_open_tcp_listeners.py
+++ b/trio/_highlevel_open_tcp_listeners.py
@@ -41,7 +41,7 @@ if sys.version_info < (3, 11):
 # so this is unnecessary -- we can just pass in "infinity" and get the maximum
 # that way. (Verified on Windows, Linux, macOS using
 # notes-to-self/measure-listen-backlog.py)
-def _compute_backlog(backlog: float | None) -> int:
+def _compute_backlog(backlog: int | float | None) -> int:  # noqa: PYI041
     # Many systems (Linux, BSDs, ...) store the backlog in a uint16 and are
     # missing overflow protection, so we apply our own overflow protection.
     # https://github.com/golang/go/issues/5030
@@ -57,7 +57,10 @@ def _compute_backlog(backlog: float | None) -> int:
 
 
 async def open_tcp_listeners(
-    port: int, *, host: str | bytes | None = None, backlog: float | None = None
+    port: int,
+    *,
+    host: str | bytes | None = None,
+    backlog: int | float | None = None,  # noqa: PYI041
 ) -> list[trio.SocketListener]:
     """Create :class:`SocketListener` objects to listen for TCP connections.
 
@@ -169,7 +172,7 @@ async def serve_tcp(
     port: int,
     *,
     host: str | bytes | None = None,
-    backlog: float | None = None,
+    backlog: int | float | None = None,  # noqa: PYI041
     handler_nursery: trio.Nursery | None = None,
     task_status: TaskStatus[list[trio.SocketListener]] = trio.TASK_STATUS_IGNORED,
 ) -> None:

--- a/trio/_highlevel_ssl_helpers.py
+++ b/trio/_highlevel_ssl_helpers.py
@@ -72,7 +72,7 @@ async def open_ssl_over_tcp_listeners(
     *,
     host: str | bytes | None = None,
     https_compatible: bool = False,
-    backlog: float | None = None,
+    backlog: int | float | None = None,  # noqa: PYI041
 ) -> list[trio.SSLListener]:
     """Start listening for SSL/TLS-encrypted TCP connections to the given port.
 
@@ -101,7 +101,7 @@ async def serve_ssl_over_tcp(
     *,
     host: str | bytes | None = None,
     https_compatible: bool = False,
-    backlog: float | None = None,
+    backlog: int | float | None = None,  # noqa: PYI041
     handler_nursery: trio.Nursery | None = None,
     task_status: trio.TaskStatus[list[trio.SSLListener]] = trio.TASK_STATUS_IGNORED,
 ) -> NoReturn:

--- a/trio/_highlevel_ssl_helpers.py
+++ b/trio/_highlevel_ssl_helpers.py
@@ -72,7 +72,7 @@ async def open_ssl_over_tcp_listeners(
     *,
     host: str | bytes | None = None,
     https_compatible: bool = False,
-    backlog: int | float | None = None,
+    backlog: float | None = None,
 ) -> list[trio.SSLListener]:
     """Start listening for SSL/TLS-encrypted TCP connections to the given port.
 
@@ -101,7 +101,7 @@ async def serve_ssl_over_tcp(
     *,
     host: str | bytes | None = None,
     https_compatible: bool = False,
-    backlog: int | float | None = None,
+    backlog: float | None = None,
     handler_nursery: trio.Nursery | None = None,
     task_status: trio.TaskStatus[list[trio.SSLListener]] = trio.TASK_STATUS_IGNORED,
 ) -> NoReturn:

--- a/trio/_subprocess.py
+++ b/trio/_subprocess.py
@@ -26,7 +26,7 @@ from ._sync import Lock
 from ._util import NoPublicConstructor, final
 
 if TYPE_CHECKING:
-    from typing_extensions import TypeAlias
+    from typing_extensions import Self, TypeAlias
 
 
 # Only subscriptable in 3.9+
@@ -215,7 +215,7 @@ class Process(AsyncResource, metaclass=NoPublicConstructor):
         issue=1104,
         instead="run_process or nursery.start(run_process, ...)",
     )
-    async def __aenter__(self) -> Process:
+    async def __aenter__(self) -> Self:
         return self
 
     @deprecated(

--- a/trio/_sync.py
+++ b/trio/_sync.py
@@ -151,7 +151,7 @@ class CapacityLimiterStatistics:
     """
 
     borrowed_tokens: int = attr.ib()
-    total_tokens: float = attr.ib()
+    total_tokens: int | float = attr.ib()
     borrowers: list[Task | object] = attr.ib()
     tasks_waiting: int = attr.ib()
 
@@ -215,13 +215,13 @@ class CapacityLimiter(AsyncContextManagerMixin):
     """
 
     # total_tokens would ideally be int|Literal[math.inf] - but that's not valid typing
-    def __init__(self, total_tokens: float):
+    def __init__(self, total_tokens: int | float):  # noqa: PYI041
         self._lot = ParkingLot()
         self._borrowers: set[Task | object] = set()
         # Maps tasks attempting to acquire -> borrower, to handle on-behalf-of
         self._pending_borrowers: dict[Task, Task | object] = {}
         # invoke the property setter for validation
-        self.total_tokens: float = total_tokens
+        self.total_tokens: int | float = total_tokens
         assert self._total_tokens == total_tokens
 
     def __repr__(self) -> str:
@@ -230,7 +230,7 @@ class CapacityLimiter(AsyncContextManagerMixin):
         )
 
     @property
-    def total_tokens(self) -> float:
+    def total_tokens(self) -> int | float:
         """The total capacity available.
 
         You can change :attr:`total_tokens` by assigning to this attribute. If
@@ -245,7 +245,7 @@ class CapacityLimiter(AsyncContextManagerMixin):
         return self._total_tokens
 
     @total_tokens.setter
-    def total_tokens(self, new_total_tokens: float) -> None:
+    def total_tokens(self, new_total_tokens: int | float) -> None:  # noqa: PYI041
         if not isinstance(new_total_tokens, int) and new_total_tokens != math.inf:
             raise TypeError("total_tokens must be an int or math.inf")
         if new_total_tokens < 1:
@@ -264,7 +264,7 @@ class CapacityLimiter(AsyncContextManagerMixin):
         return len(self._borrowers)
 
     @property
-    def available_tokens(self) -> float:
+    def available_tokens(self) -> int | float:
         """The amount of capacity that's available to use."""
         return self.total_tokens - self.borrowed_tokens
 

--- a/trio/_sync.py
+++ b/trio/_sync.py
@@ -151,7 +151,7 @@ class CapacityLimiterStatistics:
     """
 
     borrowed_tokens: int = attr.ib()
-    total_tokens: int | float = attr.ib()
+    total_tokens: float = attr.ib()
     borrowers: list[Task | object] = attr.ib()
     tasks_waiting: int = attr.ib()
 
@@ -215,13 +215,13 @@ class CapacityLimiter(AsyncContextManagerMixin):
     """
 
     # total_tokens would ideally be int|Literal[math.inf] - but that's not valid typing
-    def __init__(self, total_tokens: int | float):
+    def __init__(self, total_tokens: float):
         self._lot = ParkingLot()
         self._borrowers: set[Task | object] = set()
         # Maps tasks attempting to acquire -> borrower, to handle on-behalf-of
         self._pending_borrowers: dict[Task, Task | object] = {}
         # invoke the property setter for validation
-        self.total_tokens: int | float = total_tokens
+        self.total_tokens: float = total_tokens
         assert self._total_tokens == total_tokens
 
     def __repr__(self) -> str:
@@ -230,7 +230,7 @@ class CapacityLimiter(AsyncContextManagerMixin):
         )
 
     @property
-    def total_tokens(self) -> int | float:
+    def total_tokens(self) -> float:
         """The total capacity available.
 
         You can change :attr:`total_tokens` by assigning to this attribute. If
@@ -245,7 +245,7 @@ class CapacityLimiter(AsyncContextManagerMixin):
         return self._total_tokens
 
     @total_tokens.setter
-    def total_tokens(self, new_total_tokens: int | float) -> None:
+    def total_tokens(self, new_total_tokens: float) -> None:
         if not isinstance(new_total_tokens, int) and new_total_tokens != math.inf:
             raise TypeError("total_tokens must be an int or math.inf")
         if new_total_tokens < 1:
@@ -264,7 +264,7 @@ class CapacityLimiter(AsyncContextManagerMixin):
         return len(self._borrowers)
 
     @property
-    def available_tokens(self) -> int | float:
+    def available_tokens(self) -> float:
         """The amount of capacity that's available to use."""
         return self.total_tokens - self.borrowed_tokens
 

--- a/trio/_tests/test_socket.py
+++ b/trio/_tests/test_socket.py
@@ -28,10 +28,10 @@ if TYPE_CHECKING:
         str,
         Union[Tuple[str, int], Tuple[str, int, int, int]],
     ]
-    getaddrinfoResponse: TypeAlias = List[GaiTuple]
+    GetAddrInfoResponse: TypeAlias = List[GaiTuple]
 else:
     GaiTuple: object
-    getaddrinfoResponse = object
+    GetAddrInfoResponse = object
 
 ################################################################
 # utils
@@ -39,9 +39,9 @@ else:
 
 
 class MonkeypatchedGAI:
-    def __init__(self, orig_getaddrinfo: Callable[..., getaddrinfoResponse]):
+    def __init__(self, orig_getaddrinfo: Callable[..., GetAddrInfoResponse]):
         self._orig_getaddrinfo = orig_getaddrinfo
-        self._responses: dict[tuple[Any, ...], getaddrinfoResponse | str] = {}
+        self._responses: dict[tuple[Any, ...], GetAddrInfoResponse | str] = {}
         self.record: list[tuple[Any, ...]] = []
 
     # get a normalized getaddrinfo argument tuple
@@ -54,11 +54,11 @@ class MonkeypatchedGAI:
         return frozenbound
 
     def set(
-        self, response: getaddrinfoResponse | str, *args: Any, **kwargs: Any
+        self, response: GetAddrInfoResponse | str, *args: Any, **kwargs: Any
     ) -> None:
         self._responses[self._frozenbind(*args, **kwargs)] = response
 
-    def getaddrinfo(self, *args: Any, **kwargs: Any) -> getaddrinfoResponse | str:
+    def getaddrinfo(self, *args: Any, **kwargs: Any) -> GetAddrInfoResponse | str:
         bound = self._frozenbind(*args, **kwargs)
         self.record.append(bound)
         if bound in self._responses:
@@ -119,7 +119,7 @@ def test_socket_has_some_reexports() -> None:
 
 
 async def test_getaddrinfo(monkeygai: MonkeypatchedGAI) -> None:
-    def check(got: getaddrinfoResponse, expected: getaddrinfoResponse) -> None:
+    def check(got: GetAddrInfoResponse, expected: GetAddrInfoResponse) -> None:
         # win32 returns 0 for the proto field
         # musl and glibc have inconsistent handling of the canonical name
         # field (https://github.com/python-trio/trio/issues/1499)
@@ -137,7 +137,7 @@ async def test_getaddrinfo(monkeygai: MonkeypatchedGAI) -> None:
             return (family, type, sockaddr)
 
         def filtered(
-            gai_list: getaddrinfoResponse,
+            gai_list: GetAddrInfoResponse,
         ) -> list[
             tuple[
                 AddressFamily,

--- a/trio/_threads.py
+++ b/trio/_threads.py
@@ -410,7 +410,7 @@ def from_thread_check_cancelled() -> None:
     try:
         raise_cancel = PARENT_TASK_DATA.cancel_register[0]
     except AttributeError:
-        raise RuntimeError(
+        raise RuntimeError(  # noqa: B904
             "this thread wasn't created by Trio, can't check for cancellation"
         )
     if raise_cancel is not None:


### PR DESCRIPTION
"But wait CoolCat, why do we need pyi if we aren't shipping stubs?"
Because some of the rule checks it does look like they might help notice bugs in PRs in process.
Full rule list section: https://docs.astral.sh/ruff/rules/#flake8-pyi-pyi