### PR TITLE
Remove infinity support for tcp listener backlogs

### DIFF
--- a/newsfragments/2842.removal.rst
+++ b/newsfragments/2842.removal.rst
@@ -1,0 +1,1 @@
+Removed support for ``math.inf`` for the ``backlog`` argument in ``open_tcp_listeners``, making it's docstring correct in the fact that only ``TypeError``s are raised if invalid arguments are passed.

--- a/newsfragments/2842.removal.rst
+++ b/newsfragments/2842.removal.rst
@@ -1,1 +1,1 @@
-Removed support for ``math.inf`` for the ``backlog`` argument in ``open_tcp_listeners``, making it's docstring correct in the fact that only ``TypeError``s are raised if invalid arguments are passed.
+Removed support for ``math.inf`` for the ``backlog`` argument in ``open_tcp_listeners``, making its docstring correct in the fact that only ``TypeError``s are raised if invalid arguments are passed.

--- a/trio/_highlevel_open_tcp_listeners.py
+++ b/trio/_highlevel_open_tcp_listeners.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import errno
 import sys
 from collections.abc import Awaitable, Callable
-from math import inf
 
 import trio
 from trio import TaskStatus
@@ -41,16 +40,12 @@ if sys.version_info < (3, 11):
 # so this is unnecessary -- we can just pass in "infinity" and get the maximum
 # that way. (Verified on Windows, Linux, macOS using
 # notes-to-self/measure-listen-backlog.py)
-def _compute_backlog(backlog: int | float | None) -> int:  # noqa: PYI041
+def _compute_backlog(backlog: int | None) -> int:
     # Many systems (Linux, BSDs, ...) store the backlog in a uint16 and are
     # missing overflow protection, so we apply our own overflow protection.
     # https://github.com/golang/go/issues/5030
-    if isinstance(backlog, float):
-        # TODO: Remove when removing infinity support
-        # https://github.com/python-trio/trio/pull/2724#discussion_r1278541729
-        if backlog != inf:
-            raise ValueError(f"Only accepts infinity, not {backlog!r}")
-        backlog = None
+    if not isinstance(backlog, int) or backlog is not None:
+        raise TypeError(f"backlog must be an int or None not {backlog!r}")
     if backlog is None:
         return 0xFFFF
     return min(backlog, 0xFFFF)
@@ -60,7 +55,7 @@ async def open_tcp_listeners(
     port: int,
     *,
     host: str | bytes | None = None,
-    backlog: int | float | None = None,  # noqa: PYI041
+    backlog: int | None = None,
 ) -> list[trio.SocketListener]:
     """Create :class:`SocketListener` objects to listen for TCP connections.
 
@@ -93,8 +88,8 @@ async def open_tcp_listeners(
           all interfaces, pass the family-specific wildcard address:
           ``"0.0.0.0"`` for IPv4-only and ``"::"`` for IPv6-only.
 
-      backlog (int, math.inf, or None): The listen backlog to use. If you leave this as
-          ``None`` or ``math.inf`` then Trio will pick a good default. (Currently: whatever
+      backlog (int or None): The listen backlog to use. If you leave this as
+          ``None`` then Trio will pick a good default. (Currently: whatever
           your system has configured as the maximum backlog.)
 
     Returns:
@@ -172,7 +167,7 @@ async def serve_tcp(
     port: int,
     *,
     host: str | bytes | None = None,
-    backlog: int | float | None = None,  # noqa: PYI041
+    backlog: int | None = None,
     handler_nursery: trio.Nursery | None = None,
     task_status: TaskStatus[list[trio.SocketListener]] = trio.TASK_STATUS_IGNORED,
 ) -> None:

--- a/trio/_highlevel_open_tcp_listeners.py
+++ b/trio/_highlevel_open_tcp_listeners.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import errno
+import math
 import sys
+import warnings
 from collections.abc import Awaitable, Callable
 
 import trio
@@ -44,8 +46,14 @@ def _compute_backlog(backlog: int | None) -> int:
     # Many systems (Linux, BSDs, ...) store the backlog in a uint16 and are
     # missing overflow protection, so we apply our own overflow protection.
     # https://github.com/golang/go/issues/5030
+    if backlog == math.inf:
+        backlog = None
+        warnings.warn(
+            "Accepting infinity for backlog for compatibility, please use `None` instead.",
+            stacklevel=2,
+        )
     if not isinstance(backlog, int) and backlog is not None:
-        raise TypeError(f"backlog must be an int or None not {backlog!r}")
+        raise TypeError(f"backlog must be an int or None, not {backlog!r}")
     if backlog is None:
         return 0xFFFF
     return min(backlog, 0xFFFF)

--- a/trio/_highlevel_open_tcp_listeners.py
+++ b/trio/_highlevel_open_tcp_listeners.py
@@ -44,7 +44,7 @@ def _compute_backlog(backlog: int | None) -> int:
     # Many systems (Linux, BSDs, ...) store the backlog in a uint16 and are
     # missing overflow protection, so we apply our own overflow protection.
     # https://github.com/golang/go/issues/5030
-    if not isinstance(backlog, int) or backlog is not None:
+    if not isinstance(backlog, int) and backlog is not None:
         raise TypeError(f"backlog must be an int or None not {backlog!r}")
     if backlog is None:
         return 0xFFFF

--- a/trio/_highlevel_open_tcp_listeners.py
+++ b/trio/_highlevel_open_tcp_listeners.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 import errno
 import math
 import sys
-import warnings
 from collections.abc import Awaitable, Callable
 
 import trio
 from trio import TaskStatus
 
 from . import socket as tsocket
+from ._deprecate import warn_deprecated
 
 if sys.version_info < (3, 11):
     from exceptiongroup import ExceptionGroup
@@ -48,9 +48,11 @@ def _compute_backlog(backlog: int | None) -> int:
     # https://github.com/golang/go/issues/5030
     if backlog == math.inf:
         backlog = None
-        warnings.warn(
-            "Accepting infinity for backlog for compatibility, please use `None` instead.",
-            stacklevel=2,
+        warn_deprecated(
+            thing="math.inf as a backlog",
+            version="0.23.0",
+            instead="None",
+            issue=2842,
         )
     if not isinstance(backlog, int) and backlog is not None:
         raise TypeError(f"backlog must be an int or None, not {backlog!r}")

--- a/trio/_highlevel_ssl_helpers.py
+++ b/trio/_highlevel_ssl_helpers.py
@@ -72,7 +72,7 @@ async def open_ssl_over_tcp_listeners(
     *,
     host: str | bytes | None = None,
     https_compatible: bool = False,
-    backlog: int | float | None = None,  # noqa: PYI041
+    backlog: int | None = None,
 ) -> list[trio.SSLListener]:
     """Start listening for SSL/TLS-encrypted TCP connections to the given port.
 
@@ -101,7 +101,7 @@ async def serve_ssl_over_tcp(
     *,
     host: str | bytes | None = None,
     https_compatible: bool = False,
-    backlog: int | float | None = None,  # noqa: PYI041
+    backlog: int | None = None,
     handler_nursery: trio.Nursery | None = None,
     task_status: trio.TaskStatus[list[trio.SSLListener]] = trio.TASK_STATUS_IGNORED,
 ) -> NoReturn:

--- a/trio/_tests/test_highlevel_open_tcp_listeners.py
+++ b/trio/_tests/test_highlevel_open_tcp_listeners.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import errno
 import socket as stdlib_socket
 import sys
-from math import inf
 from socket import AddressFamily, SocketKind
 from typing import TYPE_CHECKING, Any, Sequence, overload
 
@@ -368,7 +367,6 @@ async def test_open_tcp_listeners_backlog() -> None:
     tsocket.set_custom_socket_factory(fsf)
     for given, expected in [
         (None, 0xFFFF),
-        (inf, 0xFFFF),
         (99999999, 0xFFFF),
         (10, 10),
         (1, 1),
@@ -385,6 +383,6 @@ async def test_open_tcp_listeners_backlog_float_error() -> None:
     tsocket.set_custom_socket_factory(fsf)
     for should_fail in (0.0, 2.18, 3.14, 9.75):
         with pytest.raises(
-            ValueError, match=f"Only accepts infinity, not {should_fail!r}"
+            TypeError, match=f"backlog must be an int or None not {should_fail!r}"
         ):
-            await open_tcp_listeners(0, backlog=should_fail)
+            await open_tcp_listeners(0, backlog=should_fail)  # type: ignore[arg-type]

--- a/trio/_tests/test_highlevel_open_tcp_listeners.py
+++ b/trio/_tests/test_highlevel_open_tcp_listeners.py
@@ -383,6 +383,6 @@ async def test_open_tcp_listeners_backlog_float_error() -> None:
     tsocket.set_custom_socket_factory(fsf)
     for should_fail in (0.0, 2.18, 3.14, 9.75):
         with pytest.raises(
-            TypeError, match=f"backlog must be an int or None not {should_fail!r}"
+            TypeError, match=f"backlog must be an int or None, not {should_fail!r}"
         ):
             await open_tcp_listeners(0, backlog=should_fail)  # type: ignore[arg-type]


### PR DESCRIPTION
This PR makes due on my comment in 6f9ab95349044dbb9d63408d2245dc95ad167f7e, removing support for `math.inf` as an argument for the tcp listener backlog, leaving only `int | None` as valid options.