### PR TITLE
extend apport excepthook detection to also detect partial_apport_excepthook

### DIFF
--- a/trio/_core/_multierror.py
+++ b/trio/_core/_multierror.py
@@ -474,9 +474,9 @@ def concat_tb(
 # hook.
 #
 # More details: https://github.com/python-trio/trio/issues/1065
-if (
-    sys.version_info < (3, 11)
-    and getattr(sys.excepthook, "__name__", None) == "apport_excepthook"
+if sys.version_info < (3, 11) and getattr(sys.excepthook, "__name__", None) in (
+    "apport_excepthook",
+    "partial_apport_excepthook",
 ):
     from types import ModuleType
 


### PR DESCRIPTION
fixes #2464 

A slighly more general fix would be `if "apport_excepthook" in getattr(sys.excepthook, "__name__", "")` in case they make another slight change to the name of the function.

The issue mentioned that this broke as they updated to Ubuntu 22.10, and all the ubuntu builds in our CI runs on 22.04, which I assume is why this wasn't picked up by the test suite.
It would be great if @Adrien-Luxey or somebody else with easy access to an ubuntu 22.10 machine could run the test suite on master and then this PR to see if it is fixed.

Checking https://github.com/actions/runner-images#available-images it looks like 22.04 is the only available image, so would require a bunch of extra work to get this tested in CI.