### PR TITLE
Fix thread reentry deadlocks

### DIFF
--- a/trio/_tests/test_threads.py
+++ b/trio/_tests/test_threads.py
@@ -13,9 +13,17 @@ from typing import Callable, Optional
 import pytest
 import sniffio
 
-from .. import CapacityLimiter, Event, _core, fail_after, sleep, sleep_forever
+from .. import (
+    CapacityLimiter,
+    Event,
+    _core,
+    fail_after,
+    move_on_after,
+    sleep,
+    sleep_forever,
+)
 from .._core._tests.test_ki import ki_self
-from .._core._tests.tutil import buggy_pypy_asyncgens
+from .._core._tests.tutil import buggy_pypy_asyncgens, slow
 from .._threads import (
     current_default_thread_limiter,
     from_thread_check_cancelled,
@@ -1015,3 +1023,19 @@ async def test_from_thread_check_cancelled_raises_in_foreign_threads():
     _core.start_thread_soon(from_thread_check_cancelled, lambda _: q.put(_))
     with pytest.raises(RuntimeError):
         q.get(timeout=1).unwrap()
+
+
+@slow
+async def test_reentry_doesnt_deadlock():
+    # Regression test for issue noticed in GH-2827
+    # The failure mode is to hang the whole test suite, unfortunately.
+    # XXX consider running this in a subprocess with a timeout, if it comes up again!
+
+    async def child() -> None:
+        while True:
+            await to_thread_run_sync(from_thread_run, sleep, 0, cancellable=False)
+
+    with move_on_after(2):
+        async with _core.open_nursery() as nursery:
+            for _ in range(4):
+                nursery.start_soon(child)


### PR DESCRIPTION
Should fix the timeouts @jakkdl worked on in #2827, which were introduced in #2392.  Some discussion from chat:

> @richardsheridan: the examples used seem to be extremely simple use cases where  we do `to_thread_run_sync(from_thread_run_X(afn))` back to back. if we can make a test that just loops for a few seconds doing that maybe it could reliably trigger the race for debugging? I won't be able to get to it for a while but just thinking out loud in case someone else wants to try first.

> @oremanj: richardsheridan: I just took another look at the threading code changes and I think there is a race here that I missed. When a host-task `run` completes, the host task immediately writes the result to the queue, which unblocks the thread and makes it possible for it to terminate. The thread's termination will reschedule the host task. But there's one checkpoint that the host task executes in between putting the result on the queue and going back to sleep:
> 
> ```
>     async def run(self) -> None:
>         # we use extra checkpoints to pick up and reset any context changes
>         task = trio.lowlevel.current_task()
>         old_context = task.context
>         task.context = self.context.copy()
>         try:
>             await trio.lowlevel.cancel_shielded_checkpoint()
>             result = await outcome.acapture(self.unprotected_afn)
>             self.queue.put_nowait(result)
>         finally:
>             task.context = old_context
>             await trio.lowlevel.cancel_shielded_checkpoint() # <-- this one
> ```
> 
> If the `report_back_in_trio_thread` callback is run during that checkpoint, then we will try to reschedule an already-scheduled task, which violates the task invariants and is probably what's causing this hang.

I'm going to first see how the test suite goes on my new regression test, then push the fix.