### PR TITLE
Format using Ruff instead of Black.

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,4 @@
 # sorting all imports with isort
 933f77b96f0092e1baab4474a9208fc2e379aa32
+# reformatting using ruff
+1507cca4728ffcd9ded19c410bb134cd96df522a

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,13 +18,10 @@ repos:
       - id: check-case-conflict
       - id: sort-simple-yaml
         files: .pre-commit-config.yaml
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.3.0
-    hooks:
-      - id: black
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.3.5
     hooks:
+      - id: ruff-format
       - id: ruff
         types: [file]
         types_or: [python, pyi, toml]

--- a/check.sh
+++ b/check.sh
@@ -22,13 +22,13 @@ echo "::endgroup::"
 # see https://forum.bors.tech/t/pre-test-and-pre-merge-hooks/322)
 # autoflake --recursive --in-place .
 # pyupgrade --py3-plus $(find . -name "*.py")
-echo "::group::Black"
-if ! black --check src/trio; then
-    echo "* Black found issues" >> "$GITHUB_STEP_SUMMARY"
+echo "::group::Ruff-Format"
+if ! ruff format --check src/trio; then
+    echo "* Ruff found issues" >> "$GITHUB_STEP_SUMMARY"
     EXIT_STATUS=1
-    black --diff src/trio
+    ruff format --diff src/trio
     echo "::endgroup::"
-    echo "::error:: Black found issues"
+    echo "::error:: Ruff found issues"
 else
     echo "::endgroup::"
 fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ force-exclude = '''
 ignore-words-list = 'astroid,crasher,asend'
 
 [tool.ruff]
+target-version = "py38"
 respect-gitignore = true
 fix = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,6 @@ force-exclude = '''
 ignore-words-list = 'astroid,crasher,asend'
 
 [tool.ruff]
-target-version = "py38"
 respect-gitignore = true
 fix = true
 

--- a/src/trio/__init__.py
+++ b/src/trio/__init__.py
@@ -1,5 +1,4 @@
-"""Trio - A friendly Python library for async concurrency and I/O
-"""
+"""Trio - A friendly Python library for async concurrency and I/O"""
 
 from __future__ import annotations
 

--- a/src/trio/_channel.py
+++ b/src/trio/_channel.py
@@ -96,7 +96,8 @@ if TYPE_CHECKING:
     # Need to use Tuple instead of tuple due to CI check running on 3.8
     class open_memory_channel(Tuple["MemorySendChannel[T]", "MemoryReceiveChannel[T]"]):
         def __new__(  # type: ignore[misc]  # "must return a subtype"
-            cls, max_buffer_size: int | float  # noqa: PYI041
+            cls,
+            max_buffer_size: int | float,  # noqa: PYI041
         ) -> tuple[MemorySendChannel[T], MemoryReceiveChannel[T]]:
             return _open_memory_channel(max_buffer_size)
 

--- a/src/trio/_core/_generated_io_epoll.py
+++ b/src/trio/_core/_generated_io_epoll.py
@@ -18,7 +18,7 @@ assert not TYPE_CHECKING or sys.platform == "linux"
 __all__ = ["notify_closing", "wait_readable", "wait_writable"]
 
 
-async def wait_readable(fd: int | _HasFileNo) -> None:
+async def wait_readable(fd: (int | _HasFileNo)) -> None:
     """Block until the kernel reports that the given object is readable.
 
     On Unix systems, ``fd`` must either be an integer file descriptor,
@@ -47,7 +47,7 @@ async def wait_readable(fd: int | _HasFileNo) -> None:
         raise RuntimeError("must be called from async context") from None
 
 
-async def wait_writable(fd: int | _HasFileNo) -> None:
+async def wait_writable(fd: (int | _HasFileNo)) -> None:
     """Block until the kernel reports that the given object is writable.
 
     See `wait_readable` for the definition of ``fd``.
@@ -66,7 +66,7 @@ async def wait_writable(fd: int | _HasFileNo) -> None:
         raise RuntimeError("must be called from async context") from None
 
 
-def notify_closing(fd: int | _HasFileNo) -> None:
+def notify_closing(fd: (int | _HasFileNo)) -> None:
     """Notify waiters of the given object that it will be closed.
 
     Call this before closing a file descriptor (on Unix) or socket (on

--- a/src/trio/_core/_generated_io_kqueue.py
+++ b/src/trio/_core/_generated_io_kqueue.py
@@ -71,7 +71,7 @@ async def wait_kevent(
         raise RuntimeError("must be called from async context") from None
 
 
-async def wait_readable(fd: int | _HasFileNo) -> None:
+async def wait_readable(fd: (int | _HasFileNo)) -> None:
     """Block until the kernel reports that the given object is readable.
 
     On Unix systems, ``fd`` must either be an integer file descriptor,
@@ -100,7 +100,7 @@ async def wait_readable(fd: int | _HasFileNo) -> None:
         raise RuntimeError("must be called from async context") from None
 
 
-async def wait_writable(fd: int | _HasFileNo) -> None:
+async def wait_writable(fd: (int | _HasFileNo)) -> None:
     """Block until the kernel reports that the given object is writable.
 
     See `wait_readable` for the definition of ``fd``.
@@ -119,7 +119,7 @@ async def wait_writable(fd: int | _HasFileNo) -> None:
         raise RuntimeError("must be called from async context") from None
 
 
-def notify_closing(fd: int | _HasFileNo) -> None:
+def notify_closing(fd: (int | _HasFileNo)) -> None:
     """Notify waiters of the given object that it will be closed.
 
     Call this before closing a file descriptor (on Unix) or socket (on

--- a/src/trio/_core/_generated_io_windows.py
+++ b/src/trio/_core/_generated_io_windows.py
@@ -32,7 +32,7 @@ __all__ = [
 ]
 
 
-async def wait_readable(sock: _HasFileNo | int) -> None:
+async def wait_readable(sock: (_HasFileNo | int)) -> None:
     """Block until the kernel reports that the given object is readable.
 
     On Unix systems, ``sock`` must either be an integer file descriptor,
@@ -61,7 +61,7 @@ async def wait_readable(sock: _HasFileNo | int) -> None:
         raise RuntimeError("must be called from async context") from None
 
 
-async def wait_writable(sock: _HasFileNo | int) -> None:
+async def wait_writable(sock: (_HasFileNo | int)) -> None:
     """Block until the kernel reports that the given object is writable.
 
     See `wait_readable` for the definition of ``sock``.
@@ -80,7 +80,7 @@ async def wait_writable(sock: _HasFileNo | int) -> None:
         raise RuntimeError("must be called from async context") from None
 
 
-def notify_closing(handle: Handle | int | _HasFileNo) -> None:
+def notify_closing(handle: (Handle | int | _HasFileNo)) -> None:
     """Notify waiters of the given object that it will be closed.
 
     Call this before closing a file descriptor (on Unix) or socket (on
@@ -112,7 +112,7 @@ def notify_closing(handle: Handle | int | _HasFileNo) -> None:
         raise RuntimeError("must be called from async context") from None
 
 
-def register_with_iocp(handle: int | CData) -> None:
+def register_with_iocp(handle: (int | CData)) -> None:
     """TODO: these are implemented, but are currently more of a sketch than
     anything real. See `#26
     <https://github.com/python-trio/trio/issues/26>`__ and `#52
@@ -125,7 +125,9 @@ def register_with_iocp(handle: int | CData) -> None:
         raise RuntimeError("must be called from async context") from None
 
 
-async def wait_overlapped(handle_: int | CData, lpOverlapped: CData | int) -> object:
+async def wait_overlapped(
+    handle_: (int | CData), lpOverlapped: (CData | int)
+) -> object:
     """TODO: these are implemented, but are currently more of a sketch than
     anything real. See `#26
     <https://github.com/python-trio/trio/issues/26>`__ and `#52
@@ -141,7 +143,7 @@ async def wait_overlapped(handle_: int | CData, lpOverlapped: CData | int) -> ob
 
 
 async def write_overlapped(
-    handle: int | CData, data: Buffer, file_offset: int = 0
+    handle: (int | CData), data: Buffer, file_offset: int = 0
 ) -> int:
     """TODO: these are implemented, but are currently more of a sketch than
     anything real. See `#26
@@ -158,7 +160,7 @@ async def write_overlapped(
 
 
 async def readinto_overlapped(
-    handle: int | CData, buffer: Buffer, file_offset: int = 0
+    handle: (int | CData), buffer: Buffer, file_offset: int = 0
 ) -> int:
     """TODO: these are implemented, but are currently more of a sketch than
     anything real. See `#26

--- a/src/trio/_core/_generated_run.py
+++ b/src/trio/_core/_generated_run.py
@@ -130,7 +130,7 @@ def spawn_system_task(
     async_fn: Callable[[Unpack[PosArgT]], Awaitable[object]],
     *args: Unpack[PosArgT],
     name: object = None,
-    context: contextvars.Context | None = None,
+    context: (contextvars.Context | None) = None,
 ) -> Task:
     """Spawn a "system" task.
 

--- a/src/trio/_core/_parking_lot.py
+++ b/src/trio/_core/_parking_lot.py
@@ -182,7 +182,10 @@ class ParkingLot:
 
     @_core.enable_ki_protection
     def repark(
-        self, new_lot: ParkingLot, *, count: int | float = 1  # noqa: PYI041
+        self,
+        new_lot: ParkingLot,
+        *,
+        count: int | float = 1,  # noqa: PYI041
     ) -> None:
         """Move parked tasks from one :class:`ParkingLot` object to another.
 

--- a/src/trio/_core/_traps.py
+++ b/src/trio/_core/_traps.py
@@ -219,7 +219,7 @@ async def permanently_detach_coroutine_object(
 
 
 async def temporarily_detach_coroutine_object(
-    abort_func: Callable[[RaiseCancelT], Abort]
+    abort_func: Callable[[RaiseCancelT], Abort],
 ) -> Any:
     """Temporarily detach the current coroutine object from the Trio
     scheduler.

--- a/src/trio/_highlevel_open_tcp_stream.py
+++ b/src/trio/_highlevel_open_tcp_stream.py
@@ -141,7 +141,7 @@ def reorder_for_rfc_6555_section_5_4(
             str,
             Any,
         ]
-    ]
+    ],
 ) -> None:
     # RFC 6555 section 5.4 says that if getaddrinfo returns multiple address
     # families (e.g. IPv4 and IPv6), then you should make sure that your first

--- a/src/trio/_path.py
+++ b/src/trio/_path.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 
 
 def _wraps_async(
-    wrapped: Callable[..., Any]
+    wrapped: Callable[..., Any],
 ) -> Callable[[Callable[P, T]], Callable[P, Awaitable[T]]]:
     def decorator(fn: Callable[P, T]) -> Callable[P, Awaitable[T]]:
         async def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:

--- a/src/trio/_tests/check_type_completeness.py
+++ b/src/trio/_tests/check_type_completeness.py
@@ -7,6 +7,7 @@
 
 If this check is giving you false alarms, you can ignore them by adding logic to `has_docstring_at_runtime`, in the main loop in `check_type`, or by updating the json file.
 """
+
 from __future__ import annotations
 
 # this file is not run as part of the tests, instead it's run standalone from check.sh

--- a/src/trio/_tests/test_highlevel_open_tcp_stream.py
+++ b/src/trio/_tests/test_highlevel_open_tcp_stream.py
@@ -276,7 +276,9 @@ class Scenario(trio.abc.SocketFactory, trio.abc.HostnameResolver):
         self.socket_count += 1
         return FakeSocket(self, family, type_, proto)
 
-    def _ip_to_gai_entry(self, ip: str) -> tuple[
+    def _ip_to_gai_entry(
+        self, ip: str
+    ) -> tuple[
         AddressFamily,
         SocketKind,
         int,

--- a/src/trio/_tests/test_socket.py
+++ b/src/trio/_tests/test_socket.py
@@ -587,7 +587,7 @@ async def test_SocketType_resolve(socket_type: AddressFamily, addrs: Addresses) 
                     | tuple[str, str]
                     | tuple[str, str, int]
                     | tuple[str, str, int, int]
-                )
+                ),
             ) -> Any:
                 return await sock._resolve_address_nocp(
                     args,

--- a/src/trio/_tests/test_ssl.py
+++ b/src/trio/_tests/test_ssl.py
@@ -409,7 +409,9 @@ def ssl_wrap_pair(
 MemoryStapledStream: TypeAlias = StapledStream[MemorySendStream, MemoryReceiveStream]
 
 
-def ssl_memory_stream_pair(client_ctx: SSLContext, **kwargs: Any) -> tuple[
+def ssl_memory_stream_pair(
+    client_ctx: SSLContext, **kwargs: Any
+) -> tuple[
     SSLStream[MemoryStapledStream],
     SSLStream[MemoryStapledStream],
 ]:
@@ -420,7 +422,9 @@ def ssl_memory_stream_pair(client_ctx: SSLContext, **kwargs: Any) -> tuple[
 MyStapledStream: TypeAlias = StapledStream[SendStream, ReceiveStream]
 
 
-def ssl_lockstep_stream_pair(client_ctx: SSLContext, **kwargs: Any) -> tuple[
+def ssl_lockstep_stream_pair(
+    client_ctx: SSLContext, **kwargs: Any
+) -> tuple[
     SSLStream[MyStapledStream],
     SSLStream[MyStapledStream],
 ]:
@@ -837,20 +841,24 @@ async def test_send_all_empty_string(client_ctx: SSLContext) -> None:
 async def test_SSLStream_generic(
     client_ctx: SSLContext, https_compatible: bool
 ) -> None:
-    async def stream_maker() -> tuple[
-        SSLStream[MemoryStapledStream],
-        SSLStream[MemoryStapledStream],
-    ]:
+    async def stream_maker() -> (
+        tuple[
+            SSLStream[MemoryStapledStream],
+            SSLStream[MemoryStapledStream],
+        ]
+    ):
         return ssl_memory_stream_pair(
             client_ctx,
             client_kwargs={"https_compatible": https_compatible},
             server_kwargs={"https_compatible": https_compatible},
         )
 
-    async def clogged_stream_maker() -> tuple[
-        SSLStream[MyStapledStream],
-        SSLStream[MyStapledStream],
-    ]:
+    async def clogged_stream_maker() -> (
+        tuple[
+            SSLStream[MyStapledStream],
+            SSLStream[MyStapledStream],
+        ]
+    ):
         client, server = ssl_lockstep_stream_pair(client_ctx)
         # If we don't do handshakes up front, then we run into a problem in
         # the following situation:

--- a/src/trio/_tests/test_testing.py
+++ b/src/trio/_tests/test_testing.py
@@ -602,10 +602,12 @@ async def test_memory_streams_with_generic_tests() -> None:
 
     await check_one_way_stream(one_way_stream_maker, None)
 
-    async def half_closeable_stream_maker() -> tuple[
-        StapledStream[MemorySendStream, MemoryReceiveStream],
-        StapledStream[MemorySendStream, MemoryReceiveStream],
-    ]:
+    async def half_closeable_stream_maker() -> (
+        tuple[
+            StapledStream[MemorySendStream, MemoryReceiveStream],
+            StapledStream[MemorySendStream, MemoryReceiveStream],
+        ]
+    ):
         return memory_stream_pair()
 
     await check_half_closeable_stream(half_closeable_stream_maker, None)
@@ -617,10 +619,12 @@ async def test_lockstep_streams_with_generic_tests() -> None:
 
     await check_one_way_stream(one_way_stream_maker, one_way_stream_maker)
 
-    async def two_way_stream_maker() -> tuple[
-        StapledStream[SendStream, ReceiveStream],
-        StapledStream[SendStream, ReceiveStream],
-    ]:
+    async def two_way_stream_maker() -> (
+        tuple[
+            StapledStream[SendStream, ReceiveStream],
+            StapledStream[SendStream, ReceiveStream],
+        ]
+    ):
         return lockstep_stream_pair()
 
     await check_two_way_stream(two_way_stream_maker, two_way_stream_maker)

--- a/src/trio/_tests/tools/test_gen_exports.py
+++ b/src/trio/_tests/tools/test_gen_exports.py
@@ -19,7 +19,6 @@ from trio._tools.gen_exports import (
     create_passthrough_args,
     get_public_methods,
     process,
-    run_black,
     run_linters,
     run_ruff,
 )
@@ -93,12 +92,6 @@ skip_lints = pytest.mark.skipif(
 @skip_lints
 @pytest.mark.parametrize("imports", [IMPORT_1, IMPORT_2, IMPORT_3])
 def test_process(tmp_path: Path, imports: str) -> None:
-    try:
-        import black  # noqa: F401
-    # there's no dedicated CI run that has astor+isort, but lacks black.
-    except ImportError as error:  # pragma: no cover
-        skip_if_optional_else_raise(error)
-
     modpath = tmp_path / "_module.py"
     genpath = tmp_path / "_generated_module.py"
     modpath.write_text(SOURCE, encoding="utf-8")
@@ -121,23 +114,6 @@ def test_process(tmp_path: Path, imports: str) -> None:
     with pytest.raises(SystemExit) as excinfo:
         process([File(modpath, "runner", imports=imports)], do_test=True)
     assert excinfo.value.code == 1
-
-
-@skip_lints
-def test_run_black(tmp_path: Path) -> None:
-    """Test that processing properly fails if black does."""
-    try:
-        import black  # noqa: F401
-    except ImportError as error:  # pragma: no cover
-        skip_if_optional_else_raise(error)
-
-    file = File(tmp_path / "module.py", "module")
-
-    success, _ = run_black(file, "class not valid code ><")
-    assert not success
-
-    success, _ = run_black(file, "import waffle\n;import trio")
-    assert not success
 
 
 @skip_lints
@@ -170,7 +146,6 @@ def test_run_ruff(tmp_path: Path) -> None:
 def test_lint_failure(tmp_path: Path) -> None:
     """Test that processing properly fails if black or ruff does."""
     try:
-        import black  # noqa: F401
         import ruff  # noqa: F401
     except ImportError as error:  # pragma: no cover
         skip_if_optional_else_raise(error)

--- a/src/trio/_tests/tools/test_gen_exports.py
+++ b/src/trio/_tests/tools/test_gen_exports.py
@@ -144,7 +144,7 @@ def test_run_ruff(tmp_path: Path) -> None:
 
 @skip_lints
 def test_lint_failure(tmp_path: Path) -> None:
-    """Test that processing properly fails if black or ruff does."""
+    """Test that processing properly fails if ruff does."""
     try:
         import ruff  # noqa: F401
     except ImportError as error:  # pragma: no cover

--- a/src/trio/_tests/type_tests/raisesgroup.py
+++ b/src/trio/_tests/type_tests/raisesgroup.py
@@ -37,7 +37,8 @@ def check_inheritance_and_assignments() -> None:
     # https://github.com/agronholm/exceptiongroup/pull/101
     # once fixed we'll get errors for unnecessary-pyright-ignore and can clean up
     a = BaseExceptionGroup(
-        "", (BaseExceptionGroup("", (ValueError(),)),)  # pyright: ignore
+        "",
+        (BaseExceptionGroup("", (ValueError(),)),),  # pyright: ignore
     )
     assert a
 
@@ -129,7 +130,8 @@ def check_nested_raisesgroups_matches() -> None:
     # https://github.com/agronholm/exceptiongroup/pull/101
     # once fixed we'll get errors for unnecessary-pyright-ignore and can clean up
     exc: ExceptionGroup[ExceptionGroup[ValueError]] = ExceptionGroup(
-        "", (ExceptionGroup("", (ValueError(),)),)  # pyright: ignore
+        "",
+        (ExceptionGroup("", (ValueError(),)),),  # pyright: ignore
     )
     # has the same problems as check_nested_raisesgroups_contextmanager
     if RaisesGroup(RaisesGroup(ValueError)).matches(exc):

--- a/src/trio/_threads.py
+++ b/src/trio/_threads.py
@@ -464,9 +464,9 @@ async def to_thread_run_sync(  # type: ignore[misc]
 
         while True:
             # wait_task_rescheduled return value cannot be typed
-            msg_from_thread: outcome.Outcome[RetT] | Run[object] | RunSync[object] = (
-                await trio.lowlevel.wait_task_rescheduled(abort)
-            )
+            msg_from_thread: (
+                outcome.Outcome[RetT] | Run[object] | RunSync[object]
+            ) = await trio.lowlevel.wait_task_rescheduled(abort)
             if isinstance(msg_from_thread, outcome.Outcome):
                 return msg_from_thread.unwrap()
             elif isinstance(msg_from_thread, Run):

--- a/src/trio/_tools/gen_exports.py
+++ b/src/trio/_tools/gen_exports.py
@@ -3,6 +3,7 @@
 Code generation script for class methods
 to be exported as public API
 """
+
 from __future__ import annotations
 
 import argparse

--- a/src/trio/_tools/gen_exports.py
+++ b/src/trio/_tools/gen_exports.py
@@ -4,8 +4,6 @@ Code generation script for class methods
 to be exported as public API
 """
 
-# mypy: disable-error-code="unused-ignore"
-
 from __future__ import annotations
 
 import argparse
@@ -175,8 +173,7 @@ def run_linters(file: File, source: str) -> str:
       Formatted source code.
 
     Raises:
-      ImportError: If either is not installed.
-      SystemExit: If either failed.
+      SystemExit: If format/check fails.
     """
 
     success, response = run_ruff_format(file, source)
@@ -244,7 +241,7 @@ def gen_public_wrappers_source(file: File) -> str:
             del method.body[1:]
 
         # Create the function definition including the body
-        func: str = astor.to_source(method, indent_with=" " * 4)  # type: ignore
+        func: str = astor.to_source(method, indent_with=" " * 4)  # type: ignore[unused-ignore]
 
         if is_cm:  # pragma: no cover
             func = func.replace("->Iterator", "->ContextManager")

--- a/src/trio/_tools/gen_exports.py
+++ b/src/trio/_tools/gen_exports.py
@@ -4,6 +4,8 @@ Code generation script for class methods
 to be exported as public API
 """
 
+# mypy: disable-error-code="unused-ignore"
+
 from __future__ import annotations
 
 import argparse

--- a/src/trio/testing/_memory_streams.py
+++ b/src/trio/testing/_memory_streams.py
@@ -356,7 +356,7 @@ def memory_stream_one_way_pair() -> tuple[MemorySendStream, MemoryReceiveStream]
 
 
 def _make_stapled_pair(
-    one_way_pair: Callable[[], tuple[SendStreamT, ReceiveStreamT]]
+    one_way_pair: Callable[[], tuple[SendStreamT, ReceiveStreamT]],
 ) -> tuple[
     StapledStream[SendStreamT, ReceiveStreamT],
     StapledStream[SendStreamT, ReceiveStreamT],
@@ -368,10 +368,12 @@ def _make_stapled_pair(
     return stream1, stream2
 
 
-def memory_stream_pair() -> tuple[
-    StapledStream[MemorySendStream, MemoryReceiveStream],
-    StapledStream[MemorySendStream, MemoryReceiveStream],
-]:
+def memory_stream_pair() -> (
+    tuple[
+        StapledStream[MemorySendStream, MemoryReceiveStream],
+        StapledStream[MemorySendStream, MemoryReceiveStream],
+    ]
+):
     """Create a connected, pure-Python, bidirectional stream with infinite
     buffering and flexible configuration options.
 
@@ -607,10 +609,12 @@ def lockstep_stream_one_way_pair() -> tuple[SendStream, ReceiveStream]:
     return _LockstepSendStream(lbq), _LockstepReceiveStream(lbq)
 
 
-def lockstep_stream_pair() -> tuple[
-    StapledStream[SendStream, ReceiveStream],
-    StapledStream[SendStream, ReceiveStream],
-]:
+def lockstep_stream_pair() -> (
+    tuple[
+        StapledStream[SendStream, ReceiveStream],
+        StapledStream[SendStream, ReceiveStream],
+    ]
+):
     """Create a connected, pure-Python, bidirectional stream where data flows
     in lockstep.
 

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -10,7 +10,6 @@ jedi                  # for jedi code completion tests
 cryptography>=41.0.0  # cryptography<41 segfaults on pypy3.10
 
 # Tools
-black; implementation_name == "cpython"
 mypy; implementation_name == "cpython"
 types-pyOpenSSL; implementation_name == "cpython" # and annotations
 ruff >= 0.1.5

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -18,8 +18,6 @@ attrs==23.2.0
     #   outcome
 babel==2.14.0
     # via sphinx
-black==24.3.0 ; implementation_name == "cpython"
-    # via -r test-requirements.in
 build==1.2.1
     # via pip-tools
 certifi==2024.2.2
@@ -29,9 +27,7 @@ cffi==1.16.0
 charset-normalizer==3.3.2
     # via requests
 click==8.1.7
-    # via
-    #   black
-    #   pip-tools
+    # via pip-tools
 codespell==2.2.6
     # via -r test-requirements.in
 coverage==7.4.4
@@ -78,7 +74,6 @@ mypy==1.9.0 ; implementation_name == "cpython"
 mypy-extensions==1.0.0 ; implementation_name == "cpython"
     # via
     #   -r test-requirements.in
-    #   black
     #   mypy
 nodeenv==1.8.0
     # via pyright
@@ -86,20 +81,15 @@ outcome==1.3.0.post0
     # via -r test-requirements.in
 packaging==24.0
     # via
-    #   black
     #   build
     #   pytest
     #   sphinx
 parso==0.8.3
     # via jedi
-pathspec==0.12.1
-    # via black
 pip-tools==7.4.1
     # via -r test-requirements.in
 platformdirs==4.2.0
-    # via
-    #   black
-    #   pylint
+    # via pylint
 pluggy==1.4.0
     # via pytest
 pycparser==2.22
@@ -146,7 +136,6 @@ sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
 tomli==2.0.1
     # via
-    #   black
     #   build
     #   mypy
     #   pip-tools
@@ -169,7 +158,6 @@ typing-extensions==4.10.0
     # via
     #   -r test-requirements.in
     #   astroid
-    #   black
     #   mypy
     #   pylint
 urllib3==2.2.1


### PR DESCRIPTION
Removes a dependency, which is always good.

Apparently it's meant to be drop-in compatible, but clearly not.

Most of the test code relating to Black has been removed, because that entire area is an atrocity and needs to be vaporised.