### PR TITLE
Enable `flake8-future-annotations`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,8 +93,6 @@ src = ["src/trio", "notes-to-self"]
 select = [
     "ASYNC", # flake8-async
     "B",     # flake8-bugbear
-    "E",     # Error
-    "F",     # pyflakes
     "C4",    # flake8-comprehensions
     "E",     # Error
     "F",     # pyflakes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,27 +91,27 @@ allowed-confusables = ["–"]
 src = ["src/trio", "notes-to-self"]
 
 select = [
-  "RUF",  # Ruff-specific rules
-  "F",  # pyflakes
-  "E",  # Error
-  "W",  # Warning
-  "I",  # isort
-  "UP",  # pyupgrade
-  "B",  # flake8-bugbear
-  "YTT",  # flake8-2020
-  "ASYNC",  # flake8-async
-  "PYI",  # flake8-pyi
-  "SIM",  # flake8-simplify
-  "TCH",  # flake8-type-checking
-  "PT",  # flake8-pytest-style
+    "RUF",   # Ruff-specific rules
+    "F",     # pyflakes
+    "E",     # Error
+    "W",     # Warning
+    "I",     # isort
+    "UP",    # pyupgrade
+    "B",     # flake8-bugbear
+    "YTT",   # flake8-2020
+    "ASYNC", # flake8-async
+    "PYI",   # flake8-pyi
+    "SIM",   # flake8-simplify
+    "TCH",   # flake8-type-checking
+    "PT",    # flake8-pytest-style
 ]
 extend-ignore = [
-    'F403',  # undefined-local-with-import-star
-    'F405',  # undefined-local-with-import-star-usage
-    'E402',  # module-import-not-at-top-of-file (usually OS-specific)
-    'E501',  # line-too-long
-    'SIM117',  # multiple-with-statements (messes up lots of context-based stuff and looks bad)
-    'PT012', # multiple statements in pytest.raises block
+    'F403',   # undefined-local-with-import-star
+    'F405',   # undefined-local-with-import-star-usage
+    'E402',   # module-import-not-at-top-of-file (usually OS-specific)
+    'E501',   # line-too-long
+    'SIM117', # multiple-with-statements (messes up lots of context-based stuff and looks bad)
+    'PT012',  # multiple statements in pytest.raises block
 ]
 
 include = ["*.py", "*.pyi", "**/pyproject.toml"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,27 +91,27 @@ allowed-confusables = ["–"]
 src = ["src/trio", "notes-to-self"]
 
 select = [
-    "RUF",   # Ruff-specific rules
-    "F",     # pyflakes
-    "E",     # Error
-    "W",     # Warning
-    "I",     # isort
-    "UP",    # pyupgrade
-    "B",     # flake8-bugbear
-    "YTT",   # flake8-2020
     "ASYNC", # flake8-async
+    "B",     # flake8-bugbear
+    "E",     # Error
+    "F",     # pyflakes
+    "I",     # isort
+    "PT",    # flake8-pytest-style
     "PYI",   # flake8-pyi
+    "RUF",   # Ruff-specific rules
     "SIM",   # flake8-simplify
     "TCH",   # flake8-type-checking
-    "PT",    # flake8-pytest-style
+    "UP",    # pyupgrade
+    "W",     # Warning
+    "YTT",   # flake8-2020
 ]
 extend-ignore = [
-    'F403',   # undefined-local-with-import-star
-    'F405',   # undefined-local-with-import-star-usage
     'E402',   # module-import-not-at-top-of-file (usually OS-specific)
     'E501',   # line-too-long
-    'SIM117', # multiple-with-statements (messes up lots of context-based stuff and looks bad)
+    'F403',   # undefined-local-with-import-star
+    'F405',   # undefined-local-with-import-star-usage
     'PT012',  # multiple statements in pytest.raises block
+    'SIM117', # multiple-with-statements (messes up lots of context-based stuff and looks bad)
 ]
 
 include = ["*.py", "*.pyi", "**/pyproject.toml"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ select = [
     "B",     # flake8-bugbear
     "E",     # Error
     "F",     # pyflakes
+    "FA",    # flake8-future-annotations
     "I",     # isort
     "PT",    # flake8-pytest-style
     "PYI",   # flake8-pyi

--- a/src/trio/_subprocess_platform/__init__.py
+++ b/src/trio/_subprocess_platform/__init__.py
@@ -1,16 +1,17 @@
 # Platform-specific subprocess bits'n'pieces.
+from __future__ import annotations
 
 import os
 import sys
-from typing import TYPE_CHECKING, Optional, Tuple
+from typing import TYPE_CHECKING
 
 import trio
 
 from .. import _core, _subprocess
 from .._abc import ReceiveStream, SendStream  # noqa: TCH001
 
-_wait_child_exiting_error: Optional[ImportError] = None
-_create_child_pipe_error: Optional[ImportError] = None
+_wait_child_exiting_error: ImportError | None = None
+_create_child_pipe_error: ImportError | None = None
 
 
 if TYPE_CHECKING:
@@ -26,7 +27,7 @@ if TYPE_CHECKING:
 
 # Fallback versions of the functions provided -- implementations
 # per OS are imported atop these at the bottom of the module.
-async def wait_child_exiting(process: "_subprocess.Process") -> None:
+async def wait_child_exiting(process: _subprocess.Process) -> None:
     """Block until the child process managed by ``process`` is exiting.
 
     It is invalid to call this function if the process has already
@@ -41,7 +42,7 @@ async def wait_child_exiting(process: "_subprocess.Process") -> None:
     raise NotImplementedError from _wait_child_exiting_error  # pragma: no cover
 
 
-def create_pipe_to_child_stdin() -> Tuple["ClosableSendStream", int]:
+def create_pipe_to_child_stdin() -> tuple[ClosableSendStream, int]:
     """Create a new pipe suitable for sending data from this
     process to the standard input of a child we're about to spawn.
 
@@ -54,7 +55,7 @@ def create_pipe_to_child_stdin() -> Tuple["ClosableSendStream", int]:
     raise NotImplementedError from _create_child_pipe_error  # pragma: no cover
 
 
-def create_pipe_from_child_output() -> Tuple["ClosableReceiveStream", int]:
+def create_pipe_from_child_output() -> tuple[ClosableReceiveStream, int]:
     """Create a new pipe suitable for receiving data into this
     process from the standard output or error stream of a child
     we're about to spawn.

--- a/src/trio/_tests/test_file_io.py
+++ b/src/trio/_tests/test_file_io.py
@@ -1,9 +1,10 @@
+from __future__ import annotations
+
 import importlib
 import io
 import os
-import pathlib
 import re
-from typing import List, Tuple
+from typing import TYPE_CHECKING
 from unittest import mock
 from unittest.mock import sentinel
 
@@ -12,6 +13,9 @@ import pytest
 import trio
 from trio import _core, _file_io
 from trio._file_io import _FILE_ASYNC_METHODS, _FILE_SYNC_ATTRS, AsyncIOWrapper
+
+if TYPE_CHECKING:
+    import pathlib
 
 
 @pytest.fixture
@@ -109,7 +113,7 @@ def test_type_stubs_match_lists() -> None:
         pytest.fail("No TYPE CHECKING line?")
 
     # Now we should be at the type checking block.
-    found: List[Tuple[str, str]] = []
+    found: list[tuple[str, str]] = []
     for line in source:  # pragma: no branch - expected to break early
         if line.strip() and not line.startswith(" " * 8):
             break  # Dedented out of the if TYPE_CHECKING block.

--- a/src/trio/socket.py
+++ b/src/trio/socket.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 # here.
 # We still have some underscore names though but only a few.
 # Uses `from x import y as y` for compatibility with `pyright --verifytypes` (#2625)
+#
 # Dynamically re-export whatever constants this particular Python happens to
 # have:
 import socket as _stdlib_socket

--- a/src/trio/socket.py
+++ b/src/trio/socket.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 # This is a public namespace, so we don't want to expose any non-underscored
 # attributes that aren't actually part of our public API. But it's very
 # annoying to carefully always use underscored names for module-level
@@ -5,10 +7,7 @@
 # implementation in an underscored module, and then re-export the public parts
 # here.
 # We still have some underscore names though but only a few.
-
-
 # Uses `from x import y as y` for compatibility with `pyright --verifytypes` (#2625)
-
 # Dynamically re-export whatever constants this particular Python happens to
 # have:
 import socket as _stdlib_socket
@@ -17,7 +16,7 @@ import typing as _t
 
 from . import _socket
 
-_bad_symbols: _t.Set[str] = set()
+_bad_symbols: set[str] = set()
 if sys.platform == "win32":
     # See https://github.com/python-trio/trio/issues/39
     # Do not import for windows platform


### PR DESCRIPTION
This pull request enables ruff's `flake8-future-annotations` rule, building off of the formatting changes done in https://github.com/python-trio/trio/pull/2930.