### PR TITLE
Ensure we're deterministic for Hypothesis in Trio, not pytest-trio

### DIFF
--- a/docs/source/awesome-trio-libraries.rst
+++ b/docs/source/awesome-trio-libraries.rst
@@ -91,7 +91,8 @@ RPC
 Testing
 -------
 * `pytest-trio <https://github.com/python-trio/pytest-trio>`__ - Pytest plugin for trio.
-* `hypothesis-trio <https://github.com/python-trio/hypothesis-trio>`__ - Hypothesis plugin for trio.
+* `hypothesis-trio <https://github.com/python-trio/hypothesis-trio>`__ - Hypothesis supports Trio out of the box for
+  ``@given(...)`` tests; this extension provides Trio-compatible stateful testing.
 * `trustme <https://github.com/python-trio/trustme>`__ - #1 quality TLS certs while you wait, for the discerning tester.
 * `pytest-aio <https://github.com/klen/pytest-aio>`_ - Pytest plugin with support for trio, curio, asyncio
 * `logot <https://github.com/etianen/logot>`_ - Test whether your async code is logging correctly.
@@ -99,7 +100,6 @@ Testing
 
 Tools and Utilities
 -------------------
-* `trio-typing <https://github.com/python-trio/trio-typing>`__ - Type hints for Trio and related projects.
 * `trio-util <https://github.com/groove-x/trio-util>`__ - An assortment of utilities for the Trio async/await framework.
 * `flake8-trio <https://github.com/Zac-HD/flake8-trio>`__ - Highly opinionated linter for various sorts of problems in Trio and/or AnyIO. Can run as a flake8 plugin, or standalone with support for autofixing some errors.
 * `tricycle <https://github.com/oremanj/tricycle>`__ - This is a library of interesting-but-maybe-not-yet-fully-proven extensions to Trio.
@@ -109,8 +109,9 @@ Tools and Utilities
 * `triotp <https://linkdd.github.io/triotp>`__ - OTP framework for Python Trio
 * `aioresult <https://github.com/arthur-tacca/aioresult>`__ - Get the return value of a background async function in Trio or anyio, along with a simple Future class and wait utilities
 
+
 Trio/Asyncio Interoperability
 -----------------------------
-* `anyio <https://github.com/agronholm/anyio>`__ - AnyIO is a asynchronous compatibility API that allows applications and libraries written against it to run unmodified on asyncio, curio and trio.
+* `anyio <https://github.com/agronholm/anyio>`__ - AnyIO is a asynchronous compatibility API that allows applications and libraries written against it to run unmodified on asyncio or trio.
 * `sniffio <https://github.com/python-trio/sniffio>`__ - This is a tiny package whose only purpose is to let you detect which async library your code is running under.
 * `trio-asyncio <https://github.com/python-trio/trio-asyncio>`__ - Trio-Asyncio lets you use many asyncio libraries from your Trio app.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,9 @@ Homepage = "https://github.com/python-trio/trio"
 Documentation = "https://trio.readthedocs.io/"
 Changelog = "https://trio.readthedocs.io/en/latest/history.html"
 
+[project.entry-points.hypothesis]
+trio = "trio._core._run:_hypothesis_plugin_setup"
+
 [tool.setuptools]
 # This means, just install *everything* you see under trio/, even if it
 # doesn't look like a source file, so long as it appears in MANIFEST.in:


### PR DESCRIPTION
This registration was previously handled by pytest-trio (before Hypothesis supported entry-point plugins).  Upstreaming it means that we'll get the behavior we want for unittest, for functions people call by hand, and so on.  Fixes https://github.com/python-trio/trio/issues/2981.  Manual testing with Hypothesis confirms this works, and our existing determinism-related unit tests continue to pass, so I haven't added more complicated tests which would require subprocesses and installing Hypothesis.

I'll open a PR to remove the relevant logic from pytest-trio once this has been released; double-registration is perfectly safe so it's better to overlap than leave a gap.

Plus some bonus updates to the awesome-trio-libraries page, since I noticed outdated information there.