### PR TITLE
Enable ruff's `flake8-trio` rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ select = [
     "RUF",   # Ruff-specific rules
     "SIM",   # flake8-simplify
     "TCH",   # flake8-type-checking
+    "TRIO",  # flake8-trio
     "UP",    # pyupgrade
     "W",     # Warning
     "YTT",   # flake8-2020

--- a/src/trio/_core/_tests/test_guest_mode.py
+++ b/src/trio/_core/_tests/test_guest_mode.py
@@ -111,7 +111,7 @@ def trivial_guest_run(
 
 def test_guest_trivial() -> None:
     async def trio_return(in_host: InHost) -> str:
-        await trio.sleep(0)
+        await trio.lowlevel.checkpoint()
         return "ok"
 
     assert trivial_guest_run(trio_return) == "ok"
@@ -149,7 +149,7 @@ def test_guest_is_initialized_when_start_returns() -> None:
 
     async def trio_main(in_host: InHost) -> str:
         record.append("main task ran")
-        await trio.sleep(0)
+        await trio.lowlevel.checkpoint()
         assert trio.lowlevel.current_trio_token() is trio_token
         return "ok"
 
@@ -164,7 +164,7 @@ def test_guest_is_initialized_when_start_returns() -> None:
         @trio.lowlevel.spawn_system_task
         async def early_task() -> None:
             record.append("system task ran")
-            await trio.sleep(0)
+            await trio.lowlevel.checkpoint()
 
     res = trivial_guest_run(trio_main, in_host_after_start=after_start)
     assert res == "ok"
@@ -396,7 +396,7 @@ def test_guest_warns_if_abandoned() -> None:
         async def abandoned_main(in_host: InHost) -> None:
             in_host(lambda: 1 / 0)
             while True:
-                await trio.sleep(0)
+                await trio.lowlevel.checkpoint()
 
         with pytest.raises(ZeroDivisionError):
             trivial_guest_run(abandoned_main)
@@ -472,7 +472,7 @@ def test_guest_mode_on_asyncio() -> None:
 
         # Make sure we have at least one tick where we don't need to go into
         # the thread
-        await trio.sleep(0)
+        await trio.lowlevel.checkpoint()
 
         from_trio.put_nowait(0)
 
@@ -540,7 +540,7 @@ def test_guest_mode_internal_errors(
 
         async def crash_in_io(in_host: InHost) -> None:
             m.setattr("trio._core._run.TheIOManager.get_events", None)
-            await trio.sleep(0)
+            await trio.lowlevel.checkpoint()
 
         with pytest.raises(trio.TrioInternalError):
             trivial_guest_run(crash_in_io)

--- a/src/trio/_tests/test_scheduler_determinism.py
+++ b/src/trio/_tests/test_scheduler_determinism.py
@@ -15,7 +15,7 @@ async def scheduler_trace() -> tuple[tuple[str, int], ...]:
     async def tracer(name: str) -> None:
         for i in range(50):
             trace.append((name, i))
-            await trio.sleep(0)
+            await trio.lowlevel.checkpoint()
 
     async with trio.open_nursery() as nursery:
         for i in range(5):

--- a/src/trio/_tests/test_threads.py
+++ b/src/trio/_tests/test_threads.py
@@ -24,6 +24,8 @@ from typing import (
 import pytest
 import sniffio
 
+from trio import lowlevel
+
 from .. import (
     CancelScope,
     CapacityLimiter,
@@ -165,7 +167,7 @@ def test_run_in_trio_thread_ki() -> None:
         thread.start()
         print("waiting")
         while thread.is_alive():
-            await sleep(0.01)
+            await lowlevel.checkpoint()
         print("waited, joining")
         thread.join()
         print("done")
@@ -535,7 +537,7 @@ async def test_run_in_worker_thread_limiter(
             # check below won't fail due to scheduling issues. (It could still
             # fail if too many threads are let through here.)
             while state.parked != MAX or c.statistics().tasks_waiting != MAX:
-                await sleep(0.01)  # pragma: no cover
+                await lowlevel.checkpoint()  # pragma: no cover
             # Then release the threads
             gate.set()
 
@@ -546,7 +548,7 @@ async def test_run_in_worker_thread_limiter(
             # finish before checking that all threads ran. We can do this
             # using the CapacityLimiter.
             while c.borrowed_tokens > 0:
-                await sleep(0.01)  # pragma: no cover
+                await lowlevel.checkpoint()  # pragma: no cover
 
         assert state.ran == COUNT
         assert state.running == 0


### PR DESCRIPTION
              Probably should enable the TRIO rules? Maybe in a separate PR.

_Originally posted by @TeamSpen210 in https://github.com/python-trio/trio/issues/2946#issuecomment-1928600531_

This pull request enables the `flake8-trio` ruff rule (but in ruff's system it's marked as `TRIO`).