### PR TITLE
Add removals as a newsfragment type

### DIFF
--- a/newsfragments/2842.deprecated.rst
+++ b/newsfragments/2842.deprecated.rst
@@ -1,1 +1,1 @@
-Deprecated support for ``math.inf`` for the ``backlog`` argument in ``open_tcp_listeners``, making its docstring correct in the fact that only ``TypeError``s are raised if invalid arguments are passed.
+Deprecated support for ``math.inf`` for the ``backlog`` argument in ``open_tcp_listeners``, making its docstring correct in the fact that only ``TypeError`` is raised if invalid arguments are passed.

--- a/newsfragments/2842.deprecated.rst
+++ b/newsfragments/2842.deprecated.rst
@@ -1,0 +1,1 @@
+Deprecated support for ``math.inf`` for the ``backlog`` argument in ``open_tcp_listeners``, making its docstring correct in the fact that only ``TypeError``s are raised if invalid arguments are passed.

--- a/newsfragments/2842.removal.rst
+++ b/newsfragments/2842.removal.rst
@@ -1,1 +1,0 @@
-Removed support for ``math.inf`` for the ``backlog`` argument in ``open_tcp_listeners``, making its docstring correct in the fact that only ``TypeError``s are raised if invalid arguments are passed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,6 +149,11 @@ name = "Deprecations and removals"
 showcontent = true
 
 [[tool.towncrier.type]]
+directory = "removal"
+name = "Removals without deprecations"
+showcontent = true
+
+[[tool.towncrier.type]]
 directory = "misc"
 name = "Miscellaneous internal changes"
 showcontent = true


### PR DESCRIPTION
Fixes https://github.com/python-trio/trio/issues/2846

cc @CoolCat467 about changing the category for your newsfragment.