### PR TITLE
fix: updated the google docstring url

### DIFF
--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -379,7 +379,7 @@ Documentation is hosted at `Read the Docs
 rebuilding it after every commit.
 
 For docstrings, we use `the Google docstring format
-<https://www.sphinx-doc.org/en/3.x/usage/extensions/example_google.html#example-google-style-python-docstrings>`__.
+<https://www.sphinx-doc.org/en/master/usage/extensions/example_google.html#example-google-style-python-docstrings>`__.
 If you add a new function or class, there's no mechanism for
 automatically adding that to the docs: you'll have to at least add a
 line like ``.. autofunction:: <your function>`` in the appropriate


### PR DESCRIPTION
Updated Google Docstring Format link since currently it points to a 404 page.

Fixes https://github.com/python-trio/trio/issues/2546