### PR TITLE
Sort pre-commit config file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,10 @@
+ci:
+  autofix_commit_msg: "[pre-commit.ci] auto fixes from pre-commit.com hooks"
+  autofix_prs: false
+  autoupdate_commit_msg: "[pre-commit.ci] pre-commit autoupdate"
+  autoupdate_schedule: weekly
+  submodules: false
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
@@ -9,6 +16,8 @@ repos:
       - id: check-merge-conflict
       - id: mixed-line-ending
       - id: check-case-conflict
+      - id: sort-simple-yaml
+        files: .pre-commit-config.yaml
   - repo: https://github.com/psf/black
     rev: 23.10.1
     hooks:
@@ -23,10 +32,3 @@ repos:
     rev: v2.2.6
     hooks:
       - id: codespell
-
-ci:
-  autofix_commit_msg: "[pre-commit.ci] auto fixes from pre-commit.com hooks"
-  autofix_prs: false
-  autoupdate_commit_msg: "[pre-commit.ci] pre-commit autoupdate"
-  autoupdate_schedule: weekly
-  submodules: false


### PR DESCRIPTION
This PR enables the `sort-simple-yaml` pre-commit hook, and has it sort the `.pre-commit-config.yaml` file.
The intention is to give it order if changes ever happen in the future, but in the end it's personal preference.