### PR TITLE
Don't use absolute path for sleep binary in tests

### DIFF
--- a/src/trio/_tests/test_subprocess.py
+++ b/src/trio/_tests/test_subprocess.py
@@ -73,7 +73,7 @@ CAT = python("sys.stdout.buffer.write(sys.stdin.buffer.read())")
 if posix:
 
     def SLEEP(seconds: int) -> list[str]:
-        return ["/bin/sleep", str(seconds)]
+        return ["sleep", str(seconds)]
 
 else:
 


### PR DESCRIPTION
While most OSes will have the `sleep` binary in `/bin`, this is not guaranteed (e.g. `/bin` only contains `sh` on NixOS). While in principle one might have an incompatible `sleep` somewhere in PATH, this seems unlikely.