### PR TITLE
tweaks to new REPL

### DIFF
--- a/src/trio/_tests/test_repl.py
+++ b/src/trio/_tests/test_repl.py
@@ -96,6 +96,36 @@ async def test_system_exits_quit_interpreter(monkeypatch: pytest.MonkeyPatch) ->
         await trio._repl.run_repl(console)
 
 
+async def test_KI_interrupts(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    console = trio._repl.TrioInteractiveConsole(repl_locals=build_locals())
+    raw_input = build_raw_input(
+        [
+            "from trio._util import signal_raise",
+            "import signal, trio, trio.lowlevel",
+            "async def f():",
+            "  trio.lowlevel.spawn_system_task("
+            "    trio.to_thread.run_sync,"
+            "    signal_raise,signal.SIGINT,"
+            "  )",  # just awaiting this kills the test runner?!
+            "  await trio.sleep_forever()",
+            "  print('should not see this')",
+            "",
+            "await f()",
+            "print('AFTER KeyboardInterrupt')",
+        ]
+    )
+    monkeypatch.setattr(console, "raw_input", raw_input)
+    await trio._repl.run_repl(console)
+    out, err = capsys.readouterr()
+    assert "KeyboardInterrupt" in err
+    assert "running" in out
+    assert "should" not in out
+    assert "AFTER KeyboardInterrupt" in out
+
+
 async def test_system_exits_in_exc_group(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,

--- a/src/trio/_tests/test_repl.py
+++ b/src/trio/_tests/test_repl.py
@@ -187,7 +187,8 @@ async def test_base_exception_captured(
     monkeypatch.setattr(console, "raw_input", raw_input)
     await trio._repl.run_repl(console)
     out, err = capsys.readouterr()
-    assert "_threads.py" not in err
+    if sys.version_info >= (3, 11):
+        assert "_threads.py" not in err
     assert "AFTER BaseException" in out
 
 
@@ -228,7 +229,8 @@ async def test_base_exception_capture_from_coroutine(
     monkeypatch.setattr(console, "raw_input", raw_input)
     await trio._repl.run_repl(console)
     out, err = capsys.readouterr()
-    assert "_threads.py" not in err
+    if sys.version_info >= (3, 11):
+        assert "_threads.py" not in err
     assert "AFTER BaseException" in out
 
 

--- a/src/trio/_tests/test_repl.py
+++ b/src/trio/_tests/test_repl.py
@@ -121,7 +121,6 @@ async def test_KI_interrupts(
     await trio._repl.run_repl(console)
     out, err = capsys.readouterr()
     assert "KeyboardInterrupt" in err
-    assert "running" in out
     assert "should" not in out
     assert "AFTER KeyboardInterrupt" in out
 
@@ -188,6 +187,7 @@ async def test_base_exception_captured(
     monkeypatch.setattr(console, "raw_input", raw_input)
     await trio._repl.run_repl(console)
     out, err = capsys.readouterr()
+    assert "_threads.py" not in err
     assert "AFTER BaseException" in out
 
 
@@ -228,6 +228,7 @@ async def test_base_exception_capture_from_coroutine(
     monkeypatch.setattr(console, "raw_input", raw_input)
     await trio._repl.run_repl(console)
     out, err = capsys.readouterr()
+    assert "_threads.py" not in err
     assert "AFTER BaseException" in out
 
 

--- a/src/trio/_tests/test_repl.py
+++ b/src/trio/_tests/test_repl.py
@@ -187,8 +187,8 @@ async def test_base_exception_captured(
     monkeypatch.setattr(console, "raw_input", raw_input)
     await trio._repl.run_repl(console)
     out, err = capsys.readouterr()
-    if sys.version_info >= (3, 11):
-        assert "_threads.py" not in err
+    assert "_threads.py" not in err
+    assert "_repl.py" not in err
     assert "AFTER BaseException" in out
 
 
@@ -229,8 +229,8 @@ async def test_base_exception_capture_from_coroutine(
     monkeypatch.setattr(console, "raw_input", raw_input)
     await trio._repl.run_repl(console)
     out, err = capsys.readouterr()
-    if sys.version_info >= (3, 11):
-        assert "_threads.py" not in err
+    assert "_threads.py" not in err
+    assert "_repl.py" not in err
     assert "AFTER BaseException" in out
 
 


### PR DESCRIPTION
A follow up to #2972. These would have been review comments earlier if I knew the code was going to be (a) this simple and (b) in my wheelhouse!

I think `runcode` can just be:

``` python

    def runcode(self, code: types.CodeType) -> None:
        try:
            func = types.FunctionType(code, self.locals)
            if inspect.iscoroutinefunction(func):
                trio.from_thread.run(func)
            else:
                trio.from_thread.run_sync(func)
        except SystemExit:
            # ...snip...
            raise
        except BaseException:
            self.showtraceback()

```

It's less code, less layers of onion unwrapping, and the more common `from_thread.run_sync` is more efficient (not that anyone would notice latency from two extra checkpoints at the REPL). That's the first commit.

I also noticed one fragility, which is that KI works thanks to the thread task reentry feature combined with the fact that we inject `KeyboardInterrupt` into the main task.  If we were to go the route of https://github.com/python-trio/trio/issues/733#issuecomment-629126671 and just cancel everything and transmute to `KeyboardInterrupt` when the run finishes, the run would be cancelled. I put a test for this in the second commit.

Finally, we can hide the threading code frames from the traceback, although I'm not sure about editing the global exception state like that. that's the last commit.