### PR TITLE
change all instances of 'import typing as ...' to 'from typing import ...'

### DIFF
--- a/src/trio/_tests/type_tests/check_wraps.py
+++ b/src/trio/_tests/type_tests/check_wraps.py
@@ -1,9 +1,9 @@
 # https://github.com/python-trio/trio/issues/2775#issuecomment-1702267589
 # (except platform independent...)
 import trio
-import typing_extensions
+from typing_extensions import assert_type
 
 
 async def fn(s: trio.SocketStream) -> None:
     result = await s.socket.sendto(b"a", "h")
-    typing_extensions.assert_type(result, int)
+    assert_type(result, int)

--- a/src/trio/_util.py
+++ b/src/trio/_util.py
@@ -6,19 +6,29 @@ import inspect
 import os
 import signal
 import threading
-import typing as t
 from abc import ABCMeta
 from functools import update_wrapper
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Awaitable,
+    Callable,
+    Generic,
+    NoReturn,
+    Sequence,
+    TypeVar,
+    final as std_final,
+)
 
 from sniffio import thread_local as sniffio_loop
 
 import trio
 
-CallT = t.TypeVar("CallT", bound=t.Callable[..., t.Any])
-T = t.TypeVar("T")
-RetT = t.TypeVar("RetT")
+CallT = TypeVar("CallT", bound=Callable[..., Any])
+T = TypeVar("T")
+RetT = TypeVar("RetT")
 
-if t.TYPE_CHECKING:
+if TYPE_CHECKING:
     from types import AsyncGeneratorType, TracebackType
 
     from typing_extensions import ParamSpec, Self, TypeVarTuple, Unpack
@@ -27,7 +37,7 @@ if t.TYPE_CHECKING:
     PosArgsT = TypeVarTuple("PosArgsT")
 
 
-if t.TYPE_CHECKING:
+if TYPE_CHECKING:
     # Don't type check the implementation below, pthread_kill does not exist on Windows.
     def signal_raise(signum: int) -> None:
         ...
@@ -104,9 +114,9 @@ def is_main_thread() -> bool:
 # errors for common mistakes. Returns coroutine object.
 ######
 def coroutine_or_error(
-    async_fn: t.Callable[[Unpack[PosArgsT]], t.Awaitable[RetT]],
+    async_fn: Callable[[Unpack[PosArgsT]], Awaitable[RetT]],
     *args: Unpack[PosArgsT],
-) -> collections.abc.Coroutine[object, t.NoReturn, RetT]:
+) -> collections.abc.Coroutine[object, NoReturn, RetT]:
     def _return_value_looks_like_wrong_library(value: object) -> bool:
         # Returned by legacy @asyncio.coroutine functions, which includes
         # a surprising proportion of asyncio builtins.
@@ -231,7 +241,7 @@ def async_wraps(
     cls: type[object],
     wrapped_cls: type[object],
     attr_name: str,
-) -> t.Callable[[CallT], CallT]:
+) -> Callable[[CallT], CallT]:
     """Similar to wraps, but for async wrappers of non-async functions."""
 
     def decorator(func: CallT) -> CallT:
@@ -283,7 +293,7 @@ def fixup_module_metadata(
 # We need ParamSpec to type this "properly", but that requires a runtime typing_extensions import
 # to use as a class base. This is only used at runtime and isn't correct for type checkers anyway,
 # so don't bother.
-class generic_function(t.Generic[RetT]):
+class generic_function(Generic[RetT]):
     """Decorator that makes a function indexable, to communicate
     non-inferrable generic type parameters to a static type checker.
 
@@ -300,18 +310,18 @@ class generic_function(t.Generic[RetT]):
     but at least it becomes possible to write those.
     """
 
-    def __init__(self, fn: t.Callable[..., RetT]) -> None:
+    def __init__(self, fn: Callable[..., RetT]) -> None:
         update_wrapper(self, fn)
         self._fn = fn
 
-    def __call__(self, *args: t.Any, **kwargs: t.Any) -> RetT:
+    def __call__(self, *args: Any, **kwargs: Any) -> RetT:
         return self._fn(*args, **kwargs)
 
     def __getitem__(self, subscript: object) -> Self:
         return self
 
 
-def _init_final_cls(cls: type[object]) -> t.NoReturn:
+def _init_final_cls(cls: type[object]) -> NoReturn:
     """Raises an exception when a final class is subclassed."""
     raise TypeError(f"{cls.__module__}.{cls.__qualname__} does not support subclassing")
 
@@ -335,10 +345,10 @@ def _final_impl(decorated: type[T]) -> type[T]:
     # matter what the original did (if anything).
     decorated.__init_subclass__ = classmethod(_init_final_cls)  # type: ignore[assignment]
     # Apply the typing decorator, in 3.11+ it adds a __final__ marker attribute.
-    return t.final(decorated)
+    return std_final(decorated)
 
 
-if t.TYPE_CHECKING:
+if TYPE_CHECKING:
     from typing import final
 else:
     final = _final_impl
@@ -374,7 +384,7 @@ class NoPublicConstructor(ABCMeta):
         return super().__call__(*args, **kwargs)  # type: ignore
 
 
-def name_asyncgen(agen: AsyncGeneratorType[object, t.NoReturn]) -> str:
+def name_asyncgen(agen: AsyncGeneratorType[object, NoReturn]) -> str:
     """Return the fully-qualified name of the async generator function
     that produced the async generator iterator *agen*.
     """
@@ -392,14 +402,14 @@ def name_asyncgen(agen: AsyncGeneratorType[object, t.NoReturn]) -> str:
 
 
 # work around a pyright error
-if t.TYPE_CHECKING:
-    Fn = t.TypeVar("Fn", bound=t.Callable[..., object])
+if TYPE_CHECKING:
+    Fn = TypeVar("Fn", bound=Callable[..., object])
 
     def wraps(
-        wrapped: t.Callable[..., object],
-        assigned: t.Sequence[str] = ...,
-        updated: t.Sequence[str] = ...,
-    ) -> t.Callable[[Fn], Fn]:
+        wrapped: Callable[..., object],
+        assigned: Sequence[str] = ...,
+        updated: Sequence[str] = ...,
+    ) -> Callable[[Fn], Fn]:
         ...
 
 else:

--- a/src/trio/lowlevel.py
+++ b/src/trio/lowlevel.py
@@ -5,7 +5,7 @@ but useful for extending Trio's functionality.
 
 import select as _select
 import sys
-import typing as _t
+from typing import TYPE_CHECKING
 
 # Generally available symbols
 from ._core import (
@@ -69,7 +69,7 @@ else:
     from ._unix_pipes import FdStream as FdStream
 
     # Kqueue-specific symbols
-    if sys.platform != "linux" and (_t.TYPE_CHECKING or not hasattr(_select, "epoll")):
+    if sys.platform != "linux" and (TYPE_CHECKING or not hasattr(_select, "epoll")):
         from ._core import (
             current_kqueue as current_kqueue,
             monitor_kevent as monitor_kevent,

--- a/src/trio/lowlevel.py
+++ b/src/trio/lowlevel.py
@@ -3,9 +3,13 @@ This namespace represents low-level functionality not intended for daily use,
 but useful for extending Trio's functionality.
 """
 
+# imports are renamed with leading underscores to indicate they are not part of the public API
+
 import select as _select
+
+# static checkers don't understand if importing this as _sys, so it's deleted later
 import sys
-from typing import TYPE_CHECKING
+import typing as _t
 
 # Generally available symbols
 from ._core import (
@@ -69,7 +73,7 @@ else:
     from ._unix_pipes import FdStream as FdStream
 
     # Kqueue-specific symbols
-    if sys.platform != "linux" and (TYPE_CHECKING or not hasattr(_select, "epoll")):
+    if sys.platform != "linux" and (_t.TYPE_CHECKING or not hasattr(_select, "epoll")):
         from ._core import (
             current_kqueue as current_kqueue,
             monitor_kevent as monitor_kevent,

--- a/src/trio/socket.py
+++ b/src/trio/socket.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 # have:
 import socket as _stdlib_socket
 import sys
-import typing as _t
+from typing import TYPE_CHECKING
 
 from . import _socket
 
@@ -49,7 +49,7 @@ from ._socket import (
 )
 
 # not always available so expose only if
-if sys.platform == "win32" or not _t.TYPE_CHECKING:
+if sys.platform == "win32" or not TYPE_CHECKING:
     with _suppress(ImportError):
         from ._socket import fromshare as fromshare
 
@@ -82,13 +82,13 @@ if sys.implementation.name == "cpython":
 
 
 # not always available so expose only if
-if sys.platform != "win32" or not _t.TYPE_CHECKING:
+if sys.platform != "win32" or not TYPE_CHECKING:
     with _suppress(ImportError):
         from socket import (
             sethostname as sethostname,
         )
 
-if _t.TYPE_CHECKING:
+if TYPE_CHECKING:
     IP_BIND_ADDRESS_NO_PORT: int
 else:
     try:
@@ -108,7 +108,7 @@ del sys
 # import statement statically lists every constant that *could* be
 # exported. There's a test in test_exports.py to make sure that the list is
 # kept up to date.
-if _t.TYPE_CHECKING:
+if TYPE_CHECKING:
     from socket import (  # type: ignore[attr-defined]
         AF_ALG as AF_ALG,
         AF_APPLETALK as AF_APPLETALK,

--- a/src/trio/socket.py
+++ b/src/trio/socket.py
@@ -81,6 +81,7 @@ if sys.implementation.name == "cpython":
             if_nameindex as if_nameindex,
         )
 
+
 # not always available so expose only if
 if sys.platform != "win32" or not _t.TYPE_CHECKING:
     with _suppress(ImportError):

--- a/src/trio/socket.py
+++ b/src/trio/socket.py
@@ -7,13 +7,11 @@ from __future__ import annotations
 # implementation in an underscored module, and then re-export the public parts
 # here.
 # We still have some underscore names though but only a few.
-# Uses `from x import y as y` for compatibility with `pyright --verifytypes` (#2625)
-#
-# Dynamically re-export whatever constants this particular Python happens to
-# have:
 import socket as _stdlib_socket
+
+# static checkers don't understand if importing this as _sys, so it's deleted later
 import sys
-from typing import TYPE_CHECKING
+import typing as _t
 
 from . import _socket
 
@@ -24,6 +22,8 @@ if sys.platform == "win32":
     # (you can still get it from stdlib socket, of course, if you want it)
     _bad_symbols.add("SO_REUSEADDR")
 
+# Dynamically re-export whatever constants this particular Python happens to
+# have:
 globals().update(
     {
         _name: getattr(_stdlib_socket, _name)
@@ -35,6 +35,7 @@ globals().update(
 # import the overwrites
 from contextlib import suppress as _suppress
 
+# Uses `from x import y as y` for compatibility with `pyright --verifytypes` (#2625)
 from ._socket import (
     SocketType as SocketType,
     from_stdlib_socket as from_stdlib_socket,
@@ -49,7 +50,7 @@ from ._socket import (
 )
 
 # not always available so expose only if
-if sys.platform == "win32" or not TYPE_CHECKING:
+if sys.platform == "win32" or not _t.TYPE_CHECKING:
     with _suppress(ImportError):
         from ._socket import fromshare as fromshare
 
@@ -80,15 +81,14 @@ if sys.implementation.name == "cpython":
             if_nameindex as if_nameindex,
         )
 
-
 # not always available so expose only if
-if sys.platform != "win32" or not TYPE_CHECKING:
+if sys.platform != "win32" or not _t.TYPE_CHECKING:
     with _suppress(ImportError):
         from socket import (
             sethostname as sethostname,
         )
 
-if TYPE_CHECKING:
+if _t.TYPE_CHECKING:
     IP_BIND_ADDRESS_NO_PORT: int
 else:
     try:
@@ -104,11 +104,11 @@ del sys
 # re-export them. Since the exact set of constants varies depending on Python
 # version, platform, the libc installed on the system where Python was built,
 # etc., we figure out which constants to re-export dynamically at runtime (see
-# below). But that confuses static analysis tools like jedi and mypy. So this
+# above). But that confuses static analysis tools like jedi and mypy. So this
 # import statement statically lists every constant that *could* be
 # exported. There's a test in test_exports.py to make sure that the list is
 # kept up to date.
-if TYPE_CHECKING:
+if _t.TYPE_CHECKING:
     from socket import (  # type: ignore[attr-defined]
         AF_ALG as AF_ALG,
         AF_APPLETALK as AF_APPLETALK,


### PR DESCRIPTION
Noticed this when reviewing #2932. For context, `from typing import` is what's used everywhere else, with 110 matches in the repository when `grep`ing.

also one instance of `import typing_extensions`, where statistics are similar.