### PR TITLE
Make ``start_soon`` a protocol.

### DIFF
--- a/src/trio/_abc.py
+++ b/src/trio/_abc.py
@@ -4,12 +4,12 @@ import socket
 from abc import ABCMeta, abstractmethod
 from typing import TYPE_CHECKING, Generic, Protocol, TypeVar
 
-from typing_extensions import TypeVarTuple
+if TYPE_CHECKING:
+    from typing_extensions import TypeVarTuple
+
+    PosArgT = TypeVarTuple("PosArgT")
 
 import trio
-
-PosArgT = TypeVarTuple("PosArgT")
-
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable

--- a/src/trio/_core/_run.py
+++ b/src/trio/_core/_run.py
@@ -32,7 +32,7 @@ from sniffio import thread_local as sniffio_library
 from sortedcontainers import SortedDict
 
 from .. import _core
-from .._abc import Clock, Instrument
+from .._abc import Clock, Instrument, PosArgT
 from .._util import NoPublicConstructor, coroutine_or_error, final
 from ._asyncgens import AsyncGenerators
 from ._entry_queue import EntryQueue, TrioToken
@@ -76,9 +76,7 @@ if TYPE_CHECKING:
     # for some strange reason Sphinx works with outcome.Outcome, but not Outcome, in
     # start_guest_run. Same with types.FrameType in iter_await_frames
     import outcome
-    from typing_extensions import Self, TypeVarTuple, Unpack
-
-    PosArgT = TypeVarTuple("PosArgT")
+    from typing_extensions import Self, Unpack
 
     # Needs to be guarded, since Unpack[] would be evaluated at runtime.
     class _NurseryStartFunc(Protocol[Unpack[PosArgT], StatusT_co]):

--- a/src/trio/_core/_run.py
+++ b/src/trio/_core/_run.py
@@ -32,7 +32,7 @@ from sniffio import thread_local as sniffio_library
 from sortedcontainers import SortedDict
 
 from .. import _core
-from .._abc import Clock, Instrument, PosArgT
+from .._abc import Clock, Instrument
 from .._util import NoPublicConstructor, coroutine_or_error, final
 from ._asyncgens import AsyncGenerators
 from ._entry_queue import EntryQueue, TrioToken
@@ -76,7 +76,9 @@ if TYPE_CHECKING:
     # for some strange reason Sphinx works with outcome.Outcome, but not Outcome, in
     # start_guest_run. Same with types.FrameType in iter_await_frames
     import outcome
-    from typing_extensions import Self, Unpack
+    from typing_extensions import Self, TypeVarTuple, Unpack
+
+    PosArgT = TypeVarTuple("PosArgT")
 
     # Needs to be guarded, since Unpack[] would be evaluated at runtime.
     class _NurseryStartFunc(Protocol[Unpack[PosArgT], StatusT_co]):

--- a/src/trio/_highlevel_open_tcp_listeners.py
+++ b/src/trio/_highlevel_open_tcp_listeners.py
@@ -14,6 +14,8 @@ from ._deprecate import warn_deprecated
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
+    from .abc import TaskSpawner
+
 if sys.version_info < (3, 11):
     from exceptiongroup import ExceptionGroup
 
@@ -181,7 +183,7 @@ async def serve_tcp(
     *,
     host: str | bytes | None = None,
     backlog: int | None = None,
-    handler_nursery: trio.Nursery | None = None,
+    handler_nursery: TaskSpawner | None = None,
     task_status: TaskStatus[list[trio.SocketListener]] = trio.TASK_STATUS_IGNORED,
 ) -> None:
     """Listen for incoming TCP connections, and for each one start a task

--- a/src/trio/_highlevel_serve_listeners.py
+++ b/src/trio/_highlevel_serve_listeners.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import errno
 import logging
 import os
-from typing import Any, Awaitable, Callable, NoReturn, TypeVar
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, NoReturn, TypeVar
 
 import trio
+
+if TYPE_CHECKING:
+    from .abc import TaskSpawner
 
 # Errors that accept(2) can return, and which indicate that the system is
 # overloaded
@@ -37,7 +40,7 @@ async def _run_handler(stream: StreamT, handler: Handler[StreamT]) -> None:
 
 async def _serve_one_listener(
     listener: trio.abc.Listener[StreamT],
-    handler_nursery: trio.Nursery,
+    handler_nursery: TaskSpawner,
     handler: Handler[StreamT],
 ) -> NoReturn:
     async with listener:
@@ -70,7 +73,7 @@ async def serve_listeners(
     handler: Handler[StreamT],
     listeners: list[ListenerT],
     *,
-    handler_nursery: trio.Nursery | None = None,
+    handler_nursery: TaskSpawner | None = None,
     task_status: trio.TaskStatus[list[ListenerT]] = trio.TASK_STATUS_IGNORED,
 ) -> NoReturn:
     r"""Listen for incoming connections on ``listeners``, and for each one

--- a/src/trio/_highlevel_ssl_helpers.py
+++ b/src/trio/_highlevel_ssl_helpers.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
     from ._highlevel_socket import SocketStream
+    from .abc import TaskSpawner
 
 
 # It might have been nice to take a ssl_protocols= argument here to set up
@@ -108,7 +109,7 @@ async def serve_ssl_over_tcp(
     host: str | bytes | None = None,
     https_compatible: bool = False,
     backlog: int | None = None,
-    handler_nursery: trio.Nursery | None = None,
+    handler_nursery: TaskSpawner | None = None,
     task_status: trio.TaskStatus[
         list[trio.SSLListener[SocketStream]]
     ] = trio.TASK_STATUS_IGNORED,

--- a/src/trio/abc.py
+++ b/src/trio/abc.py
@@ -20,4 +20,5 @@ from ._abc import (
     SendStream as SendStream,
     SocketFactory as SocketFactory,
     Stream as Stream,
+    TaskSpawner as TaskSpawner,
 )


### PR DESCRIPTION
Don't care for bikeshedding over the name of the protocol. The definition of ``start_soon`` is directly copied from ``Nursery``. 

I would've liked Nursery to explicitly implement TaskSpawner but it can't due to metaclass clashing.