### PR TITLE
Remove `test_run_black`

### DIFF
--- a/src/trio/_tests/tools/test_gen_exports.py
+++ b/src/trio/_tests/tools/test_gen_exports.py
@@ -19,7 +19,6 @@ from trio._tools.gen_exports import (
     create_passthrough_args,
     get_public_methods,
     process,
-    run_black,
     run_linters,
     run_ruff,
 )

--- a/src/trio/_tests/tools/test_gen_exports.py
+++ b/src/trio/_tests/tools/test_gen_exports.py
@@ -124,23 +124,6 @@ def test_process(tmp_path: Path, imports: str) -> None:
 
 
 @skip_lints
-def test_run_black(tmp_path: Path) -> None:
-    """Test that processing properly fails if black does."""
-    try:
-        import black  # noqa: F401
-    except ImportError as error:  # pragma: no cover
-        skip_if_optional_else_raise(error)
-
-    file = File(tmp_path / "module.py", "module")
-
-    success, _ = run_black(file, "class not valid code ><")
-    assert not success
-
-    success, _ = run_black(file, "import waffle\n;import trio")
-    assert not success
-
-
-@skip_lints
 def test_run_ruff(tmp_path: Path) -> None:
     """Test that processing properly fails if ruff does."""
     try:


### PR DESCRIPTION
https://github.com/python-trio/trio/pull/2988 was closed, but I think we agree that `test_run_black` can be removed. I don't actually remember why it was introduced, but using blame all the way back leads to it not seeming necessary. It was made because `test_lint_failure` wouldn't check that `ruff` was actually running, so we duplicated that to have a `black`-specific test and a `ruff`-specific test. The `ruff` one is still useful (maybe), but the `black` one is duplicated.

I'm not so sure *any* of these tests should exist anymore. I think I kinda pushed for the `ruff`-specific one but now I think it's ultimately unnecessary. If `ruff` doesn't run in `gen_exports`, that's ... fine. We have CI jobs dedicated to checking our code is alright and if it isn't, then that will be caught. Removing that is another PR's job though.