### PR TITLE
Use `abc.ABC` rather than `abc.ABCMeta`

### DIFF
--- a/src/trio/_abc.py
+++ b/src/trio/_abc.py
@@ -215,6 +215,8 @@ class SocketFactory(ABC):
 
     """
 
+    __slots__ = ()
+
     @abstractmethod
     def socket(
         self,
@@ -696,3 +698,5 @@ class Channel(SendChannel[T], ReceiveChannel[T]):
     `ReceiveChannel` interfaces, so you can both send and receive objects.
 
     """
+
+    __slots__ = ()

--- a/src/trio/_abc.py
+++ b/src/trio/_abc.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import socket
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Generic, TypeVar
 
 import trio
@@ -16,9 +16,7 @@ if TYPE_CHECKING:
     from .lowlevel import Task
 
 
-# We use ABCMeta instead of ABC, plus set __slots__=(), so as not to force a
-# __dict__ onto subclasses.
-class Clock(metaclass=ABCMeta):
+class Clock(metaclass=ABC):
     """The interface for custom run loop clocks."""
 
     __slots__ = ()
@@ -68,7 +66,7 @@ class Clock(metaclass=ABCMeta):
         """
 
 
-class Instrument(metaclass=ABCMeta):  # noqa: B024  # conceptually is ABC
+class Instrument(ABC):  # noqa: B024  # conceptually is ABC
     """The interface for run loop instrumentation.
 
     Instruments don't have to inherit from this abstract base class, and all
@@ -155,7 +153,7 @@ class Instrument(metaclass=ABCMeta):  # noqa: B024  # conceptually is ABC
         return
 
 
-class HostnameResolver(metaclass=ABCMeta):
+class HostnameResolver(ABC):
     """If you have a custom hostname resolver, then implementing
     :class:`HostnameResolver` allows you to register this to be used by Trio.
 
@@ -209,7 +207,7 @@ class HostnameResolver(metaclass=ABCMeta):
         """
 
 
-class SocketFactory(metaclass=ABCMeta):
+class SocketFactory(ABC):
     """If you write a custom class implementing the Trio socket interface,
     then you can use a :class:`SocketFactory` to get Trio to use it.
 
@@ -240,7 +238,7 @@ class SocketFactory(metaclass=ABCMeta):
         """
 
 
-class AsyncResource(metaclass=ABCMeta):
+class AsyncResource(ABC):
     """A standard interface for resources that needs to be cleaned up, and
     where that cleanup may require blocking operations.
 

--- a/src/trio/_abc.py
+++ b/src/trio/_abc.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from .lowlevel import Task
 
 
-class Clock(metaclass=ABC):
+class Clock(ABC):
     """The interface for custom run loop clocks."""
 
     __slots__ = ()


### PR DESCRIPTION
[Since 3.7](https://github.com/python/cpython/issues/74648), CPython provides slots for `abc.ABC`. I'm not sure about pypy but a) they use the same stdlib so probably and b) slots on pypy don't mean anything.

This means trio can use `abc.ABC` instead of `abc.ABCMeta`.