### PR TITLE
Fix finding pthread_*name_np on vanilla musl libc

### DIFF
--- a/newsfragments/2939.bugfix.rst
+++ b/newsfragments/2939.bugfix.rst
@@ -1,0 +1,1 @@
+The pthread functions are now correctly found on systems using vanilla versions of musl libc.

--- a/src/trio/_core/_thread_cache.py
+++ b/src/trio/_core/_thread_cache.py
@@ -41,10 +41,15 @@ def get_os_thread_name_func() -> Callable[[int | None, str], None] | None:
             setname(_to_os_thread_name(name))
 
     # find the pthread library
-    # this will fail on windows
+    # this will fail on windows and musl
     libpthread_path = ctypes.util.find_library("pthread")
     if not libpthread_path:
-        return None
+        # musl includes pthread functions directly in libc.so
+        # (but note that find_library("c") does not work on musl,
+        #  see: https://github.com/python/cpython/issues/65821)
+        # so try that library instead
+        # if it doesn't exist, CDLL() will fail below
+        libpthread_path = "libc.so"
 
     # Sometimes windows can find the path, but gives a permission error when
     # accessing it. Catching a wider exception in case of more esoteric errors.


### PR DESCRIPTION
Fix the `pthread_getname_np` and `pthread_setname_np` search logic to support vanilla versions of musl and CPython, e.g. as used on Gentoo musl systems.  On such systems, there is no "libpthread.so" (there is only a static library) and the relevant functions are found in "libc.so".  Additionally, `ctypes.util.find_library("c")` does not work because of an old unsolved bug in CPython (linked in the code).

To resolve the problem, add a fallback to trying `libc.so` if no pthread library can be found.  This roughly covers three possibilities:

- a "typical" system with `libpthread.so` will find that library and use it

- a musl system will fall back to `libc.so`, load that library and find pthread functions there

- any other system will try to load `libc.so`, and fail

The code in `get_os_thread_name_func()` remains fully relaxed, allowing either CDLL construction (i.e. finding the library) to fail, or the library not to contain `pthread_setname_np`.

The code in `test_threads.py` was made more relaxed — rather than skipping if `libpthread.so` does not exist, it tries to load `libc.so` as a fallback, and skips if that fails.

Originally reported as https://bugs.gentoo.org/923257.