### PR TITLE
Refactor `gc_collect_harder` to use new PyPy API

### DIFF
--- a/src/trio/_core/_tests/tutil.py
+++ b/src/trio/_core/_tests/tutil.py
@@ -62,7 +62,7 @@ def gc_collect_harder() -> None:
         gc.collect()
     elif sys.implementation.name == "pypy":
         gc.collect_all_finalizers()
-    else:
+    else:  # pragma: no cover
         raise AssertionError("not sure how to conclusively GC")
 
 


### PR DESCRIPTION
I just realized https://foss.heptapod.net/pypy/pypy/-/commit/5a6a733370542b26e7c4ee756c4fb566523e53d8 happened in response to an issue I made on PyPy. Let's try out this API!