### PR TITLE
Address PyPy flakiness in test_for_leaking_fds

### DIFF
--- a/src/trio/_tests/test_subprocess.py
+++ b/src/trio/_tests/test_subprocess.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import gc
 import os
 import random
 import signal
@@ -620,6 +621,8 @@ async def test_run_process_background_fail() -> None:
     reason="requires a way to iterate through open files",
 )
 async def test_for_leaking_fds() -> None:
+    gc.collect()  # address possible flakiness on PyPy
+
     starting_fds = set(SyncPath("/dev/fd").iterdir())
     await run_process(EXIT_TRUE)
     assert set(SyncPath("/dev/fd").iterdir()) == starting_fds


### PR DESCRIPTION
Refs https://github.com/python-trio/trio/issues/2885

I've run the PyPy test suite a lot and this test in particular has failed.

See https://github.com/A5rocks/trio/actions/runs/6953123771/job/18951033826#step:5:5284 for an example of this happening.

I'm guessing that this is because PyPy GC is weird and isn't guaranteed to clean up previous test objects which might contain something with a file descriptor. I added this here and I didn't get this test to fail again in a bunch of runs, so I think this fixes that.

Now I'm kinda thinking of if it's possible to upstream this in pytest, because this kind of thing is insidious. https://foss.heptapod.net/pypy/pypy/-/commit/5a6a733370542b26e7c4ee756c4fb566523e53d8 introduces a new PyPy GC API that can address this more generally, I believe.