### PR TITLE
Path decorators: allow empty docstrings to support embedded Python

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.3
+    rev: v0.3.4
     hooks:
       - id: ruff
         types: [file]

--- a/newsfragments/2987.issue.rst
+++ b/newsfragments/2987.issue.rst
@@ -1,0 +1,1 @@
+Fix crash when importing trio in python windows embedded, and other installs that removes docstrings.

--- a/newsfragments/2987.issue.rst
+++ b/newsfragments/2987.issue.rst
@@ -1,1 +1,1 @@
-Fix crash when importing trio in python windows embedded, and other installs that removes docstrings.
+Fix crash when importing trio in embedded Python on Windows, and other installs that remove docstrings.

--- a/src/trio/_path.py
+++ b/src/trio/_path.py
@@ -38,11 +38,12 @@ def _wraps_async(
             return await run_sync(partial(fn, *args, **kwargs))
 
         update_wrapper(wrapper, wrapped)
-        wrapper.__doc__ = (
-            f"Like :meth:`~{wrapped.__module__}.{wrapped.__qualname__}`, but async.\n"
-            f"\n"
-            f"{cleandoc(wrapped.__doc__ or '')}\n"
-        )
+        if wrapped.__doc__:
+            wrapper.__doc__ = (
+                f"Like :meth:`~{wrapped.__module__}.{wrapped.__qualname__}`, but async.\n"
+                f"\n"
+                f"{cleandoc(wrapped.__doc__)}\n"
+            )
         return wrapper
 
     return decorator

--- a/src/trio/_path.py
+++ b/src/trio/_path.py
@@ -75,9 +75,7 @@ def _wrap_method_path_iterable(
     def wrapper(self: PathT, /, *args: P.args, **kwargs: P.kwargs) -> Iterable[PathT]:
         return map(self.__class__, [*fn(self._wrapped_cls(self), *args, **kwargs)])
 
-    if wrapper.__doc__ is None:
-        wrapper.__doc__ = ""
-    wrapper.__doc__ += (
+    wrapper.__doc__ = (wrapper.__doc__ or "") + (
         f"\n"
         f"This is an async method that returns a synchronous iterator, so you\n"
         f"use it like:\n"

--- a/src/trio/_path.py
+++ b/src/trio/_path.py
@@ -75,22 +75,23 @@ def _wrap_method_path_iterable(
     def wrapper(self: PathT, /, *args: P.args, **kwargs: P.kwargs) -> Iterable[PathT]:
         return map(self.__class__, [*fn(self._wrapped_cls(self), *args, **kwargs)])
 
-    wrapper.__doc__ = (wrapper.__doc__ or "") + (
-        f"\n"
-        f"This is an async method that returns a synchronous iterator, so you\n"
-        f"use it like:\n"
-        f"\n"
-        f".. code:: python\n"
-        f"\n"
-        f"    for subpath in await mypath.{fn.__name__}():\n"
-        f"        ...\n"
-        f"\n"
-        f".. note::\n"
-        f"\n"
-        f"    The iterator is loaded into memory immediately during the initial\n"
-        f"    call (see `issue #501\n"
-        f"    <https://github.com/python-trio/trio/issues/501>`__ for discussion).\n"
-    )
+    if wrapper.__doc__:
+        wrapper.__doc__ += (
+            f"\n"
+            f"This is an async method that returns a synchronous iterator, so you\n"
+            f"use it like:\n"
+            f"\n"
+            f".. code:: python\n"
+            f"\n"
+            f"    for subpath in await mypath.{fn.__name__}():\n"
+            f"        ...\n"
+            f"\n"
+            f".. note::\n"
+            f"\n"
+            f"    The iterator is loaded into memory immediately during the initial\n"
+            f"    call (see `issue #501\n"
+            f"    <https://github.com/python-trio/trio/issues/501>`__ for discussion).\n"
+        )
     return wrapper
 
 

--- a/src/trio/_path.py
+++ b/src/trio/_path.py
@@ -38,11 +38,10 @@ def _wraps_async(
             return await run_sync(partial(fn, *args, **kwargs))
 
         update_wrapper(wrapper, wrapped)
-        assert wrapped.__doc__ is not None
         wrapper.__doc__ = (
             f"Like :meth:`~{wrapped.__module__}.{wrapped.__qualname__}`, but async.\n"
             f"\n"
-            f"{cleandoc(wrapped.__doc__)}\n"
+            f"{cleandoc(wrapped.__doc__ or '')}\n"
         )
         return wrapper
 
@@ -76,7 +75,8 @@ def _wrap_method_path_iterable(
     def wrapper(self: PathT, /, *args: P.args, **kwargs: P.kwargs) -> Iterable[PathT]:
         return map(self.__class__, [*fn(self._wrapped_cls(self), *args, **kwargs)])
 
-    assert wrapper.__doc__ is not None
+    if wrapper.__doc__ is None:
+        wrapper.__doc__ = ""
     wrapper.__doc__ += (
         f"\n"
         f"This is an async method that returns a synchronous iterator, so you\n"

--- a/src/trio/_tests/test_path.py
+++ b/src/trio/_tests/test_path.py
@@ -267,6 +267,6 @@ def test_wrapping_without_docstrings(
     wrapper: Callable[[Callable[[], None]], Callable[[], None]]
 ) -> None:
     @wrapper
-    def func_without_docstring() -> None: ...
+    def func_without_docstring() -> None: ...  # pragma: no cover
 
     assert func_without_docstring.__doc__ is None

--- a/src/trio/_tests/test_path.py
+++ b/src/trio/_tests/test_path.py
@@ -252,3 +252,21 @@ async def test_classmethods() -> None:
 
     # Wrapped method has docstring
     assert trio.Path.home.__doc__
+
+
+@pytest.mark.parametrize(
+    "wrapper",
+    [
+        trio._path._wraps_async,
+        trio._path._wrap_method,
+        trio._path._wrap_method_path,
+        trio._path._wrap_method_path_iterable,
+    ],
+)
+def test_wrapping_without_docstrings(
+    wrapper: Callable[[Callable[[], None]], Callable[[], None]]
+) -> None:
+    @wrapper
+    def func_without_docstring() -> None: ...
+
+    assert func_without_docstring.__doc__ is None


### PR DESCRIPTION
I am developing an application that runs on the Windows embedded Python package. It appears that the embedded Python standard library does not include docstrings which means an unhandled exception is raised when importing trio because of a couple `assert X.__doc__ is not None` statements. This PR makes it so `__doc__` is allowed to be `None`.

To test, I am using [Python Windows Embedded 64-bit 3.11.8](https://www.python.org/downloads/release/python-3118/) package. I wrote a small script to show that `__doc__ is None` on every Path function:

```python
import inspect
from pathlib import Path

for name in dir(Path):
    if name.startswith("_"):
        continue

    attr = getattr(Path, name)
    if inspect.isfunction(attr) or inspect.ismethod(attr):
        if attr.__doc__ is None:
            print(f"Path.{name}.__doc__ is None")
```

When I run this through embedded Python I see every function in `Path` has no docstring.