### PR TITLE
Add pre-commit autoupdate to autodeps

### DIFF
--- a/.github/workflows/autodeps.yml
+++ b/.github/workflows/autodeps.yml
@@ -26,10 +26,11 @@ jobs:
           python-version: "3.8"
       - name: Bump dependencies
         run: |
-          python -m pip install -U pip
+          python -m pip install -U pip pre-commit
           python -m pip install -r test-requirements.txt
           pip-compile -U test-requirements.in
           pip-compile -U docs-requirements.in
+          pre-commit autoupdate --jobs 0
       - name: Black
         run: |
           # The new dependencies may contain a new black version.


### PR DESCRIPTION
This pull request adds `pre-commit run --jobs 0` to the autodeps run.

I didn't see this listed in the documentation anywhere, [but marking `0` for number of jobs uses maximum number of threads](https://github.com/pre-commit/pre-commit/blob/ddbee32ad0722a0bc216bc29ee29a1885454bd78/pre_commit/commands/autoupdate.py#L178).