### PR TITLE
Support Pyright detection of constructor kwargs in `attrs`-based data classes

### DIFF
--- a/docs-requirements.in
+++ b/docs-requirements.in
@@ -9,7 +9,7 @@ towncrier
 
 # Trio's own dependencies
 cffi; os_name == "nt"
-attrs >= 19.2.0
+attrs >= 23.2.0
 sortedcontainers
 idna
 outcome

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -12,7 +12,7 @@ attrs==23.2.0
     #   outcome
 babel==2.14.0
     # via sphinx
-certifi==2023.11.17
+certifi==2024.2.2
     # via requests
 cffi==1.16.0
     # via cryptography
@@ -47,7 +47,7 @@ jinja2==3.1.3
     #   -r docs-requirements.in
     #   sphinx
     #   towncrier
-markupsafe==2.1.4
+markupsafe==2.1.5
     # via jinja2
 outcome==1.3.0.post0
     # via -r docs-requirements.in
@@ -59,7 +59,7 @@ pygments==2.17.2
     # via sphinx
 pyopenssl==24.0.0
     # via -r docs-requirements.in
-pytz==2023.4
+pytz==2024.1
     # via babel
 requests==2.31.0
     # via sphinx

--- a/notes-to-self/time-wait.py
+++ b/notes-to-self/time-wait.py
@@ -34,11 +34,11 @@ import attrs
 
 @attrs.define(repr=False, slots=False)
 class Options:
-    listen1_early = attrs.field(default=None)
-    listen1_middle = attrs.field(default=None)
-    listen1_late = attrs.field(default=None)
-    server = attrs.field(default=None)
-    listen2 = attrs.field(default=None)
+    listen1_early = None
+    listen1_middle = None
+    listen1_late = None
+    server = None
+    listen2 = None
 
     def set(self, which, sock):
         value = getattr(self, which)

--- a/notes-to-self/time-wait.py
+++ b/notes-to-self/time-wait.py
@@ -29,16 +29,16 @@
 import errno
 import socket
 
-import attr
+import attrs
 
 
-@attr.define(repr=False, slots=False)
+@attrs.define(repr=False, slots=False)
 class Options:
-    listen1_early = attr.field(default=None)
-    listen1_middle = attr.field(default=None)
-    listen1_late = attr.field(default=None)
-    server = attr.field(default=None)
-    listen2 = attr.field(default=None)
+    listen1_early = attrs.field(default=None)
+    listen1_middle = attrs.field(default=None)
+    listen1_late = attrs.field(default=None)
+    server = attrs.field(default=None)
+    listen2 = attrs.field(default=None)
 
     def set(self, which, sock):
         value = getattr(self, which)
@@ -47,7 +47,7 @@ class Options:
 
     def describe(self):
         info = []
-        for f in attr.fields(self.__class__):
+        for f in attrs.fields(self.__class__):
             value = getattr(self, f.name)
             if value is not None:
                 info.append(f"{f.name}={value}")

--- a/notes-to-self/time-wait.py
+++ b/notes-to-self/time-wait.py
@@ -34,11 +34,11 @@ import attr
 
 @attr.s(repr=False)
 class Options:
-    listen1_early = attr.ib(default=None)
-    listen1_middle = attr.ib(default=None)
-    listen1_late = attr.ib(default=None)
-    server = attr.ib(default=None)
-    listen2 = attr.ib(default=None)
+    listen1_early = attr.field(default=None)
+    listen1_middle = attr.field(default=None)
+    listen1_late = attr.field(default=None)
+    server = attr.field(default=None)
+    listen2 = attr.field(default=None)
 
     def set(self, which, sock):
         value = getattr(self, which)

--- a/notes-to-self/time-wait.py
+++ b/notes-to-self/time-wait.py
@@ -32,7 +32,7 @@ import socket
 import attr
 
 
-@attr.s(repr=False)
+@attr.define(repr=False, slots=False)
 class Options:
     listen1_early = attr.field(default=None)
     listen1_middle = attr.field(default=None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ requires-python = ">=3.8"
 dependencies = [
     # attrs 19.2.0 adds `eq` option to decorators
     # attrs 20.1.0 adds @frozen
-    "attrs >= 20.1.0",
+    "attrs >= 21.2.0",
     "sortedcontainers",
     "idna",
     "outcome",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,9 @@ requires-python = ">=3.8"
 dependencies = [
     # attrs 19.2.0 adds `eq` option to decorators
     # attrs 20.1.0 adds @frozen
-    "attrs >= 21.2.0",
+    # attrs 21.1.0 adds a dataclass transform for type-checkers
+    # attrs 21.3.0 adds `import addrs`
+    "attrs >= 23.2.0",
     "sortedcontainers",
     "idna",
     "outcome",

--- a/src/trio/_channel.py
+++ b/src/trio/_channel.py
@@ -122,14 +122,14 @@ class MemoryChannelStats:
 @attrs.define
 class MemoryChannelState(Generic[T]):
     max_buffer_size: int | float
-    data: deque[T] = attrs.field(factory=deque)
+    data: deque[T] = attrs.Factory(deque)
     # Counts of open endpoints using this state
     open_send_channels: int = attrs.field(default=0)
     open_receive_channels: int = attrs.field(default=0)
     # {task: value}
-    send_tasks: OrderedDict[Task, T] = attrs.field(factory=OrderedDict)
+    send_tasks: OrderedDict[Task, T] = attrs.Factory(OrderedDict)
     # {task: None}
-    receive_tasks: OrderedDict[Task, None] = attrs.field(factory=OrderedDict)
+    receive_tasks: OrderedDict[Task, None] = attrs.Factory(OrderedDict)
 
     def statistics(self) -> MemoryChannelStats:
         return MemoryChannelStats(
@@ -150,7 +150,7 @@ class MemorySendChannel(SendChannel[SendType], metaclass=NoPublicConstructor):
     # This is just the tasks waiting on *this* object. As compared to
     # self._state.send_tasks, which includes tasks from this object and
     # all clones.
-    _tasks: set[Task] = attrs.field(factory=set)
+    _tasks: set[Task] = attrs.Factory(set)
 
     def __attrs_post_init__(self) -> None:
         self._state.open_send_channels += 1
@@ -290,7 +290,7 @@ class MemorySendChannel(SendChannel[SendType], metaclass=NoPublicConstructor):
 class MemoryReceiveChannel(ReceiveChannel[ReceiveType], metaclass=NoPublicConstructor):
     _state: MemoryChannelState[ReceiveType]
     _closed: bool = attrs.field(default=False)
-    _tasks: set[trio._core._run.Task] = attrs.field(factory=set)
+    _tasks: set[trio._core._run.Task] = attrs.Factory(set)
 
     def __attrs_post_init__(self) -> None:
         self._state.open_receive_channels += 1

--- a/src/trio/_channel.py
+++ b/src/trio/_channel.py
@@ -111,25 +111,25 @@ else:
 
 @attr.s(frozen=True, slots=True)
 class MemoryChannelStats:
-    current_buffer_used: int = attr.ib()
-    max_buffer_size: int | float = attr.ib()
-    open_send_channels: int = attr.ib()
-    open_receive_channels: int = attr.ib()
-    tasks_waiting_send: int = attr.ib()
-    tasks_waiting_receive: int = attr.ib()
+    current_buffer_used: int = attr.field()
+    max_buffer_size: int | float = attr.field()
+    open_send_channels: int = attr.field()
+    open_receive_channels: int = attr.field()
+    tasks_waiting_send: int = attr.field()
+    tasks_waiting_receive: int = attr.field()
 
 
 @attr.s(slots=True)
 class MemoryChannelState(Generic[T]):
-    max_buffer_size: int | float = attr.ib()
-    data: deque[T] = attr.ib(factory=deque)
+    max_buffer_size: int | float = attr.field()
+    data: deque[T] = attr.field(factory=deque)
     # Counts of open endpoints using this state
-    open_send_channels: int = attr.ib(default=0)
-    open_receive_channels: int = attr.ib(default=0)
+    open_send_channels: int = attr.field(default=0)
+    open_receive_channels: int = attr.field(default=0)
     # {task: value}
-    send_tasks: OrderedDict[Task, T] = attr.ib(factory=OrderedDict)
+    send_tasks: OrderedDict[Task, T] = attr.field(factory=OrderedDict)
     # {task: None}
-    receive_tasks: OrderedDict[Task, None] = attr.ib(factory=OrderedDict)
+    receive_tasks: OrderedDict[Task, None] = attr.field(factory=OrderedDict)
 
     def statistics(self) -> MemoryChannelStats:
         return MemoryChannelStats(
@@ -145,12 +145,12 @@ class MemoryChannelState(Generic[T]):
 @final
 @attr.s(eq=False, repr=False)
 class MemorySendChannel(SendChannel[SendType], metaclass=NoPublicConstructor):
-    _state: MemoryChannelState[SendType] = attr.ib()
-    _closed: bool = attr.ib(default=False)
+    _state: MemoryChannelState[SendType] = attr.field()
+    _closed: bool = attr.field(default=False)
     # This is just the tasks waiting on *this* object. As compared to
     # self._state.send_tasks, which includes tasks from this object and
     # all clones.
-    _tasks: set[Task] = attr.ib(factory=set)
+    _tasks: set[Task] = attr.field(factory=set)
 
     def __attrs_post_init__(self) -> None:
         self._state.open_send_channels += 1
@@ -288,9 +288,9 @@ class MemorySendChannel(SendChannel[SendType], metaclass=NoPublicConstructor):
 @final
 @attr.s(eq=False, repr=False)
 class MemoryReceiveChannel(ReceiveChannel[ReceiveType], metaclass=NoPublicConstructor):
-    _state: MemoryChannelState[ReceiveType] = attr.ib()
-    _closed: bool = attr.ib(default=False)
-    _tasks: set[trio._core._run.Task] = attr.ib(factory=set)
+    _state: MemoryChannelState[ReceiveType] = attr.field()
+    _closed: bool = attr.field(default=False)
+    _tasks: set[trio._core._run.Task] = attr.field(factory=set)
 
     def __attrs_post_init__(self) -> None:
         self._state.open_receive_channels += 1

--- a/src/trio/_channel.py
+++ b/src/trio/_channel.py
@@ -111,17 +111,17 @@ else:
 
 @attrs.frozen
 class MemoryChannelStats:
-    current_buffer_used: int = attrs.field()
-    max_buffer_size: int | float = attrs.field()
-    open_send_channels: int = attrs.field()
-    open_receive_channels: int = attrs.field()
-    tasks_waiting_send: int = attrs.field()
-    tasks_waiting_receive: int = attrs.field()
+    current_buffer_used: int
+    max_buffer_size: int | float
+    open_send_channels: int
+    open_receive_channels: int
+    tasks_waiting_send: int
+    tasks_waiting_receive: int
 
 
 @attrs.define
 class MemoryChannelState(Generic[T]):
-    max_buffer_size: int | float = attrs.field()
+    max_buffer_size: int | float
     data: deque[T] = attrs.field(factory=deque)
     # Counts of open endpoints using this state
     open_send_channels: int = attrs.field(default=0)
@@ -145,7 +145,7 @@ class MemoryChannelState(Generic[T]):
 @final
 @attrs.define(eq=False, repr=False, slots=False)
 class MemorySendChannel(SendChannel[SendType], metaclass=NoPublicConstructor):
-    _state: MemoryChannelState[SendType] = attrs.field()
+    _state: MemoryChannelState[SendType]
     _closed: bool = attrs.field(default=False)
     # This is just the tasks waiting on *this* object. As compared to
     # self._state.send_tasks, which includes tasks from this object and
@@ -288,7 +288,7 @@ class MemorySendChannel(SendChannel[SendType], metaclass=NoPublicConstructor):
 @final
 @attrs.define(eq=False, repr=False, slots=False)
 class MemoryReceiveChannel(ReceiveChannel[ReceiveType], metaclass=NoPublicConstructor):
-    _state: MemoryChannelState[ReceiveType] = attrs.field()
+    _state: MemoryChannelState[ReceiveType]
     _closed: bool = attrs.field(default=False)
     _tasks: set[trio._core._run.Task] = attrs.field(factory=set)
 

--- a/src/trio/_channel.py
+++ b/src/trio/_channel.py
@@ -124,8 +124,8 @@ class MemoryChannelState(Generic[T]):
     max_buffer_size: int | float
     data: deque[T] = attrs.Factory(deque)
     # Counts of open endpoints using this state
-    open_send_channels: int = attrs.field(default=0)
-    open_receive_channels: int = attrs.field(default=0)
+    open_send_channels: int = 0
+    open_receive_channels: int = 0
     # {task: value}
     send_tasks: OrderedDict[Task, T] = attrs.Factory(OrderedDict)
     # {task: None}
@@ -146,7 +146,7 @@ class MemoryChannelState(Generic[T]):
 @attrs.define(eq=False, repr=False, slots=False)
 class MemorySendChannel(SendChannel[SendType], metaclass=NoPublicConstructor):
     _state: MemoryChannelState[SendType]
-    _closed: bool = attrs.field(default=False)
+    _closed: bool = False
     # This is just the tasks waiting on *this* object. As compared to
     # self._state.send_tasks, which includes tasks from this object and
     # all clones.
@@ -289,7 +289,7 @@ class MemorySendChannel(SendChannel[SendType], metaclass=NoPublicConstructor):
 @attrs.define(eq=False, repr=False, slots=False)
 class MemoryReceiveChannel(ReceiveChannel[ReceiveType], metaclass=NoPublicConstructor):
     _state: MemoryChannelState[ReceiveType]
-    _closed: bool = attrs.field(default=False)
+    _closed: bool = False
     _tasks: set[trio._core._run.Task] = attrs.Factory(set)
 
     def __attrs_post_init__(self) -> None:

--- a/src/trio/_channel.py
+++ b/src/trio/_channel.py
@@ -119,7 +119,7 @@ class MemoryChannelStats:
     tasks_waiting_receive: int = attr.field()
 
 
-@attr.s(slots=True)
+@attr.define
 class MemoryChannelState(Generic[T]):
     max_buffer_size: int | float = attr.field()
     data: deque[T] = attr.field(factory=deque)
@@ -143,7 +143,7 @@ class MemoryChannelState(Generic[T]):
 
 
 @final
-@attr.s(eq=False, repr=False)
+@attr.define(eq=False, repr=False, slots=False)
 class MemorySendChannel(SendChannel[SendType], metaclass=NoPublicConstructor):
     _state: MemoryChannelState[SendType] = attr.field()
     _closed: bool = attr.field(default=False)
@@ -286,7 +286,7 @@ class MemorySendChannel(SendChannel[SendType], metaclass=NoPublicConstructor):
 
 
 @final
-@attr.s(eq=False, repr=False)
+@attr.define(eq=False, repr=False, slots=False)
 class MemoryReceiveChannel(ReceiveChannel[ReceiveType], metaclass=NoPublicConstructor):
     _state: MemoryChannelState[ReceiveType] = attr.field()
     _closed: bool = attr.field(default=False)

--- a/src/trio/_channel.py
+++ b/src/trio/_channel.py
@@ -8,7 +8,7 @@ from typing import (
     Tuple,  # only needed for typechecking on <3.9
 )
 
-import attr
+import attrs
 from outcome import Error, Value
 
 import trio
@@ -109,27 +109,27 @@ else:
     open_memory_channel = generic_function(_open_memory_channel)
 
 
-@attr.frozen
+@attrs.frozen
 class MemoryChannelStats:
-    current_buffer_used: int = attr.field()
-    max_buffer_size: int | float = attr.field()
-    open_send_channels: int = attr.field()
-    open_receive_channels: int = attr.field()
-    tasks_waiting_send: int = attr.field()
-    tasks_waiting_receive: int = attr.field()
+    current_buffer_used: int = attrs.field()
+    max_buffer_size: int | float = attrs.field()
+    open_send_channels: int = attrs.field()
+    open_receive_channels: int = attrs.field()
+    tasks_waiting_send: int = attrs.field()
+    tasks_waiting_receive: int = attrs.field()
 
 
-@attr.define
+@attrs.define
 class MemoryChannelState(Generic[T]):
-    max_buffer_size: int | float = attr.field()
-    data: deque[T] = attr.field(factory=deque)
+    max_buffer_size: int | float = attrs.field()
+    data: deque[T] = attrs.field(factory=deque)
     # Counts of open endpoints using this state
-    open_send_channels: int = attr.field(default=0)
-    open_receive_channels: int = attr.field(default=0)
+    open_send_channels: int = attrs.field(default=0)
+    open_receive_channels: int = attrs.field(default=0)
     # {task: value}
-    send_tasks: OrderedDict[Task, T] = attr.field(factory=OrderedDict)
+    send_tasks: OrderedDict[Task, T] = attrs.field(factory=OrderedDict)
     # {task: None}
-    receive_tasks: OrderedDict[Task, None] = attr.field(factory=OrderedDict)
+    receive_tasks: OrderedDict[Task, None] = attrs.field(factory=OrderedDict)
 
     def statistics(self) -> MemoryChannelStats:
         return MemoryChannelStats(
@@ -143,14 +143,14 @@ class MemoryChannelState(Generic[T]):
 
 
 @final
-@attr.define(eq=False, repr=False, slots=False)
+@attrs.define(eq=False, repr=False, slots=False)
 class MemorySendChannel(SendChannel[SendType], metaclass=NoPublicConstructor):
-    _state: MemoryChannelState[SendType] = attr.field()
-    _closed: bool = attr.field(default=False)
+    _state: MemoryChannelState[SendType] = attrs.field()
+    _closed: bool = attrs.field(default=False)
     # This is just the tasks waiting on *this* object. As compared to
     # self._state.send_tasks, which includes tasks from this object and
     # all clones.
-    _tasks: set[Task] = attr.field(factory=set)
+    _tasks: set[Task] = attrs.field(factory=set)
 
     def __attrs_post_init__(self) -> None:
         self._state.open_send_channels += 1
@@ -286,11 +286,11 @@ class MemorySendChannel(SendChannel[SendType], metaclass=NoPublicConstructor):
 
 
 @final
-@attr.define(eq=False, repr=False, slots=False)
+@attrs.define(eq=False, repr=False, slots=False)
 class MemoryReceiveChannel(ReceiveChannel[ReceiveType], metaclass=NoPublicConstructor):
-    _state: MemoryChannelState[ReceiveType] = attr.field()
-    _closed: bool = attr.field(default=False)
-    _tasks: set[trio._core._run.Task] = attr.field(factory=set)
+    _state: MemoryChannelState[ReceiveType] = attrs.field()
+    _closed: bool = attrs.field(default=False)
+    _tasks: set[trio._core._run.Task] = attrs.field(factory=set)
 
     def __attrs_post_init__(self) -> None:
         self._state.open_receive_channels += 1

--- a/src/trio/_channel.py
+++ b/src/trio/_channel.py
@@ -109,7 +109,7 @@ else:
     open_memory_channel = generic_function(_open_memory_channel)
 
 
-@attr.s(frozen=True, slots=True)
+@attr.frozen
 class MemoryChannelStats:
     current_buffer_used: int = attr.field()
     max_buffer_size: int | float = attr.field()

--- a/src/trio/_core/_asyncgens.py
+++ b/src/trio/_core/_asyncgens.py
@@ -6,7 +6,7 @@ import warnings
 import weakref
 from typing import TYPE_CHECKING, NoReturn
 
-import attr
+import attrs
 
 from .. import _core
 from .._util import name_asyncgen
@@ -26,7 +26,7 @@ else:
     _ASYNC_GEN_SET = set
 
 
-@attr.define(eq=False)
+@attrs.define(eq=False)
 class AsyncGenerators:
     # Async generators are added to this set when first iterated. Any
     # left after the main task exits will be closed before trio.run()
@@ -35,16 +35,16 @@ class AsyncGenerators:
     # asyncgens after the system nursery has been closed, it's a
     # regular set so we don't have to deal with GC firing at
     # unexpected times.
-    alive: _WEAK_ASYNC_GEN_SET | _ASYNC_GEN_SET = attr.field(
+    alive: _WEAK_ASYNC_GEN_SET | _ASYNC_GEN_SET = attrs.field(
         factory=_WEAK_ASYNC_GEN_SET
     )
 
     # This collects async generators that get garbage collected during
     # the one-tick window between the system nursery closing and the
     # init task starting end-of-run asyncgen finalization.
-    trailing_needs_finalize: _ASYNC_GEN_SET = attr.field(factory=_ASYNC_GEN_SET)
+    trailing_needs_finalize: _ASYNC_GEN_SET = attrs.field(factory=_ASYNC_GEN_SET)
 
-    prev_hooks: sys._asyncgen_hooks = attr.field(init=False)
+    prev_hooks: sys._asyncgen_hooks = attrs.field(init=False)
 
     def install_hooks(self, runner: _run.Runner) -> None:
         def firstiter(agen: AsyncGeneratorType[object, NoReturn]) -> None:

--- a/src/trio/_core/_asyncgens.py
+++ b/src/trio/_core/_asyncgens.py
@@ -35,14 +35,12 @@ class AsyncGenerators:
     # asyncgens after the system nursery has been closed, it's a
     # regular set so we don't have to deal with GC firing at
     # unexpected times.
-    alive: _WEAK_ASYNC_GEN_SET | _ASYNC_GEN_SET = attrs.field(
-        factory=_WEAK_ASYNC_GEN_SET
-    )
+    alive: _WEAK_ASYNC_GEN_SET | _ASYNC_GEN_SET = attrs.Factory(_WEAK_ASYNC_GEN_SET)
 
     # This collects async generators that get garbage collected during
     # the one-tick window between the system nursery closing and the
     # init task starting end-of-run asyncgen finalization.
-    trailing_needs_finalize: _ASYNC_GEN_SET = attrs.field(factory=_ASYNC_GEN_SET)
+    trailing_needs_finalize: _ASYNC_GEN_SET = attrs.Factory(_ASYNC_GEN_SET)
 
     prev_hooks: sys._asyncgen_hooks = attrs.field(init=False)
 

--- a/src/trio/_core/_asyncgens.py
+++ b/src/trio/_core/_asyncgens.py
@@ -35,14 +35,16 @@ class AsyncGenerators:
     # asyncgens after the system nursery has been closed, it's a
     # regular set so we don't have to deal with GC firing at
     # unexpected times.
-    alive: _WEAK_ASYNC_GEN_SET | _ASYNC_GEN_SET = attr.ib(factory=_WEAK_ASYNC_GEN_SET)
+    alive: _WEAK_ASYNC_GEN_SET | _ASYNC_GEN_SET = attr.field(
+        factory=_WEAK_ASYNC_GEN_SET
+    )
 
     # This collects async generators that get garbage collected during
     # the one-tick window between the system nursery closing and the
     # init task starting end-of-run asyncgen finalization.
-    trailing_needs_finalize: _ASYNC_GEN_SET = attr.ib(factory=_ASYNC_GEN_SET)
+    trailing_needs_finalize: _ASYNC_GEN_SET = attr.field(factory=_ASYNC_GEN_SET)
 
-    prev_hooks: sys._asyncgen_hooks = attr.ib(init=False)
+    prev_hooks: sys._asyncgen_hooks = attr.field(init=False)
 
     def install_hooks(self, runner: _run.Runner) -> None:
         def firstiter(agen: AsyncGeneratorType[object, NoReturn]) -> None:

--- a/src/trio/_core/_asyncgens.py
+++ b/src/trio/_core/_asyncgens.py
@@ -26,7 +26,7 @@ else:
     _ASYNC_GEN_SET = set
 
 
-@attr.s(eq=False, slots=True)
+@attr.define(eq=False)
 class AsyncGenerators:
     # Async generators are added to this set when first iterated. Any
     # left after the main task exits will be closed before trio.run()

--- a/src/trio/_core/_entry_queue.py
+++ b/src/trio/_core/_entry_queue.py
@@ -32,7 +32,7 @@ class EntryQueue:
     idempotent_queue: dict[Job, None] = attrs.Factory(dict)
 
     wakeup: WakeupSocketpair = attrs.Factory(WakeupSocketpair)
-    done: bool = attrs.field(default=False)
+    done: bool = False
     # Must be a reentrant lock, because it's acquired from signal handlers.
     # RLock is signal-safe as of cpython 3.2. NB that this does mean that the
     # lock is effectively *disabled* when we enter from signal context. The

--- a/src/trio/_core/_entry_queue.py
+++ b/src/trio/_core/_entry_queue.py
@@ -28,11 +28,11 @@ class EntryQueue:
     # atomic WRT signal delivery (signal handlers can run on either side, but
     # not *during* a deque operation). dict makes similar guarantees - and
     # it's even ordered!
-    queue: deque[Job] = attr.ib(factory=deque)
-    idempotent_queue: dict[Job, None] = attr.ib(factory=dict)
+    queue: deque[Job] = attr.field(factory=deque)
+    idempotent_queue: dict[Job, None] = attr.field(factory=dict)
 
-    wakeup: WakeupSocketpair = attr.ib(factory=WakeupSocketpair)
-    done: bool = attr.ib(default=False)
+    wakeup: WakeupSocketpair = attr.field(factory=WakeupSocketpair)
+    done: bool = attr.field(default=False)
     # Must be a reentrant lock, because it's acquired from signal handlers.
     # RLock is signal-safe as of cpython 3.2. NB that this does mean that the
     # lock is effectively *disabled* when we enter from signal context. The
@@ -41,7 +41,7 @@ class EntryQueue:
     # main thread -- it just might happen at some inconvenient place. But if
     # you look at the one place where the main thread holds the lock, it's
     # just to make 1 assignment, so that's atomic WRT a signal anyway.
-    lock: threading.RLock = attr.ib(factory=threading.RLock)
+    lock: threading.RLock = attr.field(factory=threading.RLock)
 
     async def task(self) -> None:
         assert _core.currently_ki_protected()
@@ -166,7 +166,7 @@ class TrioToken(metaclass=NoPublicConstructor):
 
     """
 
-    _reentry_queue: EntryQueue = attr.ib()
+    _reentry_queue: EntryQueue = attr.field()
 
     def run_sync_soon(
         self,

--- a/src/trio/_core/_entry_queue.py
+++ b/src/trio/_core/_entry_queue.py
@@ -4,7 +4,7 @@ import threading
 from collections import deque
 from typing import TYPE_CHECKING, Callable, NoReturn, Tuple
 
-import attr
+import attrs
 
 from .. import _core
 from .._util import NoPublicConstructor, final
@@ -19,7 +19,7 @@ Function = Callable[..., object]
 Job = Tuple[Function, Tuple[object, ...]]
 
 
-@attr.define
+@attrs.define
 class EntryQueue:
     # This used to use a queue.Queue. but that was broken, because Queues are
     # implemented in Python, and not reentrant -- so it was thread-safe, but
@@ -28,11 +28,11 @@ class EntryQueue:
     # atomic WRT signal delivery (signal handlers can run on either side, but
     # not *during* a deque operation). dict makes similar guarantees - and
     # it's even ordered!
-    queue: deque[Job] = attr.field(factory=deque)
-    idempotent_queue: dict[Job, None] = attr.field(factory=dict)
+    queue: deque[Job] = attrs.field(factory=deque)
+    idempotent_queue: dict[Job, None] = attrs.field(factory=dict)
 
-    wakeup: WakeupSocketpair = attr.field(factory=WakeupSocketpair)
-    done: bool = attr.field(default=False)
+    wakeup: WakeupSocketpair = attrs.field(factory=WakeupSocketpair)
+    done: bool = attrs.field(default=False)
     # Must be a reentrant lock, because it's acquired from signal handlers.
     # RLock is signal-safe as of cpython 3.2. NB that this does mean that the
     # lock is effectively *disabled* when we enter from signal context. The
@@ -41,7 +41,7 @@ class EntryQueue:
     # main thread -- it just might happen at some inconvenient place. But if
     # you look at the one place where the main thread holds the lock, it's
     # just to make 1 assignment, so that's atomic WRT a signal anyway.
-    lock: threading.RLock = attr.field(factory=threading.RLock)
+    lock: threading.RLock = attrs.field(factory=threading.RLock)
 
     async def task(self) -> None:
         assert _core.currently_ki_protected()
@@ -146,7 +146,7 @@ class EntryQueue:
 
 
 @final
-@attr.define(eq=False, hash=False)
+@attrs.define(eq=False, hash=False)
 class TrioToken(metaclass=NoPublicConstructor):
     """An opaque object representing a single call to :func:`trio.run`.
 
@@ -166,7 +166,7 @@ class TrioToken(metaclass=NoPublicConstructor):
 
     """
 
-    _reentry_queue: EntryQueue = attr.field()
+    _reentry_queue: EntryQueue = attrs.field()
 
     def run_sync_soon(
         self,

--- a/src/trio/_core/_entry_queue.py
+++ b/src/trio/_core/_entry_queue.py
@@ -19,7 +19,7 @@ Function = Callable[..., object]
 Job = Tuple[Function, Tuple[object, ...]]
 
 
-@attr.s(slots=True)
+@attr.define
 class EntryQueue:
     # This used to use a queue.Queue. but that was broken, because Queues are
     # implemented in Python, and not reentrant -- so it was thread-safe, but
@@ -146,7 +146,7 @@ class EntryQueue:
 
 
 @final
-@attr.s(eq=False, hash=False, slots=True)
+@attr.define(eq=False, hash=False)
 class TrioToken(metaclass=NoPublicConstructor):
     """An opaque object representing a single call to :func:`trio.run`.
 

--- a/src/trio/_core/_entry_queue.py
+++ b/src/trio/_core/_entry_queue.py
@@ -166,7 +166,7 @@ class TrioToken(metaclass=NoPublicConstructor):
 
     """
 
-    _reentry_queue: EntryQueue = attrs.field()
+    _reentry_queue: EntryQueue
 
     def run_sync_soon(
         self,

--- a/src/trio/_core/_entry_queue.py
+++ b/src/trio/_core/_entry_queue.py
@@ -28,10 +28,10 @@ class EntryQueue:
     # atomic WRT signal delivery (signal handlers can run on either side, but
     # not *during* a deque operation). dict makes similar guarantees - and
     # it's even ordered!
-    queue: deque[Job] = attrs.field(factory=deque)
-    idempotent_queue: dict[Job, None] = attrs.field(factory=dict)
+    queue: deque[Job] = attrs.Factory(deque)
+    idempotent_queue: dict[Job, None] = attrs.Factory(dict)
 
-    wakeup: WakeupSocketpair = attrs.field(factory=WakeupSocketpair)
+    wakeup: WakeupSocketpair = attrs.Factory(WakeupSocketpair)
     done: bool = attrs.field(default=False)
     # Must be a reentrant lock, because it's acquired from signal handlers.
     # RLock is signal-safe as of cpython 3.2. NB that this does mean that the
@@ -41,7 +41,7 @@ class EntryQueue:
     # main thread -- it just might happen at some inconvenient place. But if
     # you look at the one place where the main thread holds the lock, it's
     # just to make 1 assignment, so that's atomic WRT a signal anyway.
-    lock: threading.RLock = attrs.field(factory=threading.RLock)
+    lock: threading.RLock = attrs.Factory(threading.RLock)
 
     async def task(self) -> None:
         assert _core.currently_ki_protected()

--- a/src/trio/_core/_io_epoll.py
+++ b/src/trio/_core/_io_epoll.py
@@ -35,8 +35,8 @@ EventResult: TypeAlias = "list[tuple[int, int]]"
 
 @attrs.frozen(eq=False)
 class _EpollStatistics:
-    tasks_waiting_read: int = attrs.field()
-    tasks_waiting_write: int = attrs.field()
+    tasks_waiting_read: int
+    tasks_waiting_write: int
     backend: Literal["epoll"] = attrs.field(init=False, default="epoll")
 
 

--- a/src/trio/_core/_io_epoll.py
+++ b/src/trio/_core/_io_epoll.py
@@ -33,7 +33,7 @@ assert not TYPE_CHECKING or sys.platform == "linux"
 EventResult: TypeAlias = "list[tuple[int, int]]"
 
 
-@attr.s(slots=True, eq=False, frozen=True)
+@attr.frozen(eq=False)
 class _EpollStatistics:
     tasks_waiting_read: int = attr.field()
     tasks_waiting_write: int = attr.field()

--- a/src/trio/_core/_io_epoll.py
+++ b/src/trio/_core/_io_epoll.py
@@ -22,9 +22,9 @@ if TYPE_CHECKING:
 
 @attr.s(slots=True, eq=False)
 class EpollWaiters:
-    read_task: Task | None = attr.ib(default=None)
-    write_task: Task | None = attr.ib(default=None)
-    current_flags: int = attr.ib(default=0)
+    read_task: Task | None = attr.field(default=None)
+    write_task: Task | None = attr.field(default=None)
+    current_flags: int = attr.field(default=0)
 
 
 assert not TYPE_CHECKING or sys.platform == "linux"
@@ -35,9 +35,9 @@ EventResult: TypeAlias = "list[tuple[int, int]]"
 
 @attr.s(slots=True, eq=False, frozen=True)
 class _EpollStatistics:
-    tasks_waiting_read: int = attr.ib()
-    tasks_waiting_write: int = attr.ib()
-    backend: Literal["epoll"] = attr.ib(init=False, default="epoll")
+    tasks_waiting_read: int = attr.field()
+    tasks_waiting_write: int = attr.field()
+    backend: Literal["epoll"] = attr.field(init=False, default="epoll")
 
 
 # Some facts about epoll
@@ -200,13 +200,13 @@ class _EpollStatistics:
 
 @attr.s(slots=True, eq=False, hash=False)
 class EpollIOManager:
-    _epoll: select.epoll = attr.ib(factory=select.epoll)
+    _epoll: select.epoll = attr.field(factory=select.epoll)
     # {fd: EpollWaiters}
-    _registered: defaultdict[int, EpollWaiters] = attr.ib(
+    _registered: defaultdict[int, EpollWaiters] = attr.field(
         factory=lambda: defaultdict(EpollWaiters)
     )
-    _force_wakeup: WakeupSocketpair = attr.ib(factory=WakeupSocketpair)
-    _force_wakeup_fd: int | None = attr.ib(default=None)
+    _force_wakeup: WakeupSocketpair = attr.field(factory=WakeupSocketpair)
+    _force_wakeup_fd: int | None = attr.field(default=None)
 
     def __attrs_post_init__(self) -> None:
         self._epoll.register(self._force_wakeup.wakeup_sock, select.EPOLLIN)

--- a/src/trio/_core/_io_epoll.py
+++ b/src/trio/_core/_io_epoll.py
@@ -200,12 +200,12 @@ class _EpollStatistics:
 
 @attrs.define(eq=False, hash=False)
 class EpollIOManager:
-    _epoll: select.epoll = attrs.field(factory=select.epoll)
+    _epoll: select.epoll = attrs.Factory(select.epoll)
     # {fd: EpollWaiters}
-    _registered: defaultdict[int, EpollWaiters] = attrs.field(
-        factory=lambda: defaultdict(EpollWaiters)
+    _registered: defaultdict[int, EpollWaiters] = attrs.Factory(
+        lambda: defaultdict(EpollWaiters)
     )
-    _force_wakeup: WakeupSocketpair = attrs.field(factory=WakeupSocketpair)
+    _force_wakeup: WakeupSocketpair = attrs.Factory(WakeupSocketpair)
     _force_wakeup_fd: int | None = attrs.field(default=None)
 
     def __attrs_post_init__(self) -> None:

--- a/src/trio/_core/_io_epoll.py
+++ b/src/trio/_core/_io_epoll.py
@@ -22,9 +22,9 @@ if TYPE_CHECKING:
 
 @attrs.define(eq=False)
 class EpollWaiters:
-    read_task: Task | None = attrs.field(default=None)
-    write_task: Task | None = attrs.field(default=None)
-    current_flags: int = attrs.field(default=0)
+    read_task: Task | None = None
+    write_task: Task | None = None
+    current_flags: int = 0
 
 
 assert not TYPE_CHECKING or sys.platform == "linux"
@@ -206,7 +206,7 @@ class EpollIOManager:
         lambda: defaultdict(EpollWaiters)
     )
     _force_wakeup: WakeupSocketpair = attrs.Factory(WakeupSocketpair)
-    _force_wakeup_fd: int | None = attrs.field(default=None)
+    _force_wakeup_fd: int | None = None
 
     def __attrs_post_init__(self) -> None:
         self._epoll.register(self._force_wakeup.wakeup_sock, select.EPOLLIN)

--- a/src/trio/_core/_io_epoll.py
+++ b/src/trio/_core/_io_epoll.py
@@ -6,7 +6,7 @@ import sys
 from collections import defaultdict
 from typing import TYPE_CHECKING, Literal
 
-import attr
+import attrs
 
 from .. import _core
 from ._io_common import wake_all
@@ -20,11 +20,11 @@ if TYPE_CHECKING:
     from .._file_io import _HasFileNo
 
 
-@attr.define(eq=False)
+@attrs.define(eq=False)
 class EpollWaiters:
-    read_task: Task | None = attr.field(default=None)
-    write_task: Task | None = attr.field(default=None)
-    current_flags: int = attr.field(default=0)
+    read_task: Task | None = attrs.field(default=None)
+    write_task: Task | None = attrs.field(default=None)
+    current_flags: int = attrs.field(default=0)
 
 
 assert not TYPE_CHECKING or sys.platform == "linux"
@@ -33,11 +33,11 @@ assert not TYPE_CHECKING or sys.platform == "linux"
 EventResult: TypeAlias = "list[tuple[int, int]]"
 
 
-@attr.frozen(eq=False)
+@attrs.frozen(eq=False)
 class _EpollStatistics:
-    tasks_waiting_read: int = attr.field()
-    tasks_waiting_write: int = attr.field()
-    backend: Literal["epoll"] = attr.field(init=False, default="epoll")
+    tasks_waiting_read: int = attrs.field()
+    tasks_waiting_write: int = attrs.field()
+    backend: Literal["epoll"] = attrs.field(init=False, default="epoll")
 
 
 # Some facts about epoll
@@ -198,15 +198,15 @@ class _EpollStatistics:
 # wanted to about how epoll works.
 
 
-@attr.define(eq=False, hash=False)
+@attrs.define(eq=False, hash=False)
 class EpollIOManager:
-    _epoll: select.epoll = attr.field(factory=select.epoll)
+    _epoll: select.epoll = attrs.field(factory=select.epoll)
     # {fd: EpollWaiters}
-    _registered: defaultdict[int, EpollWaiters] = attr.field(
+    _registered: defaultdict[int, EpollWaiters] = attrs.field(
         factory=lambda: defaultdict(EpollWaiters)
     )
-    _force_wakeup: WakeupSocketpair = attr.field(factory=WakeupSocketpair)
-    _force_wakeup_fd: int | None = attr.field(default=None)
+    _force_wakeup: WakeupSocketpair = attrs.field(factory=WakeupSocketpair)
+    _force_wakeup_fd: int | None = attrs.field(default=None)
 
     def __attrs_post_init__(self) -> None:
         self._epoll.register(self._force_wakeup.wakeup_sock, select.EPOLLIN)

--- a/src/trio/_core/_io_epoll.py
+++ b/src/trio/_core/_io_epoll.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from .._file_io import _HasFileNo
 
 
-@attr.s(slots=True, eq=False)
+@attr.define(eq=False)
 class EpollWaiters:
     read_task: Task | None = attr.field(default=None)
     write_task: Task | None = attr.field(default=None)
@@ -198,7 +198,7 @@ class _EpollStatistics:
 # wanted to about how epoll works.
 
 
-@attr.s(slots=True, eq=False, hash=False)
+@attr.define(eq=False, hash=False)
 class EpollIOManager:
     _epoll: select.epoll = attr.field(factory=select.epoll)
     # {fd: EpollWaiters}

--- a/src/trio/_core/_io_kqueue.py
+++ b/src/trio/_core/_io_kqueue.py
@@ -39,7 +39,7 @@ class KqueueIOManager:
         attrs.Factory(dict)
     )
     _force_wakeup: WakeupSocketpair = attrs.Factory(WakeupSocketpair)
-    _force_wakeup_fd: int | None = attrs.field(default=None)
+    _force_wakeup_fd: int | None = None
 
     def __attrs_post_init__(self) -> None:
         force_wakeup_event = select.kevent(

--- a/src/trio/_core/_io_kqueue.py
+++ b/src/trio/_core/_io_kqueue.py
@@ -24,7 +24,7 @@ assert not TYPE_CHECKING or (sys.platform != "linux" and sys.platform != "win32"
 EventResult: TypeAlias = "list[select.kevent]"
 
 
-@attr.s(slots=True, eq=False, frozen=True)
+@attr.frozen(eq=False)
 class _KqueueStatistics:
     tasks_waiting: int = attr.field()
     monitors: int = attr.field()

--- a/src/trio/_core/_io_kqueue.py
+++ b/src/trio/_core/_io_kqueue.py
@@ -6,7 +6,7 @@ import sys
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Callable, Iterator, Literal
 
-import attr
+import attrs
 import outcome
 
 from .. import _core
@@ -24,22 +24,22 @@ assert not TYPE_CHECKING or (sys.platform != "linux" and sys.platform != "win32"
 EventResult: TypeAlias = "list[select.kevent]"
 
 
-@attr.frozen(eq=False)
+@attrs.frozen(eq=False)
 class _KqueueStatistics:
-    tasks_waiting: int = attr.field()
-    monitors: int = attr.field()
-    backend: Literal["kqueue"] = attr.field(init=False, default="kqueue")
+    tasks_waiting: int = attrs.field()
+    monitors: int = attrs.field()
+    backend: Literal["kqueue"] = attrs.field(init=False, default="kqueue")
 
 
-@attr.define(eq=False)
+@attrs.define(eq=False)
 class KqueueIOManager:
-    _kqueue: select.kqueue = attr.field(factory=select.kqueue)
+    _kqueue: select.kqueue = attrs.field(factory=select.kqueue)
     # {(ident, filter): Task or UnboundedQueue}
     _registered: dict[tuple[int, int], Task | UnboundedQueue[select.kevent]] = (
-        attr.field(factory=dict)
+        attrs.field(factory=dict)
     )
-    _force_wakeup: WakeupSocketpair = attr.field(factory=WakeupSocketpair)
-    _force_wakeup_fd: int | None = attr.field(default=None)
+    _force_wakeup: WakeupSocketpair = attrs.field(factory=WakeupSocketpair)
+    _force_wakeup_fd: int | None = attrs.field(default=None)
 
     def __attrs_post_init__(self) -> None:
         force_wakeup_event = select.kevent(

--- a/src/trio/_core/_io_kqueue.py
+++ b/src/trio/_core/_io_kqueue.py
@@ -33,12 +33,12 @@ class _KqueueStatistics:
 
 @attrs.define(eq=False)
 class KqueueIOManager:
-    _kqueue: select.kqueue = attrs.field(factory=select.kqueue)
+    _kqueue: select.kqueue = attrs.Factory(select.kqueue)
     # {(ident, filter): Task or UnboundedQueue}
     _registered: dict[tuple[int, int], Task | UnboundedQueue[select.kevent]] = (
-        attrs.field(factory=dict)
+        attrs.Factory(dict)
     )
-    _force_wakeup: WakeupSocketpair = attrs.field(factory=WakeupSocketpair)
+    _force_wakeup: WakeupSocketpair = attrs.Factory(WakeupSocketpair)
     _force_wakeup_fd: int | None = attrs.field(default=None)
 
     def __attrs_post_init__(self) -> None:

--- a/src/trio/_core/_io_kqueue.py
+++ b/src/trio/_core/_io_kqueue.py
@@ -26,20 +26,20 @@ EventResult: TypeAlias = "list[select.kevent]"
 
 @attr.s(slots=True, eq=False, frozen=True)
 class _KqueueStatistics:
-    tasks_waiting: int = attr.ib()
-    monitors: int = attr.ib()
-    backend: Literal["kqueue"] = attr.ib(init=False, default="kqueue")
+    tasks_waiting: int = attr.field()
+    monitors: int = attr.field()
+    backend: Literal["kqueue"] = attr.field(init=False, default="kqueue")
 
 
 @attr.s(slots=True, eq=False)
 class KqueueIOManager:
-    _kqueue: select.kqueue = attr.ib(factory=select.kqueue)
+    _kqueue: select.kqueue = attr.field(factory=select.kqueue)
     # {(ident, filter): Task or UnboundedQueue}
-    _registered: dict[tuple[int, int], Task | UnboundedQueue[select.kevent]] = attr.ib(
-        factory=dict
+    _registered: dict[tuple[int, int], Task | UnboundedQueue[select.kevent]] = (
+        attr.field(factory=dict)
     )
-    _force_wakeup: WakeupSocketpair = attr.ib(factory=WakeupSocketpair)
-    _force_wakeup_fd: int | None = attr.ib(default=None)
+    _force_wakeup: WakeupSocketpair = attr.field(factory=WakeupSocketpair)
+    _force_wakeup_fd: int | None = attr.field(default=None)
 
     def __attrs_post_init__(self) -> None:
         force_wakeup_event = select.kevent(

--- a/src/trio/_core/_io_kqueue.py
+++ b/src/trio/_core/_io_kqueue.py
@@ -31,7 +31,7 @@ class _KqueueStatistics:
     backend: Literal["kqueue"] = attr.field(init=False, default="kqueue")
 
 
-@attr.s(slots=True, eq=False)
+@attr.define(eq=False)
 class KqueueIOManager:
     _kqueue: select.kqueue = attr.field(factory=select.kqueue)
     # {(ident, filter): Task or UnboundedQueue}

--- a/src/trio/_core/_io_kqueue.py
+++ b/src/trio/_core/_io_kqueue.py
@@ -26,8 +26,8 @@ EventResult: TypeAlias = "list[select.kevent]"
 
 @attrs.frozen(eq=False)
 class _KqueueStatistics:
-    tasks_waiting: int = attrs.field()
-    monitors: int = attrs.field()
+    tasks_waiting: int
+    monitors: int
     backend: Literal["kqueue"] = attrs.field(init=False, default="kqueue")
 
 

--- a/src/trio/_core/_io_windows.py
+++ b/src/trio/_core/_io_windows.py
@@ -244,9 +244,9 @@ WRITABLE_FLAGS = (
 # operation and start a new one.
 @attr.s(slots=True, eq=False)
 class AFDWaiters:
-    read_task: _core.Task | None = attr.ib(default=None)
-    write_task: _core.Task | None = attr.ib(default=None)
-    current_op: AFDPollOp | None = attr.ib(default=None)
+    read_task: _core.Task | None = attr.field(default=None)
+    write_task: _core.Task | None = attr.field(default=None)
+    current_op: AFDPollOp | None = attr.field(default=None)
 
 
 # We also need to bundle up all the info for a single op into a standalone
@@ -254,10 +254,10 @@ class AFDWaiters:
 # finishes, even if we're throwing it away.
 @attr.s(slots=True, eq=False, frozen=True)
 class AFDPollOp:
-    lpOverlapped: CData = attr.ib()
-    poll_info: Any = attr.ib()
-    waiters: AFDWaiters = attr.ib()
-    afd_group: AFDGroup = attr.ib()
+    lpOverlapped: CData = attr.field()
+    poll_info: Any = attr.field()
+    waiters: AFDWaiters = attr.field()
+    afd_group: AFDGroup = attr.field()
 
 
 # The Windows kernel has a weird issue when using AFD handles. If you have N
@@ -273,8 +273,8 @@ MAX_AFD_GROUP_SIZE = 500  # at 1000, the cubic scaling is just starting to bite
 
 @attr.s(slots=True, eq=False)
 class AFDGroup:
-    size: int = attr.ib()
-    handle: Handle = attr.ib()
+    size: int = attr.field()
+    handle: Handle = attr.field()
 
 
 assert not TYPE_CHECKING or sys.platform == "win32"
@@ -282,11 +282,11 @@ assert not TYPE_CHECKING or sys.platform == "win32"
 
 @attr.s(slots=True, eq=False, frozen=True)
 class _WindowsStatistics:
-    tasks_waiting_read: int = attr.ib()
-    tasks_waiting_write: int = attr.ib()
-    tasks_waiting_overlapped: int = attr.ib()
-    completion_key_monitors: int = attr.ib()
-    backend: Literal["windows"] = attr.ib(init=False, default="windows")
+    tasks_waiting_read: int = attr.field()
+    tasks_waiting_write: int = attr.field()
+    tasks_waiting_overlapped: int = attr.field()
+    completion_key_monitors: int = attr.field()
+    backend: Literal["windows"] = attr.field(init=False, default="windows")
 
 
 # Maximum number of events to dequeue from the completion port on each pass
@@ -407,8 +407,8 @@ def _afd_helper_handle() -> Handle:
 
 @attr.s(frozen=True)
 class CompletionKeyEventInfo:
-    lpOverlapped: CData = attr.ib()
-    dwNumberOfBytesTransferred: int = attr.ib()
+    lpOverlapped: CData = attr.field()
+    dwNumberOfBytesTransferred: int = attr.field()
 
 
 class WindowsIOManager:

--- a/src/trio/_core/_io_windows.py
+++ b/src/trio/_core/_io_windows.py
@@ -242,7 +242,7 @@ WRITABLE_FLAGS = (
 # To avoid this, we have to coalesce all the operations on a single socket
 # into one, and when the set of waiters changes we have to throw away the old
 # operation and start a new one.
-@attr.s(slots=True, eq=False)
+@attr.define(eq=False)
 class AFDWaiters:
     read_task: _core.Task | None = attr.field(default=None)
     write_task: _core.Task | None = attr.field(default=None)
@@ -271,7 +271,7 @@ class AFDPollOp:
 MAX_AFD_GROUP_SIZE = 500  # at 1000, the cubic scaling is just starting to bite
 
 
-@attr.s(slots=True, eq=False)
+@attr.define(eq=False)
 class AFDGroup:
     size: int = attr.field()
     handle: Handle = attr.field()

--- a/src/trio/_core/_io_windows.py
+++ b/src/trio/_core/_io_windows.py
@@ -15,7 +15,7 @@ from typing import (
     cast,
 )
 
-import attr
+import attrs
 from outcome import Value
 
 from .. import _core
@@ -242,22 +242,22 @@ WRITABLE_FLAGS = (
 # To avoid this, we have to coalesce all the operations on a single socket
 # into one, and when the set of waiters changes we have to throw away the old
 # operation and start a new one.
-@attr.define(eq=False)
+@attrs.define(eq=False)
 class AFDWaiters:
-    read_task: _core.Task | None = attr.field(default=None)
-    write_task: _core.Task | None = attr.field(default=None)
-    current_op: AFDPollOp | None = attr.field(default=None)
+    read_task: _core.Task | None = attrs.field(default=None)
+    write_task: _core.Task | None = attrs.field(default=None)
+    current_op: AFDPollOp | None = attrs.field(default=None)
 
 
 # We also need to bundle up all the info for a single op into a standalone
 # object, because we need to keep all these objects alive until the operation
 # finishes, even if we're throwing it away.
-@attr.frozen(eq=False)
+@attrs.frozen(eq=False)
 class AFDPollOp:
-    lpOverlapped: CData = attr.field()
-    poll_info: Any = attr.field()
-    waiters: AFDWaiters = attr.field()
-    afd_group: AFDGroup = attr.field()
+    lpOverlapped: CData = attrs.field()
+    poll_info: Any = attrs.field()
+    waiters: AFDWaiters = attrs.field()
+    afd_group: AFDGroup = attrs.field()
 
 
 # The Windows kernel has a weird issue when using AFD handles. If you have N
@@ -271,22 +271,22 @@ class AFDPollOp:
 MAX_AFD_GROUP_SIZE = 500  # at 1000, the cubic scaling is just starting to bite
 
 
-@attr.define(eq=False)
+@attrs.define(eq=False)
 class AFDGroup:
-    size: int = attr.field()
-    handle: Handle = attr.field()
+    size: int = attrs.field()
+    handle: Handle = attrs.field()
 
 
 assert not TYPE_CHECKING or sys.platform == "win32"
 
 
-@attr.frozen(eq=False)
+@attrs.frozen(eq=False)
 class _WindowsStatistics:
-    tasks_waiting_read: int = attr.field()
-    tasks_waiting_write: int = attr.field()
-    tasks_waiting_overlapped: int = attr.field()
-    completion_key_monitors: int = attr.field()
-    backend: Literal["windows"] = attr.field(init=False, default="windows")
+    tasks_waiting_read: int = attrs.field()
+    tasks_waiting_write: int = attrs.field()
+    tasks_waiting_overlapped: int = attrs.field()
+    completion_key_monitors: int = attrs.field()
+    backend: Literal["windows"] = attrs.field(init=False, default="windows")
 
 
 # Maximum number of events to dequeue from the completion port on each pass
@@ -405,10 +405,10 @@ def _afd_helper_handle() -> Handle:
     return handle
 
 
-@attr.frozen(slots=False)
+@attrs.frozen(slots=False)
 class CompletionKeyEventInfo:
-    lpOverlapped: CData = attr.field()
-    dwNumberOfBytesTransferred: int = attr.field()
+    lpOverlapped: CData = attrs.field()
+    dwNumberOfBytesTransferred: int = attrs.field()
 
 
 class WindowsIOManager:

--- a/src/trio/_core/_io_windows.py
+++ b/src/trio/_core/_io_windows.py
@@ -244,9 +244,9 @@ WRITABLE_FLAGS = (
 # operation and start a new one.
 @attrs.define(eq=False)
 class AFDWaiters:
-    read_task: _core.Task | None = attrs.field(default=None)
-    write_task: _core.Task | None = attrs.field(default=None)
-    current_op: AFDPollOp | None = attrs.field(default=None)
+    read_task: _core.Task | None = None
+    write_task: _core.Task | None = None
+    current_op: AFDPollOp | None = None
 
 
 # We also need to bundle up all the info for a single op into a standalone

--- a/src/trio/_core/_io_windows.py
+++ b/src/trio/_core/_io_windows.py
@@ -252,7 +252,7 @@ class AFDWaiters:
 # We also need to bundle up all the info for a single op into a standalone
 # object, because we need to keep all these objects alive until the operation
 # finishes, even if we're throwing it away.
-@attr.s(slots=True, eq=False, frozen=True)
+@attr.frozen(eq=False)
 class AFDPollOp:
     lpOverlapped: CData = attr.field()
     poll_info: Any = attr.field()
@@ -280,7 +280,7 @@ class AFDGroup:
 assert not TYPE_CHECKING or sys.platform == "win32"
 
 
-@attr.s(slots=True, eq=False, frozen=True)
+@attr.frozen(eq=False)
 class _WindowsStatistics:
     tasks_waiting_read: int = attr.field()
     tasks_waiting_write: int = attr.field()
@@ -405,7 +405,7 @@ def _afd_helper_handle() -> Handle:
     return handle
 
 
-@attr.s(frozen=True)
+@attr.frozen(slots=False)
 class CompletionKeyEventInfo:
     lpOverlapped: CData = attr.field()
     dwNumberOfBytesTransferred: int = attr.field()

--- a/src/trio/_core/_io_windows.py
+++ b/src/trio/_core/_io_windows.py
@@ -254,10 +254,10 @@ class AFDWaiters:
 # finishes, even if we're throwing it away.
 @attrs.frozen(eq=False)
 class AFDPollOp:
-    lpOverlapped: CData = attrs.field()
-    poll_info: Any = attrs.field()
-    waiters: AFDWaiters = attrs.field()
-    afd_group: AFDGroup = attrs.field()
+    lpOverlapped: CData
+    poll_info: Any
+    waiters: AFDWaiters
+    afd_group: AFDGroup
 
 
 # The Windows kernel has a weird issue when using AFD handles. If you have N
@@ -273,8 +273,8 @@ MAX_AFD_GROUP_SIZE = 500  # at 1000, the cubic scaling is just starting to bite
 
 @attrs.define(eq=False)
 class AFDGroup:
-    size: int = attrs.field()
-    handle: Handle = attrs.field()
+    size: int
+    handle: Handle
 
 
 assert not TYPE_CHECKING or sys.platform == "win32"
@@ -282,10 +282,10 @@ assert not TYPE_CHECKING or sys.platform == "win32"
 
 @attrs.frozen(eq=False)
 class _WindowsStatistics:
-    tasks_waiting_read: int = attrs.field()
-    tasks_waiting_write: int = attrs.field()
-    tasks_waiting_overlapped: int = attrs.field()
-    completion_key_monitors: int = attrs.field()
+    tasks_waiting_read: int
+    tasks_waiting_write: int
+    tasks_waiting_overlapped: int
+    completion_key_monitors: int
     backend: Literal["windows"] = attrs.field(init=False, default="windows")
 
 
@@ -407,8 +407,8 @@ def _afd_helper_handle() -> Handle:
 
 @attrs.frozen(slots=False)
 class CompletionKeyEventInfo:
-    lpOverlapped: CData = attrs.field()
-    dwNumberOfBytesTransferred: int = attrs.field()
+    lpOverlapped: CData
+    dwNumberOfBytesTransferred: int
 
 
 class WindowsIOManager:

--- a/src/trio/_core/_ki.py
+++ b/src/trio/_core/_ki.py
@@ -201,7 +201,7 @@ disable_ki_protection: KIProtectionSignature = _ki_protection_decorator(False)  
 disable_ki_protection.__name__ = "disable_ki_protection"
 
 
-@attr.s
+@attr.define(slots=False)
 class KIManager:
     handler: Callable[[int, types.FrameType | None], None] | None = attr.field(
         default=None

--- a/src/trio/_core/_ki.py
+++ b/src/trio/_core/_ki.py
@@ -6,7 +6,7 @@ import sys
 from functools import wraps
 from typing import TYPE_CHECKING, Final, Protocol, TypeVar
 
-import attr
+import attrs
 
 from .._util import is_main_thread
 
@@ -201,9 +201,9 @@ disable_ki_protection: KIProtectionSignature = _ki_protection_decorator(False)  
 disable_ki_protection.__name__ = "disable_ki_protection"
 
 
-@attr.define(slots=False)
+@attrs.define(slots=False)
 class KIManager:
-    handler: Callable[[int, types.FrameType | None], None] | None = attr.field(
+    handler: Callable[[int, types.FrameType | None], None] | None = attrs.field(
         default=None
     )
 

--- a/src/trio/_core/_ki.py
+++ b/src/trio/_core/_ki.py
@@ -203,9 +203,7 @@ disable_ki_protection.__name__ = "disable_ki_protection"
 
 @attrs.define(slots=False)
 class KIManager:
-    handler: Callable[[int, types.FrameType | None], None] | None = attrs.field(
-        default=None
-    )
+    handler: Callable[[int, types.FrameType | None], None] | None = None
 
     def install(
         self,

--- a/src/trio/_core/_ki.py
+++ b/src/trio/_core/_ki.py
@@ -203,7 +203,7 @@ disable_ki_protection.__name__ = "disable_ki_protection"
 
 @attr.s
 class KIManager:
-    handler: Callable[[int, types.FrameType | None], None] | None = attr.ib(
+    handler: Callable[[int, types.FrameType | None], None] | None = attr.field(
         default=None
     )
 

--- a/src/trio/_core/_local.py
+++ b/src/trio/_core/_local.py
@@ -18,7 +18,7 @@ class _NoValue: ...
 @final
 @attrs.define(eq=False, hash=False)
 class RunVarToken(Generic[T], metaclass=NoPublicConstructor):
-    _var: RunVar[T] = attrs.field()
+    _var: RunVar[T]
     previous_value: T | type[_NoValue] = attrs.field(default=_NoValue)
     redeemed: bool = attrs.field(default=False, init=False)
 
@@ -38,7 +38,7 @@ class RunVar(Generic[T]):
 
     """
 
-    _name: str = attrs.field()
+    _name: str
     _default: T | type[_NoValue] = attrs.field(default=_NoValue)
 
     def get(self, default: T | type[_NoValue] = _NoValue) -> T:

--- a/src/trio/_core/_local.py
+++ b/src/trio/_core/_local.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Generic, TypeVar, cast
 
 # Runvar implementations
-import attr
+import attrs
 
 from .._util import NoPublicConstructor, final
 from . import _run
@@ -16,11 +16,11 @@ class _NoValue: ...
 
 
 @final
-@attr.define(eq=False, hash=False)
+@attrs.define(eq=False, hash=False)
 class RunVarToken(Generic[T], metaclass=NoPublicConstructor):
-    _var: RunVar[T] = attr.field()
-    previous_value: T | type[_NoValue] = attr.field(default=_NoValue)
-    redeemed: bool = attr.field(default=False, init=False)
+    _var: RunVar[T] = attrs.field()
+    previous_value: T | type[_NoValue] = attrs.field(default=_NoValue)
+    redeemed: bool = attrs.field(default=False, init=False)
 
     @classmethod
     def _empty(cls, var: RunVar[T]) -> RunVarToken[T]:
@@ -28,7 +28,7 @@ class RunVarToken(Generic[T], metaclass=NoPublicConstructor):
 
 
 @final
-@attr.define(eq=False, hash=False, repr=False)
+@attrs.define(eq=False, hash=False, repr=False)
 class RunVar(Generic[T]):
     """The run-local variant of a context variable.
 
@@ -38,8 +38,8 @@ class RunVar(Generic[T]):
 
     """
 
-    _name: str = attr.field()
-    _default: T | type[_NoValue] = attr.field(default=_NoValue)
+    _name: str = attrs.field()
+    _default: T | type[_NoValue] = attrs.field(default=_NoValue)
 
     def get(self, default: T | type[_NoValue] = _NoValue) -> T:
         """Gets the value of this :class:`RunVar` for the current run call."""

--- a/src/trio/_core/_local.py
+++ b/src/trio/_core/_local.py
@@ -19,7 +19,7 @@ class _NoValue: ...
 @attrs.define(eq=False, hash=False)
 class RunVarToken(Generic[T], metaclass=NoPublicConstructor):
     _var: RunVar[T]
-    previous_value: T | type[_NoValue] = attrs.field(default=_NoValue)
+    previous_value: T | type[_NoValue] = _NoValue
     redeemed: bool = attrs.field(default=False, init=False)
 
     @classmethod
@@ -39,7 +39,7 @@ class RunVar(Generic[T]):
     """
 
     _name: str
-    _default: T | type[_NoValue] = attrs.field(default=_NoValue)
+    _default: T | type[_NoValue] = _NoValue
 
     def get(self, default: T | type[_NoValue] = _NoValue) -> T:
         """Gets the value of this :class:`RunVar` for the current run call."""

--- a/src/trio/_core/_local.py
+++ b/src/trio/_core/_local.py
@@ -18,9 +18,9 @@ class _NoValue: ...
 @final
 @attr.s(eq=False, hash=False, slots=True)
 class RunVarToken(Generic[T], metaclass=NoPublicConstructor):
-    _var: RunVar[T] = attr.ib()
-    previous_value: T | type[_NoValue] = attr.ib(default=_NoValue)
-    redeemed: bool = attr.ib(default=False, init=False)
+    _var: RunVar[T] = attr.field()
+    previous_value: T | type[_NoValue] = attr.field(default=_NoValue)
+    redeemed: bool = attr.field(default=False, init=False)
 
     @classmethod
     def _empty(cls, var: RunVar[T]) -> RunVarToken[T]:
@@ -38,8 +38,8 @@ class RunVar(Generic[T]):
 
     """
 
-    _name: str = attr.ib()
-    _default: T | type[_NoValue] = attr.ib(default=_NoValue)
+    _name: str = attr.field()
+    _default: T | type[_NoValue] = attr.field(default=_NoValue)
 
     def get(self, default: T | type[_NoValue] = _NoValue) -> T:
         """Gets the value of this :class:`RunVar` for the current run call."""

--- a/src/trio/_core/_local.py
+++ b/src/trio/_core/_local.py
@@ -16,7 +16,7 @@ class _NoValue: ...
 
 
 @final
-@attr.s(eq=False, hash=False, slots=True)
+@attr.define(eq=False, hash=False)
 class RunVarToken(Generic[T], metaclass=NoPublicConstructor):
     _var: RunVar[T] = attr.field()
     previous_value: T | type[_NoValue] = attr.field(default=_NoValue)
@@ -28,7 +28,7 @@ class RunVarToken(Generic[T], metaclass=NoPublicConstructor):
 
 
 @final
-@attr.s(eq=False, hash=False, slots=True, repr=False)
+@attr.define(eq=False, hash=False, repr=False)
 class RunVar(Generic[T]):
     """The run-local variant of a context variable.
 

--- a/src/trio/_core/_parking_lot.py
+++ b/src/trio/_core/_parking_lot.py
@@ -101,7 +101,7 @@ class ParkingLotStatistics:
 
 
 @final
-@attr.s(eq=False, hash=False, slots=True)
+@attr.define(eq=False, hash=False)
 class ParkingLot:
     """A fair wait queue with cancellation and requeueing.
 

--- a/src/trio/_core/_parking_lot.py
+++ b/src/trio/_core/_parking_lot.py
@@ -97,7 +97,7 @@ class ParkingLotStatistics:
 
     """
 
-    tasks_waiting: int = attrs.field()
+    tasks_waiting: int
 
 
 @final

--- a/src/trio/_core/_parking_lot.py
+++ b/src/trio/_core/_parking_lot.py
@@ -75,7 +75,7 @@ import math
 from collections import OrderedDict
 from typing import TYPE_CHECKING
 
-import attr
+import attrs
 
 from .. import _core
 from .._util import final
@@ -86,7 +86,7 @@ if TYPE_CHECKING:
     from ._run import Task
 
 
-@attr.frozen
+@attrs.frozen
 class ParkingLotStatistics:
     """An object containing debugging information for a ParkingLot.
 
@@ -97,11 +97,11 @@ class ParkingLotStatistics:
 
     """
 
-    tasks_waiting: int = attr.field()
+    tasks_waiting: int = attrs.field()
 
 
 @final
-@attr.define(eq=False, hash=False)
+@attrs.define(eq=False, hash=False)
 class ParkingLot:
     """A fair wait queue with cancellation and requeueing.
 
@@ -117,7 +117,7 @@ class ParkingLot:
 
     # {task: None}, we just want a deque where we can quickly delete random
     # items
-    _parked: OrderedDict[Task, None] = attr.field(factory=OrderedDict, init=False)
+    _parked: OrderedDict[Task, None] = attrs.field(factory=OrderedDict, init=False)
 
     def __len__(self) -> int:
         """Returns the number of parked tasks."""

--- a/src/trio/_core/_parking_lot.py
+++ b/src/trio/_core/_parking_lot.py
@@ -97,7 +97,7 @@ class ParkingLotStatistics:
 
     """
 
-    tasks_waiting: int = attr.ib()
+    tasks_waiting: int = attr.field()
 
 
 @final
@@ -117,7 +117,7 @@ class ParkingLot:
 
     # {task: None}, we just want a deque where we can quickly delete random
     # items
-    _parked: OrderedDict[Task, None] = attr.ib(factory=OrderedDict, init=False)
+    _parked: OrderedDict[Task, None] = attr.field(factory=OrderedDict, init=False)
 
     def __len__(self) -> int:
         """Returns the number of parked tasks."""

--- a/src/trio/_core/_parking_lot.py
+++ b/src/trio/_core/_parking_lot.py
@@ -86,7 +86,7 @@ if TYPE_CHECKING:
     from ._run import Task
 
 
-@attr.s(frozen=True, slots=True)
+@attr.frozen
 class ParkingLotStatistics:
     """An object containing debugging information for a ParkingLot.
 

--- a/src/trio/_core/_run.py
+++ b/src/trio/_core/_run.py
@@ -1301,7 +1301,7 @@ class Task(metaclass=NoPublicConstructor):
     #   tracebacks with extraneous frames.
     # - for scheduled tasks, custom_sleep_data is None
     # Tasks start out unscheduled.
-    _next_send_fn: Callable[[Any], object] = attrs.field(default=None)
+    _next_send_fn: Callable[[Any], object] | None = attrs.field(default=None)
     _next_send: Outcome[Any] | None | BaseException = attrs.field(default=None)
     _abort_func: Callable[[_core.RaiseCancelT], Abort] | None = attrs.field(
         default=None

--- a/src/trio/_core/_run.py
+++ b/src/trio/_core/_run.py
@@ -216,7 +216,7 @@ def collapse_exception_group(
         return excgroup
 
 
-@attr.s(eq=False, slots=True)
+@attr.define(eq=False)
 class Deadlines:
     """A container of deadlined cancel scopes.
 
@@ -285,7 +285,7 @@ class Deadlines:
         return did_something
 
 
-@attr.s(eq=False, slots=True)
+@attr.define(eq=False)
 class CancelStatus:
     """Tracks the cancellation status for a contiguous extent
     of code that will become cancelled, or not, as a unit.
@@ -483,7 +483,7 @@ https://github.com/python-trio/trio/issues/new
 
 
 @final
-@attr.s(eq=False, repr=False, slots=True)
+@attr.define(eq=False, repr=False)
 class CancelScope:
     """A *cancellation scope*: the link between a unit of cancellable
     work and Trio's cancellation system.
@@ -845,7 +845,7 @@ class TaskStatus(Protocol[StatusT_contra]):
 
 # This code needs to be read alongside the code from Nursery.start to make
 # sense.
-@attr.s(eq=False, hash=False, repr=False)
+@attr.define(eq=False, hash=False, repr=False, slots=False)
 class _TaskStatus(TaskStatus[StatusT]):
     _old_nursery: Nursery = attr.field()
     _new_nursery: Nursery = attr.field()
@@ -914,7 +914,7 @@ class _TaskStatus(TaskStatus[StatusT]):
         self._old_nursery._check_nursery_closed()
 
 
-@attr.s
+@attr.define(slots=False)
 class NurseryManager:
     """Nursery context manager.
 
@@ -1281,7 +1281,7 @@ class Nursery(metaclass=NoPublicConstructor):
 
 
 @final
-@attr.s(eq=False, hash=False, repr=False, slots=True)
+@attr.define(eq=False, hash=False, repr=False)
 class Task(metaclass=NoPublicConstructor):
     _parent_nursery: Nursery | None = attr.field()
     coro: Coroutine[Any, Outcome[object], Any] = attr.field()
@@ -1524,7 +1524,7 @@ class RunStatistics:
 # worker thread.
 
 
-@attr.s(eq=False, hash=False, slots=True)
+@attr.define(eq=False, hash=False)
 class GuestState:
     runner: Runner = attr.field()
     run_sync_soon_threadsafe: Callable[[Callable[[], object]], object] = attr.field()
@@ -1576,7 +1576,7 @@ class GuestState:
             start_thread_soon(get_events, deliver)
 
 
-@attr.s(eq=False, hash=False, slots=True)
+@attr.define(eq=False, hash=False)
 class Runner:
     clock: Clock = attr.field()
     instruments: Instruments = attr.field()

--- a/src/trio/_core/_run.py
+++ b/src/trio/_core/_run.py
@@ -160,7 +160,7 @@ class SystemClock(Clock):
     # Add a large random offset to our clock to ensure that if people
     # accidentally call time.perf_counter() directly or start comparing clocks
     # between different runs, then they'll notice the bug quickly:
-    offset: float = attrs.field(factory=lambda: _r.uniform(10000, 200000))
+    offset: float = attrs.Factory(lambda: _r.uniform(10000, 200000))
 
     def start_clock(self) -> None:
         pass
@@ -226,7 +226,7 @@ class Deadlines:
     """
 
     # Heap of (deadline, id(CancelScope), CancelScope)
-    _heap: list[tuple[float, int, CancelScope]] = attrs.field(factory=list)
+    _heap: list[tuple[float, int, CancelScope]] = attrs.Factory(list)
     # Count of active deadlines (those that haven't been changed)
     _active: int = attrs.field(default=0)
 
@@ -1309,7 +1309,7 @@ class Task(metaclass=NoPublicConstructor):
     custom_sleep_data: Any = attrs.field(default=None)
 
     # For introspection and nursery.start()
-    _child_nurseries: list[Nursery] = attrs.field(factory=list)
+    _child_nurseries: list[Nursery] = attrs.Factory(list)
     _eventual_parent_nursery: Nursery | None = attrs.field(default=None)
 
     # these are counts of how many cancel/schedule points this task has
@@ -1535,7 +1535,7 @@ class GuestState:
     )
     done_callback: Callable[[Outcome[Any]], object]
     unrolled_run_gen: Generator[float, EventResult, None]
-    unrolled_run_next_send: Outcome[Any] = attrs.field(factory=lambda: Value(None))
+    unrolled_run_next_send: Outcome[Any] = attrs.Factory(lambda: Value(None))
 
     def guest_tick(self) -> None:
         prev_library, sniffio_library.name = sniffio_library.name, "trio"
@@ -1587,12 +1587,12 @@ class Runner:
     strict_exception_groups: bool
 
     # Run-local values, see _local.py
-    _locals: dict[_core.RunVar[Any], Any] = attrs.field(factory=dict)
+    _locals: dict[_core.RunVar[Any], Any] = attrs.Factory(dict)
 
-    runq: deque[Task] = attrs.field(factory=deque)
-    tasks: set[Task] = attrs.field(factory=set)
+    runq: deque[Task] = attrs.Factory(deque)
+    tasks: set[Task] = attrs.Factory(set)
 
-    deadlines: Deadlines = attrs.field(factory=Deadlines)
+    deadlines: Deadlines = attrs.Factory(Deadlines)
 
     init_task: Task | None = attrs.field(default=None)
     system_nursery: Nursery | None = attrs.field(default=None)
@@ -1600,9 +1600,9 @@ class Runner:
     main_task: Task | None = attrs.field(default=None)
     main_task_outcome: Outcome[Any] | None = attrs.field(default=None)
 
-    entry_queue: EntryQueue = attrs.field(factory=EntryQueue)
+    entry_queue: EntryQueue = attrs.Factory(EntryQueue)
     trio_token: TrioToken | None = attrs.field(default=None)
-    asyncgens: AsyncGenerators = attrs.field(factory=AsyncGenerators)
+    asyncgens: AsyncGenerators = attrs.Factory(AsyncGenerators)
 
     # If everything goes idle for this long, we call clock._autojump()
     clock_autojump_threshold: float = attrs.field(default=inf)
@@ -2001,7 +2001,7 @@ class Runner:
 
     # sortedcontainers doesn't have types, and is reportedly very hard to type:
     # https://github.com/grantjenks/python-sortedcontainers/issues/68
-    waiting_for_idle: Any = attrs.field(factory=SortedDict)
+    waiting_for_idle: Any = attrs.Factory(SortedDict)
 
     @_public
     async def wait_all_tasks_blocked(self, cushion: float = 0.0) -> None:

--- a/src/trio/_core/_run.py
+++ b/src/trio/_core/_run.py
@@ -155,7 +155,7 @@ def _count_context_run_tb_frames() -> int:
 CONTEXT_RUN_TB_FRAMES: Final = _count_context_run_tb_frames()
 
 
-@attr.s(frozen=True, slots=True)
+@attr.frozen
 class SystemClock(Clock):
     # Add a large random offset to our clock to ensure that if people
     # accidentally call time.perf_counter() directly or start comparing clocks

--- a/src/trio/_core/_run.py
+++ b/src/trio/_core/_run.py
@@ -318,7 +318,7 @@ class CancelStatus:
     # Our associated cancel scope. Can be any object with attributes
     # `deadline`, `shield`, and `cancel_called`, but in current usage
     # is always a CancelScope object. Must not be None.
-    _scope: CancelScope = attr.ib()
+    _scope: CancelScope = attr.ib(alias="scope")
 
     # True iff the tasks in self._tasks should receive cancellations
     # when they checkpoint. Always True when scope.cancel_called is True;
@@ -335,7 +335,7 @@ class CancelStatus:
     # is True.  May be None (for the outermost CancelStatus in a call
     # to trio.run(), briefly during TaskStatus.started(), or during
     # recovery from mis-nesting of cancel scopes).
-    _parent: CancelStatus | None = attr.ib(default=None, repr=False)
+    _parent: CancelStatus | None = attr.ib(default=None, repr=False, alias="parent")
 
     # All of the CancelStatuses that have this CancelStatus as their parent.
     _children: set[CancelStatus] = attr.ib(factory=set, init=False, repr=False)
@@ -530,8 +530,8 @@ class CancelScope:
     cancelled_caught: bool = attr.ib(default=False, init=False)
 
     # Constructor arguments:
-    _deadline: float = attr.ib(default=inf, kw_only=True)
-    _shield: bool = attr.ib(default=False, kw_only=True)
+    _deadline: float = attr.ib(default=inf, kw_only=True, alias="deadline")
+    _shield: bool = attr.ib(default=False, kw_only=True, alias="shield")
 
     @enable_ki_protection
     def __enter__(self) -> Self:

--- a/src/trio/_core/_run.py
+++ b/src/trio/_core/_run.py
@@ -1528,9 +1528,7 @@ class RunStatistics:
 class GuestState:
     runner: Runner
     run_sync_soon_threadsafe: Callable[[Callable[[], object]], object]
-    run_sync_soon_not_threadsafe: Callable[[Callable[[], object]], object] = (
-        attrs.field()
-    )
+    run_sync_soon_not_threadsafe: Callable[[Callable[[], object]], object]
     done_callback: Callable[[Outcome[Any]], object]
     unrolled_run_gen: Generator[float, EventResult, None]
     unrolled_run_next_send: Outcome[Any] = attrs.Factory(lambda: Value(None))

--- a/src/trio/_core/_run.py
+++ b/src/trio/_core/_run.py
@@ -847,8 +847,8 @@ class TaskStatus(Protocol[StatusT_contra]):
 # sense.
 @attrs.define(eq=False, hash=False, repr=False, slots=False)
 class _TaskStatus(TaskStatus[StatusT]):
-    _old_nursery: Nursery = attrs.field()
-    _new_nursery: Nursery = attrs.field()
+    _old_nursery: Nursery
+    _new_nursery: Nursery
     # NoStatus is a sentinel.
     _value: StatusT | type[_NoStatus] = attrs.field(default=_NoStatus)
 
@@ -1283,11 +1283,11 @@ class Nursery(metaclass=NoPublicConstructor):
 @final
 @attrs.define(eq=False, hash=False, repr=False)
 class Task(metaclass=NoPublicConstructor):
-    _parent_nursery: Nursery | None = attrs.field()
-    coro: Coroutine[Any, Outcome[object], Any] = attrs.field()
-    _runner: Runner = attrs.field()
-    name: str = attrs.field()
-    context: contextvars.Context = attrs.field()
+    _parent_nursery: Nursery | None
+    coro: Coroutine[Any, Outcome[object], Any]
+    _runner: Runner
+    name: str
+    context: contextvars.Context
     _counter: int = attrs.field(init=False, factory=itertools.count().__next__)
 
     # Invariant:
@@ -1528,13 +1528,13 @@ class RunStatistics:
 
 @attrs.define(eq=False, hash=False)
 class GuestState:
-    runner: Runner = attrs.field()
-    run_sync_soon_threadsafe: Callable[[Callable[[], object]], object] = attrs.field()
+    runner: Runner
+    run_sync_soon_threadsafe: Callable[[Callable[[], object]], object]
     run_sync_soon_not_threadsafe: Callable[[Callable[[], object]], object] = (
         attrs.field()
     )
-    done_callback: Callable[[Outcome[Any]], object] = attrs.field()
-    unrolled_run_gen: Generator[float, EventResult, None] = attrs.field()
+    done_callback: Callable[[Outcome[Any]], object]
+    unrolled_run_gen: Generator[float, EventResult, None]
     unrolled_run_next_send: Outcome[Any] = attrs.field(factory=lambda: Value(None))
 
     def guest_tick(self) -> None:
@@ -1580,11 +1580,11 @@ class GuestState:
 
 @attrs.define(eq=False, hash=False)
 class Runner:
-    clock: Clock = attrs.field()
-    instruments: Instruments = attrs.field()
-    io_manager: TheIOManager = attrs.field()
-    ki_manager: KIManager = attrs.field()
-    strict_exception_groups: bool = attrs.field()
+    clock: Clock
+    instruments: Instruments
+    io_manager: TheIOManager
+    ki_manager: KIManager
+    strict_exception_groups: bool
 
     # Run-local values, see _local.py
     _locals: dict[_core.RunVar[Any], Any] = attrs.field(factory=dict)

--- a/src/trio/_core/_run.py
+++ b/src/trio/_core/_run.py
@@ -228,7 +228,7 @@ class Deadlines:
     # Heap of (deadline, id(CancelScope), CancelScope)
     _heap: list[tuple[float, int, CancelScope]] = attrs.Factory(list)
     # Count of active deadlines (those that haven't been changed)
-    _active: int = attrs.field(default=0)
+    _active: int = 0
 
     def add(self, deadline: float, cancel_scope: CancelScope) -> None:
         heappush(self._heap, (deadline, id(cancel_scope), cancel_scope))
@@ -328,7 +328,7 @@ class CancelStatus:
     # effectively cancelled due to the cancel scope two levels out
     # becoming cancelled, but then the cancel scope one level out
     # becomes shielded so we're not effectively cancelled anymore.
-    effectively_cancelled: bool = attrs.field(default=False)
+    effectively_cancelled: bool = False
 
     # The CancelStatus whose cancellations can propagate to us; we
     # become effectively cancelled when they do, unless scope.shield
@@ -850,7 +850,7 @@ class _TaskStatus(TaskStatus[StatusT]):
     _old_nursery: Nursery
     _new_nursery: Nursery
     # NoStatus is a sentinel.
-    _value: StatusT | type[_NoStatus] = attrs.field(default=_NoStatus)
+    _value: StatusT | type[_NoStatus] = _NoStatus
 
     def __repr__(self) -> str:
         return f"<Task status object at {id(self):#x}>"
@@ -925,7 +925,7 @@ class NurseryManager:
 
     """
 
-    strict_exception_groups: bool = attrs.field(default=True)
+    strict_exception_groups: bool = True
 
     @enable_ki_protection
     async def __aenter__(self) -> Nursery:
@@ -1301,22 +1301,20 @@ class Task(metaclass=NoPublicConstructor):
     #   tracebacks with extraneous frames.
     # - for scheduled tasks, custom_sleep_data is None
     # Tasks start out unscheduled.
-    _next_send_fn: Callable[[Any], object] | None = attrs.field(default=None)
-    _next_send: Outcome[Any] | None | BaseException = attrs.field(default=None)
-    _abort_func: Callable[[_core.RaiseCancelT], Abort] | None = attrs.field(
-        default=None
-    )
-    custom_sleep_data: Any = attrs.field(default=None)
+    _next_send_fn: Callable[[Any], object] | None = None
+    _next_send: Outcome[Any] | None | BaseException = None
+    _abort_func: Callable[[_core.RaiseCancelT], Abort] | None = None
+    custom_sleep_data: Any = None
 
     # For introspection and nursery.start()
     _child_nurseries: list[Nursery] = attrs.Factory(list)
-    _eventual_parent_nursery: Nursery | None = attrs.field(default=None)
+    _eventual_parent_nursery: Nursery | None = None
 
     # these are counts of how many cancel/schedule points this task has
     # executed, for assert{_no,}_checkpoints
     # XX maybe these should be exposed as part of a statistics() method?
-    _cancel_points: int = attrs.field(default=0)
-    _schedule_points: int = attrs.field(default=0)
+    _cancel_points: int = 0
+    _schedule_points: int = 0
 
     def __repr__(self) -> str:
         return f"<Task {self.name!r} at {id(self):#x}>"
@@ -1594,22 +1592,22 @@ class Runner:
 
     deadlines: Deadlines = attrs.Factory(Deadlines)
 
-    init_task: Task | None = attrs.field(default=None)
-    system_nursery: Nursery | None = attrs.field(default=None)
+    init_task: Task | None = None
+    system_nursery: Nursery | None = None
     system_context: contextvars.Context = attrs.field(kw_only=True)
-    main_task: Task | None = attrs.field(default=None)
-    main_task_outcome: Outcome[Any] | None = attrs.field(default=None)
+    main_task: Task | None = None
+    main_task_outcome: Outcome[Any] | None = None
 
     entry_queue: EntryQueue = attrs.Factory(EntryQueue)
-    trio_token: TrioToken | None = attrs.field(default=None)
+    trio_token: TrioToken | None = None
     asyncgens: AsyncGenerators = attrs.Factory(AsyncGenerators)
 
     # If everything goes idle for this long, we call clock._autojump()
-    clock_autojump_threshold: float = attrs.field(default=inf)
+    clock_autojump_threshold: float = inf
 
     # Guest mode stuff
-    is_guest: bool = attrs.field(default=False)
-    guest_tick_scheduled: bool = attrs.field(default=False)
+    is_guest: bool = False
+    guest_tick_scheduled: bool = False
 
     def force_guest_tick_asap(self) -> None:
         if self.guest_tick_scheduled:
@@ -1968,7 +1966,7 @@ class Runner:
     # KI handling
     ################
 
-    ki_pending: bool = attrs.field(default=False)
+    ki_pending: bool = False
 
     # deliver_ki is broke. Maybe move all the actual logic and state into
     # RunToken, and we'll only have one instance per runner? But then we can't

--- a/src/trio/_core/_tests/test_instrumentation.py
+++ b/src/trio/_core/_tests/test_instrumentation.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Container, Iterable, NoReturn
 
-import attr
+import attrs
 import pytest
 
 from ... import _abc, _core
@@ -12,9 +12,9 @@ if TYPE_CHECKING:
     from ...lowlevel import Task
 
 
-@attr.define(eq=False, hash=False, slots=False)
+@attrs.define(eq=False, hash=False, slots=False)
 class TaskRecorder(_abc.Instrument):
-    record: list[tuple[str, Task | None]] = attr.field(factory=list)
+    record: list[tuple[str, Task | None]] = attrs.field(factory=list)
 
     def before_run(self) -> None:
         self.record.append(("before_run", None))

--- a/src/trio/_core/_tests/test_instrumentation.py
+++ b/src/trio/_core/_tests/test_instrumentation.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from ...lowlevel import Task
 
 
-@attr.s(eq=False, hash=False)
+@attr.define(eq=False, hash=False, slots=False)
 class TaskRecorder(_abc.Instrument):
     record: list[tuple[str, Task | None]] = attr.field(factory=list)
 

--- a/src/trio/_core/_tests/test_instrumentation.py
+++ b/src/trio/_core/_tests/test_instrumentation.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 @attr.s(eq=False, hash=False)
 class TaskRecorder(_abc.Instrument):
-    record: list[tuple[str, Task | None]] = attr.ib(factory=list)
+    record: list[tuple[str, Task | None]] = attr.field(factory=list)
 
     def before_run(self) -> None:
         self.record.append(("before_run", None))

--- a/src/trio/_core/_tests/test_instrumentation.py
+++ b/src/trio/_core/_tests/test_instrumentation.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 @attrs.define(eq=False, hash=False, slots=False)
 class TaskRecorder(_abc.Instrument):
-    record: list[tuple[str, Task | None]] = attrs.field(factory=list)
+    record: list[tuple[str, Task | None]] = attrs.Factory(list)
 
     def before_run(self) -> None:
         self.record.append(("before_run", None))

--- a/src/trio/_core/_traps.py
+++ b/src/trio/_core/_traps.py
@@ -67,7 +67,7 @@ class Abort(enum.Enum):
 
 
 # Not exported in the trio._core namespace, but imported directly by _run.
-@attr.s(frozen=True)
+@attr.frozen(slots=False)
 class WaitTaskRescheduled:
     abort_func: Callable[[RaiseCancelT], Abort] = attr.field()
 
@@ -180,7 +180,7 @@ async def wait_task_rescheduled(abort_func: Callable[[RaiseCancelT], Abort]) -> 
 
 
 # Not exported in the trio._core namespace, but imported directly by _run.
-@attr.s(frozen=True)
+@attr.frozen(slots=False)
 class PermanentlyDetachCoroutineObject:
     final_outcome: outcome.Outcome[Any] = attr.field()
 

--- a/src/trio/_core/_traps.py
+++ b/src/trio/_core/_traps.py
@@ -69,7 +69,7 @@ class Abort(enum.Enum):
 # Not exported in the trio._core namespace, but imported directly by _run.
 @attr.s(frozen=True)
 class WaitTaskRescheduled:
-    abort_func: Callable[[RaiseCancelT], Abort] = attr.ib()
+    abort_func: Callable[[RaiseCancelT], Abort] = attr.field()
 
 
 RaiseCancelT: TypeAlias = Callable[[], NoReturn]
@@ -182,7 +182,7 @@ async def wait_task_rescheduled(abort_func: Callable[[RaiseCancelT], Abort]) -> 
 # Not exported in the trio._core namespace, but imported directly by _run.
 @attr.s(frozen=True)
 class PermanentlyDetachCoroutineObject:
-    final_outcome: outcome.Outcome[Any] = attr.ib()
+    final_outcome: outcome.Outcome[Any] = attr.field()
 
 
 async def permanently_detach_coroutine_object(

--- a/src/trio/_core/_traps.py
+++ b/src/trio/_core/_traps.py
@@ -6,7 +6,7 @@ import enum
 import types
 from typing import TYPE_CHECKING, Any, Callable, NoReturn
 
-import attr
+import attrs
 import outcome
 
 from . import _run
@@ -67,9 +67,9 @@ class Abort(enum.Enum):
 
 
 # Not exported in the trio._core namespace, but imported directly by _run.
-@attr.frozen(slots=False)
+@attrs.frozen(slots=False)
 class WaitTaskRescheduled:
-    abort_func: Callable[[RaiseCancelT], Abort] = attr.field()
+    abort_func: Callable[[RaiseCancelT], Abort] = attrs.field()
 
 
 RaiseCancelT: TypeAlias = Callable[[], NoReturn]
@@ -180,9 +180,9 @@ async def wait_task_rescheduled(abort_func: Callable[[RaiseCancelT], Abort]) -> 
 
 
 # Not exported in the trio._core namespace, but imported directly by _run.
-@attr.frozen(slots=False)
+@attrs.frozen(slots=False)
 class PermanentlyDetachCoroutineObject:
-    final_outcome: outcome.Outcome[Any] = attr.field()
+    final_outcome: outcome.Outcome[Any] = attrs.field()
 
 
 async def permanently_detach_coroutine_object(

--- a/src/trio/_core/_traps.py
+++ b/src/trio/_core/_traps.py
@@ -69,7 +69,7 @@ class Abort(enum.Enum):
 # Not exported in the trio._core namespace, but imported directly by _run.
 @attrs.frozen(slots=False)
 class WaitTaskRescheduled:
-    abort_func: Callable[[RaiseCancelT], Abort] = attrs.field()
+    abort_func: Callable[[RaiseCancelT], Abort]
 
 
 RaiseCancelT: TypeAlias = Callable[[], NoReturn]
@@ -182,7 +182,7 @@ async def wait_task_rescheduled(abort_func: Callable[[RaiseCancelT], Abort]) -> 
 # Not exported in the trio._core namespace, but imported directly by _run.
 @attrs.frozen(slots=False)
 class PermanentlyDetachCoroutineObject:
-    final_outcome: outcome.Outcome[Any] = attrs.field()
+    final_outcome: outcome.Outcome[Any]
 
 
 async def permanently_detach_coroutine_object(

--- a/src/trio/_core/_unbounded_queue.py
+++ b/src/trio/_core/_unbounded_queue.py
@@ -26,8 +26,8 @@ class UnboundedQueueStatistics:
 
     """
 
-    qsize: int = attr.ib()
-    tasks_waiting: int = attr.ib()
+    qsize: int = attr.field()
+    tasks_waiting: int = attr.field()
 
 
 @final

--- a/src/trio/_core/_unbounded_queue.py
+++ b/src/trio/_core/_unbounded_queue.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
 
-@attr.s(slots=True, frozen=True)
+@attr.frozen
 class UnboundedQueueStatistics:
     """An object containing debugging information.
 

--- a/src/trio/_core/_unbounded_queue.py
+++ b/src/trio/_core/_unbounded_queue.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Generic, TypeVar
 
-import attr
+import attrs
 
 from .. import _core
 from .._deprecate import deprecated
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
 
-@attr.frozen
+@attrs.frozen
 class UnboundedQueueStatistics:
     """An object containing debugging information.
 
@@ -26,8 +26,8 @@ class UnboundedQueueStatistics:
 
     """
 
-    qsize: int = attr.field()
-    tasks_waiting: int = attr.field()
+    qsize: int = attrs.field()
+    tasks_waiting: int = attrs.field()
 
 
 @final

--- a/src/trio/_core/_unbounded_queue.py
+++ b/src/trio/_core/_unbounded_queue.py
@@ -26,8 +26,8 @@ class UnboundedQueueStatistics:
 
     """
 
-    qsize: int = attrs.field()
-    tasks_waiting: int = attrs.field()
+    qsize: int
+    tasks_waiting: int
 
 
 @final

--- a/src/trio/_deprecate.py
+++ b/src/trio/_deprecate.py
@@ -130,10 +130,10 @@ def deprecated_alias(
 class DeprecatedAttribute:
     _not_set: ClassVar[object] = object()
 
-    value: object = attr.ib()
-    version: str = attr.ib()
-    issue: int | None = attr.ib()
-    instead: object = attr.ib(default=_not_set)
+    value: object = attr.field()
+    version: str = attr.field()
+    issue: int | None = attr.field()
+    instead: object = attr.field(default=_not_set)
 
 
 class _ModuleWithDeprecations(ModuleType):

--- a/src/trio/_deprecate.py
+++ b/src/trio/_deprecate.py
@@ -6,7 +6,7 @@ from functools import wraps
 from types import ModuleType
 from typing import TYPE_CHECKING, ClassVar, TypeVar
 
-import attr
+import attrs
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -126,14 +126,14 @@ def deprecated_alias(
     return wrapper
 
 
-@attr.frozen(slots=False)
+@attrs.frozen(slots=False)
 class DeprecatedAttribute:
     _not_set: ClassVar[object] = object()
 
-    value: object = attr.field()
-    version: str = attr.field()
-    issue: int | None = attr.field()
-    instead: object = attr.field(default=_not_set)
+    value: object = attrs.field()
+    version: str = attrs.field()
+    issue: int | None = attrs.field()
+    instead: object = attrs.field(default=_not_set)
 
 
 class _ModuleWithDeprecations(ModuleType):

--- a/src/trio/_deprecate.py
+++ b/src/trio/_deprecate.py
@@ -133,7 +133,7 @@ class DeprecatedAttribute:
     value: object
     version: str
     issue: int | None
-    instead: object = attrs.field(default=_not_set)
+    instead: object = _not_set
 
 
 class _ModuleWithDeprecations(ModuleType):

--- a/src/trio/_deprecate.py
+++ b/src/trio/_deprecate.py
@@ -130,9 +130,9 @@ def deprecated_alias(
 class DeprecatedAttribute:
     _not_set: ClassVar[object] = object()
 
-    value: object = attrs.field()
-    version: str = attrs.field()
-    issue: int | None = attrs.field()
+    value: object
+    version: str
+    issue: int | None
     instead: object = attrs.field(default=_not_set)
 
 

--- a/src/trio/_deprecate.py
+++ b/src/trio/_deprecate.py
@@ -126,7 +126,7 @@ def deprecated_alias(
     return wrapper
 
 
-@attr.s(frozen=True)
+@attr.frozen(slots=False)
 class DeprecatedAttribute:
     _not_set: ClassVar[object] = object()
 

--- a/src/trio/_dtls.py
+++ b/src/trio/_dtls.py
@@ -30,7 +30,7 @@ from typing import (
 )
 from weakref import ReferenceType, WeakValueDictionary
 
-import attr
+import attrs
 
 import trio
 
@@ -160,12 +160,12 @@ def to_hex(data: bytes) -> str:  # pragma: no cover
     return data.hex()
 
 
-@attr.frozen
+@attrs.frozen
 class Record:
     content_type: int
-    version: bytes = attr.field(repr=to_hex)
+    version: bytes = attrs.field(repr=to_hex)
     epoch_seqno: int
-    payload: bytes = attr.field(repr=to_hex)
+    payload: bytes = attrs.field(repr=to_hex)
 
 
 def records_untrusted(packet: bytes) -> Iterator[Record]:
@@ -205,14 +205,14 @@ def encode_record(record: Record) -> bytes:
 HANDSHAKE_MESSAGE_HEADER = struct.Struct("!B3sH3s3s")
 
 
-@attr.frozen
+@attrs.frozen
 class HandshakeFragment:
     msg_type: int
     msg_len: int
     msg_seq: int
     frag_offset: int
     frag_len: int
-    frag: bytes = attr.field(repr=to_hex)
+    frag: bytes = attrs.field(repr=to_hex)
 
 
 def decode_handshake_fragment_untrusted(payload: bytes) -> HandshakeFragment:
@@ -325,21 +325,21 @@ def decode_client_hello_untrusted(packet: bytes) -> tuple[int, bytes, bytes]:
         raise BadPacket("bad ClientHello") from exc
 
 
-@attr.frozen
+@attrs.frozen
 class HandshakeMessage:
-    record_version: bytes = attr.field(repr=to_hex)
+    record_version: bytes = attrs.field(repr=to_hex)
     msg_type: HandshakeType
     msg_seq: int
-    body: bytearray = attr.field(repr=to_hex)
+    body: bytearray = attrs.field(repr=to_hex)
 
 
 # ChangeCipherSpec is part of the handshake, but it's not a "handshake
 # message" and can't be fragmented the same way. Sigh.
-@attr.frozen
+@attrs.frozen
 class PseudoHandshakeMessage:
-    record_version: bytes = attr.field(repr=to_hex)
+    record_version: bytes = attrs.field(repr=to_hex)
     content_type: int
-    payload: bytes = attr.field(repr=to_hex)
+    payload: bytes = attrs.field(repr=to_hex)
 
 
 # The final record in a handshake is Finished, which is encrypted, can't be fragmented
@@ -347,7 +347,7 @@ class PseudoHandshakeMessage:
 # just pass it through unchanged. (Fortunately, the payload is only a single hash value,
 # so the largest it will ever be is 64 bytes for a 512-bit hash. Which is small enough
 # that it never requires fragmenting to fit into a UDP packet.
-@attr.frozen
+@attrs.frozen
 class OpaqueHandshakeMessage:
     record: Record
 
@@ -803,7 +803,7 @@ async def dtls_receive_loop(
             raise
 
 
-@attr.frozen
+@attrs.frozen
 class DTLSChannelStatistics:
     """Currently this has only one attribute:
 

--- a/src/trio/_dtls.py
+++ b/src/trio/_dtls.py
@@ -163,9 +163,9 @@ def to_hex(data: bytes) -> str:  # pragma: no cover
 @attr.frozen
 class Record:
     content_type: int
-    version: bytes = attr.ib(repr=to_hex)
+    version: bytes = attr.field(repr=to_hex)
     epoch_seqno: int
-    payload: bytes = attr.ib(repr=to_hex)
+    payload: bytes = attr.field(repr=to_hex)
 
 
 def records_untrusted(packet: bytes) -> Iterator[Record]:
@@ -212,7 +212,7 @@ class HandshakeFragment:
     msg_seq: int
     frag_offset: int
     frag_len: int
-    frag: bytes = attr.ib(repr=to_hex)
+    frag: bytes = attr.field(repr=to_hex)
 
 
 def decode_handshake_fragment_untrusted(payload: bytes) -> HandshakeFragment:
@@ -327,19 +327,19 @@ def decode_client_hello_untrusted(packet: bytes) -> tuple[int, bytes, bytes]:
 
 @attr.frozen
 class HandshakeMessage:
-    record_version: bytes = attr.ib(repr=to_hex)
+    record_version: bytes = attr.field(repr=to_hex)
     msg_type: HandshakeType
     msg_seq: int
-    body: bytearray = attr.ib(repr=to_hex)
+    body: bytearray = attr.field(repr=to_hex)
 
 
 # ChangeCipherSpec is part of the handshake, but it's not a "handshake
 # message" and can't be fragmented the same way. Sigh.
 @attr.frozen
 class PseudoHandshakeMessage:
-    record_version: bytes = attr.ib(repr=to_hex)
+    record_version: bytes = attr.field(repr=to_hex)
     content_type: int
-    payload: bytes = attr.ib(repr=to_hex)
+    payload: bytes = attr.field(repr=to_hex)
 
 
 # The final record in a handshake is Finished, which is encrypted, can't be fragmented

--- a/src/trio/_highlevel_generic.py
+++ b/src/trio/_highlevel_generic.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Generic, TypeVar
 
-import attr
+import attrs
 
 import trio
 from trio._util import final
@@ -53,7 +53,7 @@ def _is_halfclosable(stream: SendStream) -> TypeGuard[HalfCloseableStream]:
 
 
 @final
-@attr.define(eq=False, hash=False, slots=False)
+@attrs.define(eq=False, hash=False, slots=False)
 class StapledStream(
     HalfCloseableStream,
     Generic[SendStreamT, ReceiveStreamT],
@@ -92,8 +92,8 @@ class StapledStream(
 
     """
 
-    send_stream: SendStreamT = attr.field()
-    receive_stream: ReceiveStreamT = attr.field()
+    send_stream: SendStreamT = attrs.field()
+    receive_stream: ReceiveStreamT = attrs.field()
 
     async def send_all(self, data: bytes | bytearray | memoryview) -> None:
         """Calls ``self.send_stream.send_all``."""

--- a/src/trio/_highlevel_generic.py
+++ b/src/trio/_highlevel_generic.py
@@ -92,8 +92,8 @@ class StapledStream(
 
     """
 
-    send_stream: SendStreamT = attr.ib()
-    receive_stream: ReceiveStreamT = attr.ib()
+    send_stream: SendStreamT = attr.field()
+    receive_stream: ReceiveStreamT = attr.field()
 
     async def send_all(self, data: bytes | bytearray | memoryview) -> None:
         """Calls ``self.send_stream.send_all``."""

--- a/src/trio/_highlevel_generic.py
+++ b/src/trio/_highlevel_generic.py
@@ -92,8 +92,8 @@ class StapledStream(
 
     """
 
-    send_stream: SendStreamT = attrs.field()
-    receive_stream: ReceiveStreamT = attrs.field()
+    send_stream: SendStreamT
+    receive_stream: ReceiveStreamT
 
     async def send_all(self, data: bytes | bytearray | memoryview) -> None:
         """Calls ``self.send_stream.send_all``."""

--- a/src/trio/_highlevel_generic.py
+++ b/src/trio/_highlevel_generic.py
@@ -53,7 +53,7 @@ def _is_halfclosable(stream: SendStream) -> TypeGuard[HalfCloseableStream]:
 
 
 @final
-@attr.s(eq=False, hash=False)
+@attr.define(eq=False, hash=False, slots=False)
 class StapledStream(
     HalfCloseableStream,
     Generic[SendStreamT, ReceiveStreamT],

--- a/src/trio/_sync.py
+++ b/src/trio/_sync.py
@@ -29,7 +29,7 @@ class EventStatistics:
 
     """
 
-    tasks_waiting: int = attrs.field()
+    tasks_waiting: int
 
 
 @final
@@ -148,10 +148,10 @@ class CapacityLimiterStatistics:
 
     """
 
-    borrowed_tokens: int = attrs.field()
-    total_tokens: int | float = attrs.field()
-    borrowers: list[Task | object] = attrs.field()
-    tasks_waiting: int = attrs.field()
+    borrowed_tokens: int
+    total_tokens: int | float
+    borrowers: list[Task | object]
+    tasks_waiting: int
 
 
 # Can be a generic type with a default of Task if/when PEP 696 is released
@@ -535,9 +535,9 @@ class LockStatistics:
 
     """
 
-    locked: bool = attrs.field()
-    owner: Task | None = attrs.field()
-    tasks_waiting: int = attrs.field()
+    locked: bool
+    owner: Task | None
+    tasks_waiting: int
 
 
 @attrs.define(eq=False, hash=False, repr=False, slots=False)
@@ -720,8 +720,8 @@ class ConditionStatistics:
 
     """
 
-    tasks_waiting: int = attrs.field()
-    lock_statistics: LockStatistics = attrs.field()
+    tasks_waiting: int
+    lock_statistics: LockStatistics
 
 
 @final

--- a/src/trio/_sync.py
+++ b/src/trio/_sync.py
@@ -33,7 +33,7 @@ class EventStatistics:
 
 
 @final
-@attr.s(repr=False, eq=False, hash=False, slots=True)
+@attr.define(repr=False, eq=False, hash=False)
 class Event:
     """A waitable boolean value useful for inter-task synchronization,
     inspired by :class:`threading.Event`.
@@ -540,7 +540,7 @@ class LockStatistics:
     tasks_waiting: int = attr.field()
 
 
-@attr.s(eq=False, hash=False, repr=False)
+@attr.define(eq=False, hash=False, repr=False, slots=False)
 class _LockImpl(AsyncContextManagerMixin):
     _lot: ParkingLot = attr.field(factory=ParkingLot, init=False)
     _owner: Task | None = attr.field(default=None, init=False)

--- a/src/trio/_sync.py
+++ b/src/trio/_sync.py
@@ -29,7 +29,7 @@ class EventStatistics:
 
     """
 
-    tasks_waiting: int = attr.ib()
+    tasks_waiting: int = attr.field()
 
 
 @final
@@ -60,8 +60,8 @@ class Event:
 
     """
 
-    _tasks: set[Task] = attr.ib(factory=set, init=False)
-    _flag: bool = attr.ib(default=False, init=False)
+    _tasks: set[Task] = attr.field(factory=set, init=False)
+    _flag: bool = attr.field(default=False, init=False)
 
     def is_set(self) -> bool:
         """Return the current value of the internal flag."""
@@ -148,10 +148,10 @@ class CapacityLimiterStatistics:
 
     """
 
-    borrowed_tokens: int = attr.ib()
-    total_tokens: int | float = attr.ib()
-    borrowers: list[Task | object] = attr.ib()
-    tasks_waiting: int = attr.ib()
+    borrowed_tokens: int = attr.field()
+    total_tokens: int | float = attr.field()
+    borrowers: list[Task | object] = attr.field()
+    tasks_waiting: int = attr.field()
 
 
 # Can be a generic type with a default of Task if/when PEP 696 is released
@@ -535,15 +535,15 @@ class LockStatistics:
 
     """
 
-    locked: bool = attr.ib()
-    owner: Task | None = attr.ib()
-    tasks_waiting: int = attr.ib()
+    locked: bool = attr.field()
+    owner: Task | None = attr.field()
+    tasks_waiting: int = attr.field()
 
 
 @attr.s(eq=False, hash=False, repr=False)
 class _LockImpl(AsyncContextManagerMixin):
-    _lot: ParkingLot = attr.ib(factory=ParkingLot, init=False)
-    _owner: Task | None = attr.ib(default=None, init=False)
+    _lot: ParkingLot = attr.field(factory=ParkingLot, init=False)
+    _owner: Task | None = attr.field(default=None, init=False)
 
     def __repr__(self) -> str:
         if self.locked():
@@ -720,8 +720,8 @@ class ConditionStatistics:
 
     """
 
-    tasks_waiting: int = attr.ib()
-    lock_statistics: LockStatistics = attr.ib()
+    tasks_waiting: int = attr.field()
+    lock_statistics: LockStatistics = attr.field()
 
 
 @final

--- a/src/trio/_sync.py
+++ b/src/trio/_sync.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import math
 from typing import TYPE_CHECKING, Protocol
 
-import attr
+import attrs
 
 import trio
 
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from ._core._parking_lot import ParkingLotStatistics
 
 
-@attr.frozen
+@attrs.frozen
 class EventStatistics:
     """An object containing debugging information.
 
@@ -29,11 +29,11 @@ class EventStatistics:
 
     """
 
-    tasks_waiting: int = attr.field()
+    tasks_waiting: int = attrs.field()
 
 
 @final
-@attr.define(repr=False, eq=False, hash=False)
+@attrs.define(repr=False, eq=False, hash=False)
 class Event:
     """A waitable boolean value useful for inter-task synchronization,
     inspired by :class:`threading.Event`.
@@ -60,8 +60,8 @@ class Event:
 
     """
 
-    _tasks: set[Task] = attr.field(factory=set, init=False)
-    _flag: bool = attr.field(default=False, init=False)
+    _tasks: set[Task] = attrs.field(factory=set, init=False)
+    _flag: bool = attrs.field(default=False, init=False)
 
     def is_set(self) -> bool:
         """Return the current value of the internal flag."""
@@ -129,7 +129,7 @@ class AsyncContextManagerMixin:
         self.release()
 
 
-@attr.frozen
+@attrs.frozen
 class CapacityLimiterStatistics:
     """An object containing debugging information.
 
@@ -148,10 +148,10 @@ class CapacityLimiterStatistics:
 
     """
 
-    borrowed_tokens: int = attr.field()
-    total_tokens: int | float = attr.field()
-    borrowers: list[Task | object] = attr.field()
-    tasks_waiting: int = attr.field()
+    borrowed_tokens: int = attrs.field()
+    total_tokens: int | float = attrs.field()
+    borrowers: list[Task | object] = attrs.field()
+    tasks_waiting: int = attrs.field()
 
 
 # Can be a generic type with a default of Task if/when PEP 696 is released
@@ -521,7 +521,7 @@ class Semaphore(AsyncContextManagerMixin):
         return self._lot.statistics()
 
 
-@attr.frozen
+@attrs.frozen
 class LockStatistics:
     """An object containing debugging information for a Lock.
 
@@ -535,15 +535,15 @@ class LockStatistics:
 
     """
 
-    locked: bool = attr.field()
-    owner: Task | None = attr.field()
-    tasks_waiting: int = attr.field()
+    locked: bool = attrs.field()
+    owner: Task | None = attrs.field()
+    tasks_waiting: int = attrs.field()
 
 
-@attr.define(eq=False, hash=False, repr=False, slots=False)
+@attrs.define(eq=False, hash=False, repr=False, slots=False)
 class _LockImpl(AsyncContextManagerMixin):
-    _lot: ParkingLot = attr.field(factory=ParkingLot, init=False)
-    _owner: Task | None = attr.field(default=None, init=False)
+    _lot: ParkingLot = attrs.field(factory=ParkingLot, init=False)
+    _owner: Task | None = attrs.field(default=None, init=False)
 
     def __repr__(self) -> str:
         if self.locked():
@@ -707,7 +707,7 @@ class StrictFIFOLock(_LockImpl):
     """
 
 
-@attr.frozen
+@attrs.frozen
 class ConditionStatistics:
     r"""An object containing debugging information for a Condition.
 
@@ -720,8 +720,8 @@ class ConditionStatistics:
 
     """
 
-    tasks_waiting: int = attr.field()
-    lock_statistics: LockStatistics = attr.field()
+    tasks_waiting: int = attrs.field()
+    lock_statistics: LockStatistics = attrs.field()
 
 
 @final

--- a/src/trio/_sync.py
+++ b/src/trio/_sync.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from ._core._parking_lot import ParkingLotStatistics
 
 
-@attr.s(frozen=True, slots=True)
+@attr.frozen
 class EventStatistics:
     """An object containing debugging information.
 
@@ -129,7 +129,7 @@ class AsyncContextManagerMixin:
         self.release()
 
 
-@attr.s(frozen=True, slots=True)
+@attr.frozen
 class CapacityLimiterStatistics:
     """An object containing debugging information.
 
@@ -521,7 +521,7 @@ class Semaphore(AsyncContextManagerMixin):
         return self._lot.statistics()
 
 
-@attr.s(frozen=True, slots=True)
+@attr.frozen
 class LockStatistics:
     """An object containing debugging information for a Lock.
 
@@ -707,7 +707,7 @@ class StrictFIFOLock(_LockImpl):
     """
 
 
-@attr.s(frozen=True, slots=True)
+@attr.frozen
 class ConditionStatistics:
     r"""An object containing debugging information for a Condition.
 

--- a/src/trio/_tests/test_abc.py
+++ b/src/trio/_tests/test_abc.py
@@ -32,7 +32,7 @@ def test_instrument_implements_hook_methods() -> None:
 async def test_AsyncResource_defaults() -> None:
     @attr.s
     class MyAR(tabc.AsyncResource):
-        record: list[str] = attr.ib(factory=list)
+        record: list[str] = attr.field(factory=list)
 
         async def aclose(self) -> None:
             self.record.append("ac")

--- a/src/trio/_tests/test_abc.py
+++ b/src/trio/_tests/test_abc.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import attr
+import attrs
 import pytest
 
 from .. import abc as tabc
@@ -30,9 +30,9 @@ def test_instrument_implements_hook_methods() -> None:
 
 
 async def test_AsyncResource_defaults() -> None:
-    @attr.s
+    @attrs.define(slots=False)
     class MyAR(tabc.AsyncResource):
-        record: list[str] = attr.field(factory=list)
+        record: list[str] = attrs.field(factory=list)
 
         async def aclose(self) -> None:
             self.record.append("ac")

--- a/src/trio/_tests/test_abc.py
+++ b/src/trio/_tests/test_abc.py
@@ -32,7 +32,7 @@ def test_instrument_implements_hook_methods() -> None:
 async def test_AsyncResource_defaults() -> None:
     @attrs.define(slots=False)
     class MyAR(tabc.AsyncResource):
-        record: list[str] = attrs.field(factory=list)
+        record: list[str] = attrs.Factory(list)
 
         async def aclose(self) -> None:
             self.record.append("ac")

--- a/src/trio/_tests/test_dtls.py
+++ b/src/trio/_tests/test_dtls.py
@@ -5,7 +5,7 @@ from contextlib import asynccontextmanager
 from itertools import count
 from typing import TYPE_CHECKING, NoReturn
 
-import attr
+import attrs
 import pytest
 
 from trio._tests.pytest_plugin import skip_if_optional_else_raise
@@ -160,7 +160,7 @@ async def test_handshake_over_terrible_network(
                     # elif op == "distort":
                     #     payload = bytearray(packet.payload)
                     #     payload[r.randrange(len(payload))] ^= 1 << r.randrange(8)
-                    #     packet = attr.evolve(packet, payload=payload)
+                    #     packet = attrs.evolve(packet, payload=payload)
                     else:
                         assert op == "deliver"
                         print(
@@ -485,7 +485,7 @@ async def test_invalid_cookie_rejected(autojump_clock: trio.abc.Clock) -> None:
                         offset = len(payload) - 1
                         cscope.cancel()
                     payload[offset] ^= 0x01
-                    packet = attr.evolve(packet, payload=payload)
+                    packet = attrs.evolve(packet, payload=payload)
 
             fn.deliver_packet(packet)
 

--- a/src/trio/_tests/test_highlevel_generic.py
+++ b/src/trio/_tests/test_highlevel_generic.py
@@ -9,7 +9,7 @@ from .._highlevel_generic import StapledStream
 from ..abc import ReceiveStream, SendStream
 
 
-@attr.s
+@attr.define(slots=False)
 class RecordSendStream(SendStream):
     record: list[str | tuple[str, object]] = attr.field(factory=list)
 
@@ -23,7 +23,7 @@ class RecordSendStream(SendStream):
         self.record.append("aclose")
 
 
-@attr.s
+@attr.define(slots=False)
 class RecordReceiveStream(ReceiveStream):
     record: list[str | tuple[str, int | None]] = attr.field(factory=list)
 

--- a/src/trio/_tests/test_highlevel_generic.py
+++ b/src/trio/_tests/test_highlevel_generic.py
@@ -11,7 +11,7 @@ from ..abc import ReceiveStream, SendStream
 
 @attr.s
 class RecordSendStream(SendStream):
-    record: list[str | tuple[str, object]] = attr.ib(factory=list)
+    record: list[str | tuple[str, object]] = attr.field(factory=list)
 
     async def send_all(self, data: object) -> None:
         self.record.append(("send_all", data))
@@ -25,7 +25,7 @@ class RecordSendStream(SendStream):
 
 @attr.s
 class RecordReceiveStream(ReceiveStream):
-    record: list[str | tuple[str, int | None]] = attr.ib(factory=list)
+    record: list[str | tuple[str, int | None]] = attr.field(factory=list)
 
     async def receive_some(self, max_bytes: int | None = None) -> bytes:
         self.record.append(("receive_some", max_bytes))

--- a/src/trio/_tests/test_highlevel_generic.py
+++ b/src/trio/_tests/test_highlevel_generic.py
@@ -11,7 +11,7 @@ from ..abc import ReceiveStream, SendStream
 
 @attrs.define(slots=False)
 class RecordSendStream(SendStream):
-    record: list[str | tuple[str, object]] = attrs.field(factory=list)
+    record: list[str | tuple[str, object]] = attrs.Factory(list)
 
     async def send_all(self, data: object) -> None:
         self.record.append(("send_all", data))
@@ -25,7 +25,7 @@ class RecordSendStream(SendStream):
 
 @attrs.define(slots=False)
 class RecordReceiveStream(ReceiveStream):
-    record: list[str | tuple[str, int | None]] = attrs.field(factory=list)
+    record: list[str | tuple[str, int | None]] = attrs.Factory(list)
 
     async def receive_some(self, max_bytes: int | None = None) -> bytes:
         self.record.append(("receive_some", max_bytes))

--- a/src/trio/_tests/test_highlevel_generic.py
+++ b/src/trio/_tests/test_highlevel_generic.py
@@ -2,16 +2,16 @@ from __future__ import annotations
 
 from typing import NoReturn
 
-import attr
+import attrs
 import pytest
 
 from .._highlevel_generic import StapledStream
 from ..abc import ReceiveStream, SendStream
 
 
-@attr.define(slots=False)
+@attrs.define(slots=False)
 class RecordSendStream(SendStream):
-    record: list[str | tuple[str, object]] = attr.field(factory=list)
+    record: list[str | tuple[str, object]] = attrs.field(factory=list)
 
     async def send_all(self, data: object) -> None:
         self.record.append(("send_all", data))
@@ -23,9 +23,9 @@ class RecordSendStream(SendStream):
         self.record.append("aclose")
 
 
-@attr.define(slots=False)
+@attrs.define(slots=False)
 class RecordReceiveStream(ReceiveStream):
-    record: list[str | tuple[str, int | None]] = attr.field(factory=list)
+    record: list[str | tuple[str, int | None]] = attrs.field(factory=list)
 
     async def receive_some(self, max_bytes: int | None = None) -> bytes:
         self.record.append(("receive_some", max_bytes))

--- a/src/trio/_tests/test_highlevel_open_tcp_listeners.py
+++ b/src/trio/_tests/test_highlevel_open_tcp_listeners.py
@@ -6,7 +6,7 @@ import sys
 from socket import AddressFamily, SocketKind
 from typing import TYPE_CHECKING, Any, Sequence, overload
 
-import attr
+import attrs
 import pytest
 
 import trio
@@ -132,15 +132,15 @@ class FakeOSError(OSError):
     pass
 
 
-@attr.define(slots=False)
+@attrs.define(slots=False)
 class FakeSocket(tsocket.SocketType):
-    _family: AddressFamily = attr.field(converter=AddressFamily)
-    _type: SocketKind = attr.field(converter=SocketKind)
-    _proto: int = attr.field()
+    _family: AddressFamily = attrs.field(converter=AddressFamily)
+    _type: SocketKind = attrs.field(converter=SocketKind)
+    _proto: int = attrs.field()
 
-    closed: bool = attr.field(default=False)
-    poison_listen: bool = attr.field(default=False)
-    backlog: int | None = attr.field(default=None)
+    closed: bool = attrs.field(default=False)
+    poison_listen: bool = attrs.field(default=False)
+    backlog: int | None = attrs.field(default=None)
 
     @property
     def type(self) -> SocketKind:
@@ -199,11 +199,11 @@ class FakeSocket(tsocket.SocketType):
         self.closed = True
 
 
-@attr.define(slots=False)
+@attrs.define(slots=False)
 class FakeSocketFactory(SocketFactory):
-    poison_after: int = attr.field()
-    sockets: list[tsocket.SocketType] = attr.field(factory=list)
-    raise_on_family: dict[AddressFamily, int] = attr.field(
+    poison_after: int = attrs.field()
+    sockets: list[tsocket.SocketType] = attrs.field(factory=list)
+    raise_on_family: dict[AddressFamily, int] = attrs.field(
         factory=dict
     )  # family => errno
 
@@ -227,9 +227,9 @@ class FakeSocketFactory(SocketFactory):
         return sock
 
 
-@attr.define(slots=False)
+@attrs.define(slots=False)
 class FakeHostnameResolver(HostnameResolver):
-    family_addr_pairs: Sequence[tuple[AddressFamily, str]] = attr.field()
+    family_addr_pairs: Sequence[tuple[AddressFamily, str]] = attrs.field()
 
     async def getaddrinfo(
         self,

--- a/src/trio/_tests/test_highlevel_open_tcp_listeners.py
+++ b/src/trio/_tests/test_highlevel_open_tcp_listeners.py
@@ -134,13 +134,13 @@ class FakeOSError(OSError):
 
 @attr.s
 class FakeSocket(tsocket.SocketType):
-    _family: AddressFamily = attr.ib(converter=AddressFamily)
-    _type: SocketKind = attr.ib(converter=SocketKind)
-    _proto: int = attr.ib()
+    _family: AddressFamily = attr.field(converter=AddressFamily)
+    _type: SocketKind = attr.field(converter=SocketKind)
+    _proto: int = attr.field()
 
-    closed: bool = attr.ib(default=False)
-    poison_listen: bool = attr.ib(default=False)
-    backlog: int | None = attr.ib(default=None)
+    closed: bool = attr.field(default=False)
+    poison_listen: bool = attr.field(default=False)
+    backlog: int | None = attr.field(default=None)
 
     @property
     def type(self) -> SocketKind:
@@ -201,9 +201,11 @@ class FakeSocket(tsocket.SocketType):
 
 @attr.s
 class FakeSocketFactory(SocketFactory):
-    poison_after: int = attr.ib()
-    sockets: list[tsocket.SocketType] = attr.ib(factory=list)
-    raise_on_family: dict[AddressFamily, int] = attr.ib(factory=dict)  # family => errno
+    poison_after: int = attr.field()
+    sockets: list[tsocket.SocketType] = attr.field(factory=list)
+    raise_on_family: dict[AddressFamily, int] = attr.field(
+        factory=dict
+    )  # family => errno
 
     def socket(
         self,
@@ -227,7 +229,7 @@ class FakeSocketFactory(SocketFactory):
 
 @attr.s
 class FakeHostnameResolver(HostnameResolver):
-    family_addr_pairs: Sequence[tuple[AddressFamily, str]] = attr.ib()
+    family_addr_pairs: Sequence[tuple[AddressFamily, str]] = attr.field()
 
     async def getaddrinfo(
         self,

--- a/src/trio/_tests/test_highlevel_open_tcp_listeners.py
+++ b/src/trio/_tests/test_highlevel_open_tcp_listeners.py
@@ -202,10 +202,8 @@ class FakeSocket(tsocket.SocketType):
 @attrs.define(slots=False)
 class FakeSocketFactory(SocketFactory):
     poison_after: int
-    sockets: list[tsocket.SocketType] = attrs.field(factory=list)
-    raise_on_family: dict[AddressFamily, int] = attrs.field(
-        factory=dict
-    )  # family => errno
+    sockets: list[tsocket.SocketType] = attrs.Factory(list)
+    raise_on_family: dict[AddressFamily, int] = attrs.Factory(dict)  # family => errno
 
     def socket(
         self,

--- a/src/trio/_tests/test_highlevel_open_tcp_listeners.py
+++ b/src/trio/_tests/test_highlevel_open_tcp_listeners.py
@@ -138,9 +138,9 @@ class FakeSocket(tsocket.SocketType):
     _type: SocketKind = attrs.field(converter=SocketKind)
     _proto: int
 
-    closed: bool = attrs.field(default=False)
-    poison_listen: bool = attrs.field(default=False)
-    backlog: int | None = attrs.field(default=None)
+    closed: bool = False
+    poison_listen: bool = False
+    backlog: int | None = None
 
     @property
     def type(self) -> SocketKind:

--- a/src/trio/_tests/test_highlevel_open_tcp_listeners.py
+++ b/src/trio/_tests/test_highlevel_open_tcp_listeners.py
@@ -136,7 +136,7 @@ class FakeOSError(OSError):
 class FakeSocket(tsocket.SocketType):
     _family: AddressFamily = attrs.field(converter=AddressFamily)
     _type: SocketKind = attrs.field(converter=SocketKind)
-    _proto: int = attrs.field()
+    _proto: int
 
     closed: bool = attrs.field(default=False)
     poison_listen: bool = attrs.field(default=False)
@@ -201,7 +201,7 @@ class FakeSocket(tsocket.SocketType):
 
 @attrs.define(slots=False)
 class FakeSocketFactory(SocketFactory):
-    poison_after: int = attrs.field()
+    poison_after: int
     sockets: list[tsocket.SocketType] = attrs.field(factory=list)
     raise_on_family: dict[AddressFamily, int] = attrs.field(
         factory=dict
@@ -229,7 +229,7 @@ class FakeSocketFactory(SocketFactory):
 
 @attrs.define(slots=False)
 class FakeHostnameResolver(HostnameResolver):
-    family_addr_pairs: Sequence[tuple[AddressFamily, str]] = attrs.field()
+    family_addr_pairs: Sequence[tuple[AddressFamily, str]]
 
     async def getaddrinfo(
         self,

--- a/src/trio/_tests/test_highlevel_open_tcp_listeners.py
+++ b/src/trio/_tests/test_highlevel_open_tcp_listeners.py
@@ -132,7 +132,7 @@ class FakeOSError(OSError):
     pass
 
 
-@attr.s
+@attr.define(slots=False)
 class FakeSocket(tsocket.SocketType):
     _family: AddressFamily = attr.field(converter=AddressFamily)
     _type: SocketKind = attr.field(converter=SocketKind)
@@ -199,7 +199,7 @@ class FakeSocket(tsocket.SocketType):
         self.closed = True
 
 
-@attr.s
+@attr.define(slots=False)
 class FakeSocketFactory(SocketFactory):
     poison_after: int = attr.field()
     sockets: list[tsocket.SocketType] = attr.field(factory=list)
@@ -227,7 +227,7 @@ class FakeSocketFactory(SocketFactory):
         return sock
 
 
-@attr.s
+@attr.define(slots=False)
 class FakeHostnameResolver(HostnameResolver):
     family_addr_pairs: Sequence[tuple[AddressFamily, str]] = attr.field()
 

--- a/src/trio/_tests/test_highlevel_open_tcp_stream.py
+++ b/src/trio/_tests/test_highlevel_open_tcp_stream.py
@@ -5,7 +5,7 @@ import sys
 from socket import AddressFamily, SocketKind
 from typing import TYPE_CHECKING, Any, Sequence
 
-import attr
+import attrs
 import pytest
 
 import trio
@@ -188,18 +188,18 @@ async def test_local_address_real() -> None:
 # Now, thorough tests using fake sockets
 
 
-@attr.define(eq=False, slots=False)
+@attrs.define(eq=False, slots=False)
 class FakeSocket(trio.socket.SocketType):
-    scenario: Scenario = attr.field()
-    _family: AddressFamily = attr.field()
-    _type: SocketKind = attr.field()
-    _proto: int = attr.field()
+    scenario: Scenario = attrs.field()
+    _family: AddressFamily = attrs.field()
+    _type: SocketKind = attrs.field()
+    _proto: int = attrs.field()
 
-    ip: str | int | None = attr.field(default=None)
-    port: str | int | None = attr.field(default=None)
-    succeeded: bool = attr.field(default=False)
-    closed: bool = attr.field(default=False)
-    failing: bool = attr.field(default=False)
+    ip: str | int | None = attrs.field(default=None)
+    port: str | int | None = attrs.field(default=None)
+    succeeded: bool = attrs.field(default=False)
+    closed: bool = attrs.field(default=False)
+    failing: bool = attrs.field(default=False)
 
     @property
     def type(self) -> SocketKind:

--- a/src/trio/_tests/test_highlevel_open_tcp_stream.py
+++ b/src/trio/_tests/test_highlevel_open_tcp_stream.py
@@ -195,11 +195,11 @@ class FakeSocket(trio.socket.SocketType):
     _type: SocketKind
     _proto: int
 
-    ip: str | int | None = attrs.field(default=None)
-    port: str | int | None = attrs.field(default=None)
-    succeeded: bool = attrs.field(default=False)
-    closed: bool = attrs.field(default=False)
-    failing: bool = attrs.field(default=False)
+    ip: str | int | None = None
+    port: str | int | None = None
+    succeeded: bool = False
+    closed: bool = False
+    failing: bool = False
 
     @property
     def type(self) -> SocketKind:

--- a/src/trio/_tests/test_highlevel_open_tcp_stream.py
+++ b/src/trio/_tests/test_highlevel_open_tcp_stream.py
@@ -190,16 +190,16 @@ async def test_local_address_real() -> None:
 
 @attr.s(eq=False)
 class FakeSocket(trio.socket.SocketType):
-    scenario: Scenario = attr.ib()
-    _family: AddressFamily = attr.ib()
-    _type: SocketKind = attr.ib()
-    _proto: int = attr.ib()
+    scenario: Scenario = attr.field()
+    _family: AddressFamily = attr.field()
+    _type: SocketKind = attr.field()
+    _proto: int = attr.field()
 
-    ip: str | int | None = attr.ib(default=None)
-    port: str | int | None = attr.ib(default=None)
-    succeeded: bool = attr.ib(default=False)
-    closed: bool = attr.ib(default=False)
-    failing: bool = attr.ib(default=False)
+    ip: str | int | None = attr.field(default=None)
+    port: str | int | None = attr.field(default=None)
+    succeeded: bool = attr.field(default=False)
+    closed: bool = attr.field(default=False)
+    failing: bool = attr.field(default=False)
 
     @property
     def type(self) -> SocketKind:

--- a/src/trio/_tests/test_highlevel_open_tcp_stream.py
+++ b/src/trio/_tests/test_highlevel_open_tcp_stream.py
@@ -188,7 +188,7 @@ async def test_local_address_real() -> None:
 # Now, thorough tests using fake sockets
 
 
-@attr.s(eq=False)
+@attr.define(eq=False, slots=False)
 class FakeSocket(trio.socket.SocketType):
     scenario: Scenario = attr.field()
     _family: AddressFamily = attr.field()

--- a/src/trio/_tests/test_highlevel_open_tcp_stream.py
+++ b/src/trio/_tests/test_highlevel_open_tcp_stream.py
@@ -190,10 +190,10 @@ async def test_local_address_real() -> None:
 
 @attrs.define(eq=False, slots=False)
 class FakeSocket(trio.socket.SocketType):
-    scenario: Scenario = attrs.field()
-    _family: AddressFamily = attrs.field()
-    _type: SocketKind = attrs.field()
-    _proto: int = attrs.field()
+    scenario: Scenario
+    _family: AddressFamily
+    _type: SocketKind
+    _proto: int
 
     ip: str | int | None = attrs.field(default=None)
     port: str | int | None = attrs.field(default=None)

--- a/src/trio/_tests/test_highlevel_serve_listeners.py
+++ b/src/trio/_tests/test_highlevel_serve_listeners.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 StapledMemoryStream = StapledStream[MemorySendStream, MemoryReceiveStream]
 
 
-@attr.s(hash=False, eq=False)
+@attr.define(hash=False, eq=False, slots=False)
 class MemoryListener(trio.abc.Listener[StapledMemoryStream]):
     closed: bool = attr.field(default=False)
     accepted_streams: list[trio.abc.Stream] = attr.field(factory=list)

--- a/src/trio/_tests/test_highlevel_serve_listeners.py
+++ b/src/trio/_tests/test_highlevel_serve_listeners.py
@@ -31,13 +31,13 @@ StapledMemoryStream = StapledStream[MemorySendStream, MemoryReceiveStream]
 
 @attr.s(hash=False, eq=False)
 class MemoryListener(trio.abc.Listener[StapledMemoryStream]):
-    closed: bool = attr.ib(default=False)
-    accepted_streams: list[trio.abc.Stream] = attr.ib(factory=list)
+    closed: bool = attr.field(default=False)
+    accepted_streams: list[trio.abc.Stream] = attr.field(factory=list)
     queued_streams: tuple[
         MemorySendChannel[StapledMemoryStream],
         MemoryReceiveChannel[StapledMemoryStream],
-    ] = attr.ib(factory=(lambda: trio.open_memory_channel[StapledMemoryStream](1)))
-    accept_hook: Callable[[], Awaitable[object]] | None = attr.ib(default=None)
+    ] = attr.field(factory=(lambda: trio.open_memory_channel[StapledMemoryStream](1)))
+    accept_hook: Callable[[], Awaitable[object]] | None = attr.field(default=None)
 
     async def connect(self) -> StapledMemoryStream:
         assert not self.closed

--- a/src/trio/_tests/test_highlevel_serve_listeners.py
+++ b/src/trio/_tests/test_highlevel_serve_listeners.py
@@ -4,7 +4,7 @@ import errno
 from functools import partial
 from typing import TYPE_CHECKING, Awaitable, Callable, NoReturn
 
-import attr
+import attrs
 
 import trio
 from trio import Nursery, StapledStream, TaskStatus
@@ -29,15 +29,15 @@ if TYPE_CHECKING:
 StapledMemoryStream = StapledStream[MemorySendStream, MemoryReceiveStream]
 
 
-@attr.define(hash=False, eq=False, slots=False)
+@attrs.define(hash=False, eq=False, slots=False)
 class MemoryListener(trio.abc.Listener[StapledMemoryStream]):
-    closed: bool = attr.field(default=False)
-    accepted_streams: list[trio.abc.Stream] = attr.field(factory=list)
+    closed: bool = attrs.field(default=False)
+    accepted_streams: list[trio.abc.Stream] = attrs.field(factory=list)
     queued_streams: tuple[
         MemorySendChannel[StapledMemoryStream],
         MemoryReceiveChannel[StapledMemoryStream],
-    ] = attr.field(factory=(lambda: trio.open_memory_channel[StapledMemoryStream](1)))
-    accept_hook: Callable[[], Awaitable[object]] | None = attr.field(default=None)
+    ] = attrs.field(factory=(lambda: trio.open_memory_channel[StapledMemoryStream](1)))
+    accept_hook: Callable[[], Awaitable[object]] | None = attrs.field(default=None)
 
     async def connect(self) -> StapledMemoryStream:
         assert not self.closed

--- a/src/trio/_tests/test_highlevel_serve_listeners.py
+++ b/src/trio/_tests/test_highlevel_serve_listeners.py
@@ -32,11 +32,11 @@ StapledMemoryStream = StapledStream[MemorySendStream, MemoryReceiveStream]
 @attrs.define(hash=False, eq=False, slots=False)
 class MemoryListener(trio.abc.Listener[StapledMemoryStream]):
     closed: bool = attrs.field(default=False)
-    accepted_streams: list[trio.abc.Stream] = attrs.field(factory=list)
+    accepted_streams: list[trio.abc.Stream] = attrs.Factory(list)
     queued_streams: tuple[
         MemorySendChannel[StapledMemoryStream],
         MemoryReceiveChannel[StapledMemoryStream],
-    ] = attrs.field(factory=(lambda: trio.open_memory_channel[StapledMemoryStream](1)))
+    ] = attrs.Factory(lambda: trio.open_memory_channel[StapledMemoryStream](1))
     accept_hook: Callable[[], Awaitable[object]] | None = attrs.field(default=None)
 
     async def connect(self) -> StapledMemoryStream:

--- a/src/trio/_tests/test_highlevel_serve_listeners.py
+++ b/src/trio/_tests/test_highlevel_serve_listeners.py
@@ -31,13 +31,13 @@ StapledMemoryStream = StapledStream[MemorySendStream, MemoryReceiveStream]
 
 @attrs.define(hash=False, eq=False, slots=False)
 class MemoryListener(trio.abc.Listener[StapledMemoryStream]):
-    closed: bool = attrs.field(default=False)
+    closed: bool = False
     accepted_streams: list[trio.abc.Stream] = attrs.Factory(list)
     queued_streams: tuple[
         MemorySendChannel[StapledMemoryStream],
         MemoryReceiveChannel[StapledMemoryStream],
     ] = attrs.Factory(lambda: trio.open_memory_channel[StapledMemoryStream](1))
-    accept_hook: Callable[[], Awaitable[object]] | None = attrs.field(default=None)
+    accept_hook: Callable[[], Awaitable[object]] | None = None
 
     async def connect(self) -> StapledMemoryStream:
         assert not self.closed

--- a/src/trio/_tests/test_highlevel_ssl_helpers.py
+++ b/src/trio/_tests/test_highlevel_ssl_helpers.py
@@ -43,7 +43,7 @@ async def echo_handler(stream: Stream) -> None:
 
 # Resolver that always returns the given sockaddr, no matter what host/port
 # you ask for.
-@attr.s
+@attr.define(slots=False)
 class FakeHostnameResolver(trio.abc.HostnameResolver):
     sockaddr: tuple[str, int] | tuple[str, int, int, int] = attr.field()
 

--- a/src/trio/_tests/test_highlevel_ssl_helpers.py
+++ b/src/trio/_tests/test_highlevel_ssl_helpers.py
@@ -45,7 +45,7 @@ async def echo_handler(stream: Stream) -> None:
 # you ask for.
 @attrs.define(slots=False)
 class FakeHostnameResolver(trio.abc.HostnameResolver):
-    sockaddr: tuple[str, int] | tuple[str, int, int, int] = attrs.field()
+    sockaddr: tuple[str, int] | tuple[str, int, int, int]
 
     async def getaddrinfo(
         self,

--- a/src/trio/_tests/test_highlevel_ssl_helpers.py
+++ b/src/trio/_tests/test_highlevel_ssl_helpers.py
@@ -45,7 +45,7 @@ async def echo_handler(stream: Stream) -> None:
 # you ask for.
 @attr.s
 class FakeHostnameResolver(trio.abc.HostnameResolver):
-    sockaddr: tuple[str, int] | tuple[str, int, int, int] = attr.ib()
+    sockaddr: tuple[str, int] | tuple[str, int, int, int] = attr.field()
 
     async def getaddrinfo(
         self,

--- a/src/trio/_tests/test_highlevel_ssl_helpers.py
+++ b/src/trio/_tests/test_highlevel_ssl_helpers.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from functools import partial
 from typing import TYPE_CHECKING, Any, NoReturn
 
-import attr
+import attrs
 import pytest
 
 import trio
@@ -43,9 +43,9 @@ async def echo_handler(stream: Stream) -> None:
 
 # Resolver that always returns the given sockaddr, no matter what host/port
 # you ask for.
-@attr.define(slots=False)
+@attrs.define(slots=False)
 class FakeHostnameResolver(trio.abc.HostnameResolver):
-    sockaddr: tuple[str, int] | tuple[str, int, int, int] = attr.field()
+    sockaddr: tuple[str, int] | tuple[str, int, int, int] = attrs.field()
 
     async def getaddrinfo(
         self,

--- a/src/trio/_tests/test_socket.py
+++ b/src/trio/_tests/test_socket.py
@@ -512,7 +512,7 @@ def gai_without_v4mapped_is_buggy() -> bool:  # pragma: no cover
         return True
 
 
-@attr.s
+@attr.define(slots=False)
 class Addresses:
     bind_all: str = attr.field()
     localhost: str = attr.field()

--- a/src/trio/_tests/test_socket.py
+++ b/src/trio/_tests/test_socket.py
@@ -514,10 +514,10 @@ def gai_without_v4mapped_is_buggy() -> bool:  # pragma: no cover
 
 @attr.s
 class Addresses:
-    bind_all: str = attr.ib()
-    localhost: str = attr.ib()
-    arbitrary: str = attr.ib()
-    broadcast: str = attr.ib()
+    bind_all: str = attr.field()
+    localhost: str = attr.field()
+    arbitrary: str = attr.field()
+    broadcast: str = attr.field()
 
 
 # Direct thorough tests of the implicit resolver helpers

--- a/src/trio/_tests/test_socket.py
+++ b/src/trio/_tests/test_socket.py
@@ -514,10 +514,10 @@ def gai_without_v4mapped_is_buggy() -> bool:  # pragma: no cover
 
 @attrs.define(slots=False)
 class Addresses:
-    bind_all: str = attrs.field()
-    localhost: str = attrs.field()
-    arbitrary: str = attrs.field()
-    broadcast: str = attrs.field()
+    bind_all: str
+    localhost: str
+    arbitrary: str
+    broadcast: str
 
 
 # Direct thorough tests of the implicit resolver helpers

--- a/src/trio/_tests/test_socket.py
+++ b/src/trio/_tests/test_socket.py
@@ -9,7 +9,7 @@ import tempfile
 from socket import AddressFamily, SocketKind
 from typing import TYPE_CHECKING, Any, Callable, List, Tuple, Union
 
-import attr
+import attrs
 import pytest
 
 from .. import _core, socket as tsocket
@@ -512,12 +512,12 @@ def gai_without_v4mapped_is_buggy() -> bool:  # pragma: no cover
         return True
 
 
-@attr.define(slots=False)
+@attrs.define(slots=False)
 class Addresses:
-    bind_all: str = attr.field()
-    localhost: str = attr.field()
-    arbitrary: str = attr.field()
-    broadcast: str = attr.field()
+    bind_all: str = attrs.field()
+    localhost: str = attrs.field()
+    arbitrary: str = attrs.field()
+    broadcast: str = attrs.field()
 
 
 # Direct thorough tests of the implicit resolver helpers

--- a/src/trio/_threads.py
+++ b/src/trio/_threads.py
@@ -74,16 +74,18 @@ def current_default_thread_limiter() -> CapacityLimiter:
 # keep track of who's holding the CapacityLimiter's token.
 @attr.s(frozen=True, eq=False, hash=False)
 class ThreadPlaceholder:
-    name: str = attr.ib()
+    name: str = attr.field()
 
 
 # Types for the to_thread_run_sync message loop
 @attr.s(frozen=True, eq=False)
 class Run(Generic[RetT]):
-    afn: Callable[..., Awaitable[RetT]] = attr.ib()
-    args: tuple[object, ...] = attr.ib()
-    context: contextvars.Context = attr.ib(init=False, factory=contextvars.copy_context)
-    queue: stdlib_queue.SimpleQueue[outcome.Outcome[RetT]] = attr.ib(
+    afn: Callable[..., Awaitable[RetT]] = attr.field()
+    args: tuple[object, ...] = attr.field()
+    context: contextvars.Context = attr.field(
+        init=False, factory=contextvars.copy_context
+    )
+    queue: stdlib_queue.SimpleQueue[outcome.Outcome[RetT]] = attr.field(
         init=False, factory=stdlib_queue.SimpleQueue
     )
 
@@ -133,10 +135,12 @@ class Run(Generic[RetT]):
 
 @attr.s(frozen=True, eq=False)
 class RunSync(Generic[RetT]):
-    fn: Callable[..., RetT] = attr.ib()
-    args: tuple[object, ...] = attr.ib()
-    context: contextvars.Context = attr.ib(init=False, factory=contextvars.copy_context)
-    queue: stdlib_queue.SimpleQueue[outcome.Outcome[RetT]] = attr.ib(
+    fn: Callable[..., RetT] = attr.field()
+    args: tuple[object, ...] = attr.field()
+    context: contextvars.Context = attr.field(
+        init=False, factory=contextvars.copy_context
+    )
+    queue: stdlib_queue.SimpleQueue[outcome.Outcome[RetT]] = attr.field(
         init=False, factory=stdlib_queue.SimpleQueue
     )
 

--- a/src/trio/_threads.py
+++ b/src/trio/_threads.py
@@ -72,13 +72,13 @@ def current_default_thread_limiter() -> CapacityLimiter:
 # system; see https://github.com/python-trio/trio/issues/182
 # But for now we just need an object to stand in for the thread, so we can
 # keep track of who's holding the CapacityLimiter's token.
-@attr.s(frozen=True, eq=False, hash=False)
+@attr.frozen(eq=False, hash=False, slots=False)
 class ThreadPlaceholder:
     name: str = attr.field()
 
 
 # Types for the to_thread_run_sync message loop
-@attr.s(frozen=True, eq=False)
+@attr.frozen(eq=False, slots=False)
 class Run(Generic[RetT]):
     afn: Callable[..., Awaitable[RetT]] = attr.field()
     args: tuple[object, ...] = attr.field()
@@ -133,7 +133,7 @@ class Run(Generic[RetT]):
         token.run_sync_soon(in_trio_thread)
 
 
-@attr.s(frozen=True, eq=False)
+@attr.frozen(eq=False, slots=False)
 class RunSync(Generic[RetT]):
     fn: Callable[..., RetT] = attr.field()
     args: tuple[object, ...] = attr.field()

--- a/src/trio/_threads.py
+++ b/src/trio/_threads.py
@@ -8,7 +8,7 @@ import threading
 from itertools import count
 from typing import TYPE_CHECKING, Generic, TypeVar, overload
 
-import attr
+import attrs
 import outcome
 from sniffio import current_async_library_cvar
 
@@ -72,20 +72,20 @@ def current_default_thread_limiter() -> CapacityLimiter:
 # system; see https://github.com/python-trio/trio/issues/182
 # But for now we just need an object to stand in for the thread, so we can
 # keep track of who's holding the CapacityLimiter's token.
-@attr.frozen(eq=False, hash=False, slots=False)
+@attrs.frozen(eq=False, hash=False, slots=False)
 class ThreadPlaceholder:
-    name: str = attr.field()
+    name: str = attrs.field()
 
 
 # Types for the to_thread_run_sync message loop
-@attr.frozen(eq=False, slots=False)
+@attrs.frozen(eq=False, slots=False)
 class Run(Generic[RetT]):
-    afn: Callable[..., Awaitable[RetT]] = attr.field()
-    args: tuple[object, ...] = attr.field()
-    context: contextvars.Context = attr.field(
+    afn: Callable[..., Awaitable[RetT]] = attrs.field()
+    args: tuple[object, ...] = attrs.field()
+    context: contextvars.Context = attrs.field(
         init=False, factory=contextvars.copy_context
     )
-    queue: stdlib_queue.SimpleQueue[outcome.Outcome[RetT]] = attr.field(
+    queue: stdlib_queue.SimpleQueue[outcome.Outcome[RetT]] = attrs.field(
         init=False, factory=stdlib_queue.SimpleQueue
     )
 
@@ -133,14 +133,14 @@ class Run(Generic[RetT]):
         token.run_sync_soon(in_trio_thread)
 
 
-@attr.frozen(eq=False, slots=False)
+@attrs.frozen(eq=False, slots=False)
 class RunSync(Generic[RetT]):
-    fn: Callable[..., RetT] = attr.field()
-    args: tuple[object, ...] = attr.field()
-    context: contextvars.Context = attr.field(
+    fn: Callable[..., RetT] = attrs.field()
+    args: tuple[object, ...] = attrs.field()
+    context: contextvars.Context = attrs.field(
         init=False, factory=contextvars.copy_context
     )
-    queue: stdlib_queue.SimpleQueue[outcome.Outcome[RetT]] = attr.field(
+    queue: stdlib_queue.SimpleQueue[outcome.Outcome[RetT]] = attrs.field(
         init=False, factory=stdlib_queue.SimpleQueue
     )
 

--- a/src/trio/_threads.py
+++ b/src/trio/_threads.py
@@ -74,14 +74,14 @@ def current_default_thread_limiter() -> CapacityLimiter:
 # keep track of who's holding the CapacityLimiter's token.
 @attrs.frozen(eq=False, hash=False, slots=False)
 class ThreadPlaceholder:
-    name: str = attrs.field()
+    name: str
 
 
 # Types for the to_thread_run_sync message loop
 @attrs.frozen(eq=False, slots=False)
 class Run(Generic[RetT]):
-    afn: Callable[..., Awaitable[RetT]] = attrs.field()
-    args: tuple[object, ...] = attrs.field()
+    afn: Callable[..., Awaitable[RetT]]
+    args: tuple[object, ...]
     context: contextvars.Context = attrs.field(
         init=False, factory=contextvars.copy_context
     )
@@ -135,8 +135,8 @@ class Run(Generic[RetT]):
 
 @attrs.frozen(eq=False, slots=False)
 class RunSync(Generic[RetT]):
-    fn: Callable[..., RetT] = attrs.field()
-    args: tuple[object, ...] = attrs.field()
+    fn: Callable[..., RetT]
+    args: tuple[object, ...]
     context: contextvars.Context = attrs.field(
         init=False, factory=contextvars.copy_context
     )

--- a/src/trio/_tools/gen_exports.py
+++ b/src/trio/_tools/gen_exports.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from textwrap import indent
 from typing import TYPE_CHECKING
 
-import attr
+import attrs
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
@@ -44,12 +44,12 @@ except AttributeError:
 """
 
 
-@attr.define
+@attrs.define
 class File:
     path: Path
     modname: str
-    platform: str = attr.field(default="", kw_only=True)
-    imports: str = attr.field(default="", kw_only=True)
+    platform: str = attrs.field(default="", kw_only=True)
+    imports: str = attrs.field(default="", kw_only=True)
 
 
 def is_function(node: ast.AST) -> TypeGuard[ast.FunctionDef | ast.AsyncFunctionDef]:

--- a/src/trio/testing/_fake_net.py
+++ b/src/trio/testing/_fake_net.py
@@ -24,7 +24,7 @@ from typing import (
     overload,
 )
 
-import attr
+import attrs
 
 import trio
 from trio._util import NoPublicConstructor, final
@@ -83,7 +83,7 @@ def _scatter(data: bytes, buffers: Iterable[Buffer]) -> int:
 T_UDPEndpoint = TypeVar("T_UDPEndpoint", bound="UDPEndpoint")
 
 
-@attr.frozen
+@attrs.frozen
 class UDPEndpoint:
     ip: IPAddress
     port: int
@@ -105,17 +105,17 @@ class UDPEndpoint:
         return cls(ip=ipaddress.ip_address(ip), port=port)
 
 
-@attr.frozen
+@attrs.frozen
 class UDPBinding:
     local: UDPEndpoint
     # remote: UDPEndpoint # ??
 
 
-@attr.frozen
+@attrs.frozen
 class UDPPacket:
     source: UDPEndpoint
     destination: UDPEndpoint
-    payload: bytes = attr.field(repr=lambda p: p.hex())
+    payload: bytes = attrs.field(repr=lambda p: p.hex())
 
     # not used/tested anywhere
     def reply(self, payload: bytes) -> UDPPacket:  # pragma: no cover
@@ -124,7 +124,7 @@ class UDPPacket:
         )
 
 
-@attr.frozen
+@attrs.frozen
 class FakeSocketFactory(trio.abc.SocketFactory):
     fake_net: FakeNet
 
@@ -132,7 +132,7 @@ class FakeSocketFactory(trio.abc.SocketFactory):
         return FakeSocket._create(self.fake_net, family, type_, proto)
 
 
-@attr.frozen
+@attrs.frozen
 class FakeHostnameResolver(trio.abc.HostnameResolver):
     fake_net: FakeNet
 

--- a/src/trio/testing/_fake_net.py
+++ b/src/trio/testing/_fake_net.py
@@ -115,7 +115,7 @@ class UDPBinding:
 class UDPPacket:
     source: UDPEndpoint
     destination: UDPEndpoint
-    payload: bytes = attr.ib(repr=lambda p: p.hex())
+    payload: bytes = attr.field(repr=lambda p: p.hex())
 
     # not used/tested anywhere
     def reply(self, payload: bytes) -> UDPPacket:  # pragma: no cover

--- a/src/trio/testing/_sequencer.py
+++ b/src/trio/testing/_sequencer.py
@@ -54,11 +54,11 @@ class Sequencer:
 
     """
 
-    _sequence_points: defaultdict[int, Event] = attr.ib(
+    _sequence_points: defaultdict[int, Event] = attr.field(
         factory=lambda: defaultdict(Event), init=False
     )
-    _claimed: set[int] = attr.ib(factory=set, init=False)
-    _broken: bool = attr.ib(default=False, init=False)
+    _claimed: set[int] = attr.field(factory=set, init=False)
+    _broken: bool = attr.field(default=False, init=False)
 
     @asynccontextmanager
     async def __call__(self, position: int) -> AsyncIterator[None]:

--- a/src/trio/testing/_sequencer.py
+++ b/src/trio/testing/_sequencer.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 
 @_util.final
-@attr.s(eq=False, hash=False)
+@attr.define(eq=False, hash=False, slots=False)
 class Sequencer:
     """A convenience class for forcing code in different tasks to run in an
     explicit linear order.

--- a/src/trio/testing/_sequencer.py
+++ b/src/trio/testing/_sequencer.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
 
-import attr
+import attrs
 
 from .. import Event, _core, _util
 
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 
 @_util.final
-@attr.define(eq=False, hash=False, slots=False)
+@attrs.define(eq=False, hash=False, slots=False)
 class Sequencer:
     """A convenience class for forcing code in different tasks to run in an
     explicit linear order.
@@ -54,11 +54,11 @@ class Sequencer:
 
     """
 
-    _sequence_points: defaultdict[int, Event] = attr.field(
+    _sequence_points: defaultdict[int, Event] = attrs.field(
         factory=lambda: defaultdict(Event), init=False
     )
-    _claimed: set[int] = attr.field(factory=set, init=False)
-    _broken: bool = attr.field(default=False, init=False)
+    _claimed: set[int] = attrs.field(factory=set, init=False)
+    _broken: bool = attrs.field(default=False, init=False)
 
     @asynccontextmanager
     async def __call__(self, position: int) -> AsyncIterator[None]:

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -28,7 +28,7 @@ sphinx
 
 # Trio's own dependencies
 cffi; os_name == "nt"
-attrs >= 20.1.0
+attrs >= 21.2.0
 sortedcontainers
 idna
 outcome

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -28,7 +28,7 @@ sphinx
 
 # Trio's own dependencies
 cffi; os_name == "nt"
-attrs >= 21.2.0
+attrs >= 23.2.0
 sortedcontainers
 idna
 outcome

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -22,7 +22,7 @@ black==24.1.1 ; implementation_name == "cpython"
     # via -r test-requirements.in
 build==1.0.3
     # via pip-tools
-certifi==2023.11.17
+certifi==2024.2.2
     # via requests
 cffi==1.16.0
     # via cryptography
@@ -69,7 +69,7 @@ jedi==0.19.1
     # via -r test-requirements.in
 jinja2==3.1.3
     # via sphinx
-markupsafe==2.1.4
+markupsafe==2.1.5
     # via jinja2
 mccabe==0.7.0
     # via pylint
@@ -116,11 +116,11 @@ pyright==1.1.349
     # via -r test-requirements.in
 pytest==8.0.0
     # via -r test-requirements.in
-pytz==2023.4
+pytz==2024.1
     # via babel
 requests==2.31.0
     # via sphinx
-ruff==0.1.15
+ruff==0.2.0
     # via -r test-requirements.in
 sniffio==1.3.0
     # via -r test-requirements.in
@@ -157,7 +157,7 @@ trustme==1.1.0
     # via -r test-requirements.in
 types-cffi==1.16.0.20240106 ; implementation_name == "cpython"
     # via -r test-requirements.in
-types-docutils==0.20.0.20240126
+types-docutils==0.20.0.20240201
     # via -r test-requirements.in
 types-pyopenssl==24.0.0.20240130 ; implementation_name == "cpython"
     # via -r test-requirements.in


### PR DESCRIPTION
[The changes related to this update fall into three categories:
1. `attrs>=23.2.0` is now required (based on [this comment thread](https://github.com/python-trio/trio/pull/2945#pullrequestreview-1861112927) plus needing to bump to at _least_ 22.2.0 anyway to support Pyright).
2. Adds non-underscored aliases for a few selected private (i.e. leading underscore) attributes in `CancelStatus` and `CancelScope` (this is required for Pyright to recognize private attributes as constructor kwargs).
3. Switching to the "NG" interfaces in recent versions of `attrs` per previous chat discussion.
  - `import attr` -> `import attrs` everywhere
  - `attr.ib` -> `attrs.field`
  - `attr.s` -> `attrs.define` or `attrs.frozen`, depending on existing `frozen` kwarg and with adjustments made to all calls to account for `slots=True` now being the default).
  - `attrs.field(factory=X)` -> `attrs.Factory(X)`
  - `attrs.field(default=X)` -> simply assign X
4. One typing correction that was uncovered by that last "NG" update (see [related comment](https://github.com/python-trio/trio/pull/2945#issuecomment-1925577702)).

Note: there's no new logic to be tested. All existing tests pass unchanged (except for non-logic name changes resulting from item 3 above).