### PR TITLE
nursery_cancel doesn't seem to create cyclic garbage on 3.12 anymore

### DIFF
--- a/trio/_core/_tests/test_run.py
+++ b/trio/_core/_tests/test_run.py
@@ -2374,10 +2374,6 @@ async def test_cancel_scope_exit_doesnt_create_cyclic_garbage() -> None:
         gc.garbage.clear()
 
 
-@pytest.mark.xfail(
-    sys.version_info >= (3, 12),
-    reason="Waiting on https://github.com/python/cpython/issues/100964",
-)
 @pytest.mark.skipif(
     sys.implementation.name != "cpython", reason="Only makes sense with refcounting GC"
 )


### PR DESCRIPTION
At least if I'm reading pytest output correctly.

Fixes #2646 and presumably https://github.com/python/cpython/issues/100964 can be closed as well.