### PR TITLE
Bump version to 0.25.1

### DIFF
--- a/docs/source/history.rst
+++ b/docs/source/history.rst
@@ -5,6 +5,15 @@ Release history
 
 .. towncrier release notes start
 
+Trio 0.25.1 (2024-05-16)
+------------------------
+
+Bugfixes
+~~~~~~~~
+
+- Fix crash when importing trio in embedded Python on Windows, and other installs that remove docstrings. (`#2987 <https://github.com/python-trio/trio/issues/2987>`__)
+
+
 Trio 0.25.0 (2024-03-17)
 ------------------------
 

--- a/newsfragments/2987.issue.rst
+++ b/newsfragments/2987.issue.rst
@@ -1,1 +1,0 @@
-Fix crash when importing trio in embedded Python on Windows, and other installs that remove docstrings.

--- a/src/trio/_version.py
+++ b/src/trio/_version.py
@@ -1,3 +1,3 @@
 # This file is imported from __init__.py and parsed by setuptools
 
-__version__ = "0.25.1"
+__version__ = "0.25.1+dev"

--- a/src/trio/_version.py
+++ b/src/trio/_version.py
@@ -1,3 +1,3 @@
 # This file is imported from __init__.py and parsed by setuptools
 
-__version__ = "0.25.0+dev"
+__version__ = "0.25.1"


### PR DESCRIPTION
Note: I renamed `2987.issue.rst` to `2987.bugfix.rst`.

I wanted to make this release a while ago but so it goes. This is mainly for `strict_exceptiongroups` reasons (we now have documentation!).