### PR TITLE
Add aioresult to Awesome Trio Libraries in the docs

### DIFF
--- a/docs/source/awesome-trio-libraries.rst
+++ b/docs/source/awesome-trio-libraries.rst
@@ -106,6 +106,7 @@ Tools and Utilities
 * `perf-timer <https://github.com/belm0/perf-timer>`__ - A code timer with Trio async support (see ``TrioPerfTimer``).  Collects execution time of a block of code excluding time when the coroutine isn't scheduled, such as during blocking I/O and sleep.  Also offers ``trio_perf_counter()`` for low-level timing.
 * `aiometer <https://github.com/florimondmanca/aiometer>`__ - Execute lots of tasks concurrently while controlling concurrency limits
 * `triotp <https://linkdd.github.io/triotp>`__ - OTP framework for Python Trio
+* `aioresult <https://github.com/arthur-tacca/aioresult>`__ - Get the return value of a background async function in Trio or anyio, along with a simple Future class and wait utilities
 
 Trio/Asyncio Interoperability
 -----------------------------


### PR DESCRIPTION
I think my little aioresult library ([github](https://github.com/arthur-tacca/aioresult), [docs](https://aioresult.readthedocs.io/en/v1.0/overview.html), [PyPI](https://pypi.org/project/aioresult/)) could be useful to some, so this would add it to the list of Awesome Trio Libraries in the Trio docs.