### PR TITLE
Added link to `logot` in docs

### DIFF
--- a/docs/source/awesome-trio-libraries.rst
+++ b/docs/source/awesome-trio-libraries.rst
@@ -94,6 +94,7 @@ Testing
 * `hypothesis-trio <https://github.com/python-trio/hypothesis-trio>`__ - Hypothesis plugin for trio.
 * `trustme <https://github.com/python-trio/trustme>`__ - #1 quality TLS certs while you wait, for the discerning tester.
 * `pytest-aio <https://github.com/klen/pytest-aio>`_ - Pytest plugin with support for trio, curio, asyncio
+* `logot <https://github.com/etianen/logot>`_ - Test whether your async code is logging correctly.
 
 
 Tools and Utilities


### PR DESCRIPTION
I've just released [`logot`](https://github.com/etianen/logot), a testing library with some nice tools for testing highly-concurrent async code using log capture. It includes a [`trio` integration](https://logot.readthedocs.io/latest/integrations/trio.html), so it would be great to add it to the list of testing tools in your docs. ❤️ 

Here's a quick example of how the `trio` integration looks:

``` py
from logot import Logot, logged

async def test_app(logot: Logot) -> None:
   async with trio.open_nursery() as nursery:
      nursery.start_soon(app.start())
      await logot.await_for(logged.info("App started"))
```

Of course I'd welcome any feedback you have on the `trio` integration too! 🙇 
