### PR TITLE
Switch to mypyc-compiled black mirror pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       - id: check-case-conflict
       - id: sort-simple-yaml
         files: .pre-commit-config.yaml
-  - repo: https://github.com/psf/black
+  - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 23.11.0
     hooks:
       - id: black


### PR DESCRIPTION
When I am working on PRs, I tend to run `pre-commit run -a` a lot to make sure all files are checked, and I've noticed that black runs considerably slower than all the other checks. This PR changes the black hook used to [the official pre-commit mirror](https://github.com/psf/black-pre-commit-mirror) that uses a mypyc compiled version of black that is significantly faster.


Funny quote from black-pre-commit-mirror:
> mypyc wheels go brr