### PR TITLE
Cython Workaround

### DIFF
--- a/src/trio/_core/_run.py
+++ b/src/trio/_core/_run.py
@@ -1758,7 +1758,7 @@ class Runner:
             except AttributeError:
                 name = repr(name)
 
-        if not hasattr(coro, "cr_frame"):
+        if getattr(coro, "cr_frame", None) is None:
             # This async function is implemented in C or Cython
             async def python_wrapper(orig_coro: Awaitable[RetT]) -> RetT:
                 return await orig_coro


### PR DESCRIPTION
This pull request partially completes changes that were noted in #2908.

Either added on to this pull request or in another pull request, we still need to make sure to test that cython will continue working and not find these sorts of issues after they are already a problem.

Excerpt from original comment in #2908:
>But it would be good to also run a test for this in CI. We do have a test for the interpreter's built-in C coroutines (`test_async_function_implemented_in_C`) and I [njsmith] originally assumed that would be enough, but obviously it wasn't, so I guess we need to do the legwork to install cython in CI and build a tiny Cython module.