### PR TITLE
Remove incorrect `str` possibility from HostnameResolver.getaddrinfo

### DIFF
--- a/src/trio/_abc.py
+++ b/src/trio/_abc.py
@@ -168,7 +168,7 @@ class HostnameResolver(metaclass=ABCMeta):
     @abstractmethod
     async def getaddrinfo(
         self,
-        host: bytes | str | None,
+        host: bytes | None,
         port: bytes | str | int | None,
         family: int = 0,
         type: int = 0,

--- a/src/trio/_tests/test_highlevel_open_tcp_listeners.py
+++ b/src/trio/_tests/test_highlevel_open_tcp_listeners.py
@@ -231,7 +231,7 @@ class FakeHostnameResolver(HostnameResolver):
 
     async def getaddrinfo(
         self,
-        host: bytes | str | None,
+        host: bytes | None,
         port: bytes | str | int | None,
         family: int = 0,
         type: int = 0,

--- a/src/trio/_tests/test_highlevel_open_tcp_stream.py
+++ b/src/trio/_tests/test_highlevel_open_tcp_stream.py
@@ -294,7 +294,7 @@ class Scenario(trio.abc.SocketFactory, trio.abc.HostnameResolver):
 
     async def getaddrinfo(
         self,
-        host: str | bytes | None,
+        host: bytes | None,
         port: bytes | str | int | None,
         family: int = -1,
         type: int = -1,

--- a/src/trio/_tests/test_highlevel_ssl_helpers.py
+++ b/src/trio/_tests/test_highlevel_ssl_helpers.py
@@ -49,7 +49,7 @@ class FakeHostnameResolver(trio.abc.HostnameResolver):
 
     async def getaddrinfo(
         self,
-        host: bytes | str | None,
+        host: bytes | None,
         port: bytes | str | int | None,
         family: int = 0,
         type: int = 0,

--- a/src/trio/testing/_fake_net.py
+++ b/src/trio/testing/_fake_net.py
@@ -138,7 +138,7 @@ class FakeHostnameResolver(trio.abc.HostnameResolver):
 
     async def getaddrinfo(
         self,
-        host: bytes | str | None,
+        host: bytes | None,
         port: bytes | str | int | None,
         family: int = 0,
         type: int = 0,


### PR DESCRIPTION
`_socket.getaddrinfo` takes care of encoding all passed in `str` host arguments before passing it to a custom resolver. Additionally, the docs say that a resolver will always receive IDNA-encoded bytes.

However, the type hints of `HostnameResolver.getaddrinfo` imply that a resolver may need to contend with a `str`

Remove the extraneous appearance