### PR TITLE
Use Typevar defaults for `TaskStatus` and `Matcher`

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -113,8 +113,10 @@ def autodoc_process_signature(
         # name.
         assert isinstance(obj, property), obj
         assert isinstance(obj.fget, types.FunctionType), obj.fget
-        assert obj.fget.__annotations__["return"] == "type[E]", obj.fget.__annotations__
-        obj.fget.__annotations__["return"] = "type[~trio.testing._raises_group.E]"
+        assert (
+            obj.fget.__annotations__["return"] == "type[MatchE]"
+        ), obj.fget.__annotations__
+        obj.fget.__annotations__["return"] = "type[~trio.testing._raises_group.MatchE]"
     if signature is not None:
         signature = signature.replace("~_contextvars.Context", "~contextvars.Context")
         if name == "trio.lowlevel.RunVar":  # Typevar is not useful here.
@@ -123,13 +125,15 @@ def autodoc_process_signature(
             # Strip the type from the union, make it look like = ...
             signature = signature.replace(" | type[trio._core._local._NoValue]", "")
             signature = signature.replace("<class 'trio._core._local._NoValue'>", "...")
-        if (
-            name in ("trio.testing.RaisesGroup", "trio.testing.Matcher")
-            and "+E" in signature
+        if name in ("trio.testing.RaisesGroup", "trio.testing.Matcher") and (
+            "+E" in signature or "+MatchE" in signature
         ):
             # This typevar being covariant isn't handled correctly in some cases, strip the +
             # and insert the fully-qualified name.
             signature = signature.replace("+E", "~trio.testing._raises_group.E")
+            signature = signature.replace(
+                "+MatchE", "~trio.testing._raises_group.MatchE"
+            )
         if "DTLS" in name:
             signature = signature.replace("SSL.Context", "OpenSSL.SSL.Context")
         # Don't specify PathLike[str] | PathLike[bytes], this is just for humans.

--- a/src/trio/_core/_run.py
+++ b/src/trio/_core/_run.py
@@ -21,7 +21,6 @@ from typing import (
     Final,
     NoReturn,
     Protocol,
-    TypeVar,
     cast,
     overload,
 )
@@ -54,12 +53,6 @@ from ._traps import (
 if sys.version_info < (3, 11):
     from exceptiongroup import BaseExceptionGroup
 
-FnT = TypeVar("FnT", bound="Callable[..., Any]")
-StatusT = TypeVar("StatusT")
-StatusT_co = TypeVar("StatusT_co", covariant=True)
-StatusT_contra = TypeVar("StatusT_contra", contravariant=True)
-RetT = TypeVar("RetT")
-
 
 if TYPE_CHECKING:
     import contextvars
@@ -77,9 +70,19 @@ if TYPE_CHECKING:
     # for some strange reason Sphinx works with outcome.Outcome, but not Outcome, in
     # start_guest_run. Same with types.FrameType in iter_await_frames
     import outcome
-    from typing_extensions import Self, TypeVarTuple, Unpack
+    from typing_extensions import Self, TypeVar, TypeVarTuple, Unpack
 
     PosArgT = TypeVarTuple("PosArgT")
+    StatusT = TypeVar("StatusT", default=None)
+    StatusT_contra = TypeVar("StatusT_contra", contravariant=True, default=None)
+else:
+    from typing import TypeVar
+
+    StatusT = TypeVar("StatusT")
+    StatusT_contra = TypeVar("StatusT_contra", contravariant=True)
+
+FnT = TypeVar("FnT", bound="Callable[..., Any]")
+RetT = TypeVar("RetT")
 
 
 DEADLINE_HEAP_MIN_PRUNE_THRESHOLD: Final = 1000

--- a/src/trio/_tests/type_tests/raisesgroup.py
+++ b/src/trio/_tests/type_tests/raisesgroup.py
@@ -37,6 +37,14 @@ def check_inheritance_and_assignments() -> None:
     assert a
 
 
+def check_matcher_typevar_default(e: Matcher) -> object:
+    assert e.exception_type is not None
+    exc: type[BaseException] = e.exception_type
+    # this would previously pass, as the type would be `Any`
+    e.exception_type().blah()  # type: ignore
+    return exc  # Silence Pyright unused var warning
+
+
 def check_basic_contextmanager() -> None:
     # One level of Group is correctly translated - except it's a BaseExceptionGroup
     # instead of an ExceptionGroup.

--- a/src/trio/_tests/type_tests/task_status.py
+++ b/src/trio/_tests/type_tests/task_status.py
@@ -1,0 +1,29 @@
+"""Check that started() can only be called for TaskStatus[None]."""
+
+from trio import TaskStatus
+from typing_extensions import assert_type
+
+
+async def check_status(
+    none_status_explicit: TaskStatus[None],
+    none_status_implicit: TaskStatus,
+    int_status: TaskStatus[int],
+) -> None:
+    assert_type(none_status_explicit, TaskStatus[None])
+    assert_type(none_status_implicit, TaskStatus[None])  # Default typevar
+    assert_type(int_status, TaskStatus[int])
+
+    # Omitting the parameter is only allowed for None.
+    none_status_explicit.started()
+    none_status_implicit.started()
+    int_status.started()  # type: ignore
+
+    # Explicit None is allowed.
+    none_status_explicit.started(None)
+    none_status_implicit.started(None)
+    int_status.started(None)  # type: ignore
+
+    none_status_explicit.started(42)  # type: ignore
+    none_status_implicit.started(42)  # type: ignore
+    int_status.started(42)
+    int_status.started(True)

--- a/src/trio/_util.py
+++ b/src/trio/_util.py
@@ -203,23 +203,6 @@ def coroutine_or_error(
     return coro
 
 
-class EmptySuperclass:
-    """Used as a runtime placeholder for classes which should be imported only during TYPE_CHECKING.
-
-    This can be subscripted with anything, then gets discarded entirely from the base classes list.
-    """
-
-    def __getitem__(self, item: object) -> EmptySuperclass:
-        return self
-
-    def __mro_entries__(
-        self,
-        bases: tuple[type[object], ...],
-    ) -> tuple[type[object], ...]:
-        """This is discarded."""
-        return ()
-
-
 class ConflictDetector:
     """Detect when two tasks are about to perform operations that would
     conflict.

--- a/src/trio/_util.py
+++ b/src/trio/_util.py
@@ -203,6 +203,23 @@ def coroutine_or_error(
     return coro
 
 
+class EmptySuperclass:
+    """Used as a runtime placeholder for classes which should be imported only during TYPE_CHECKING.
+
+    This can be subscripted with anything, then gets discarded entirely from the base classes list.
+    """
+
+    def __getitem__(self, item: object) -> EmptySuperclass:
+        return self
+
+    def __mro_entries__(
+        self,
+        bases: tuple[type[object], ...],
+    ) -> tuple[type[object], ...]:
+        """This is discarded."""
+        return ()
+
+
 class ConflictDetector:
     """Detect when two tasks are about to perform operations that would
     conflict.

--- a/src/trio/testing/_raises_group.py
+++ b/src/trio/testing/_raises_group.py
@@ -15,7 +15,7 @@ from typing import (
 )
 
 from trio._deprecate import warn_deprecated
-from trio._util import EmptySuperclass, final
+from trio._util import final
 
 if TYPE_CHECKING:
     import builtins
@@ -108,7 +108,7 @@ class _ExceptionInfo(Generic[MatchE]):
         showlocals: bool = False,
         style: str = "long",
         abspath: bool = False,
-        tbfilter: bool | Callable[[_ExceptionInfo[BaseException]], Traceback] = True,
+        tbfilter: bool | Callable[[_ExceptionInfo], Traceback] = True,
         funcargs: bool = False,
         truncate_locals: bool = True,
         chain: bool = True,
@@ -268,14 +268,12 @@ class Matcher(Generic[MatchE]):
 if TYPE_CHECKING:
     SuperClass = BaseExceptionGroup
 else:
-    # At runtime, just discard this base class.
-    SuperClass = EmptySuperclass()
+    # At runtime, use a redundant Generic base class which effectively gets ignored.
+    SuperClass = Generic
 
 
 @final
-class RaisesGroup(
-    SuperClass[E], ContextManager[ExceptionInfo[BaseExceptionGroup[E]]], Generic[E]
-):
+class RaisesGroup(ContextManager[ExceptionInfo[BaseExceptionGroup[E]]], SuperClass[E]):
     """Contextmanager for checking for an expected `ExceptionGroup`.
     This works similar to ``pytest.raises``, and a version of it will hopefully be added upstream, after which this can be deprecated and removed. See https://github.com/pytest-dev/pytest/issues/11538
 

--- a/src/trio/testing/_raises_group.py
+++ b/src/trio/testing/_raises_group.py
@@ -233,7 +233,7 @@ class Matcher(Generic[MatchE]):
             return False
         # If exception_type is None check() accepts BaseException.
         # If non-none, we have done an isinstance check above.
-        if self.check is not None and not self.check(cast(E, exception)):
+        if self.check is not None and not self.check(cast(MatchE, exception)):
             return False
         return True
 

--- a/src/trio/testing/_raises_group.py
+++ b/src/trio/testing/_raises_group.py
@@ -10,7 +10,6 @@ from typing import (
     Literal,
     Pattern,
     Sequence,
-    TypeVar,
     cast,
     overload,
 )
@@ -26,12 +25,16 @@ if TYPE_CHECKING:
     import types
 
     from _pytest._code.code import ExceptionChainRepr, ReprExceptionInfo, Traceback
-    from typing_extensions import TypeGuard
+    from typing_extensions import TypeGuard, TypeVar
+
+    E = TypeVar("E", bound=BaseException, default=BaseException, covariant=True)
+else:
+    from typing import TypeVar
+
+    E = TypeVar("E", bound=BaseException, covariant=True)
 
 if sys.version_info < (3, 11):
     from exceptiongroup import BaseExceptionGroup
-
-E = TypeVar("E", bound=BaseException, covariant=True)
 
 
 @final

--- a/src/trio/testing/_raises_group.py
+++ b/src/trio/testing/_raises_group.py
@@ -36,6 +36,7 @@ else:
     MatchE = TypeVar("MatchE", bound=BaseException, covariant=True)
 # RaisesGroup doesn't work with a default.
 E = TypeVar("E", bound=BaseException, covariant=True)
+# These two typevars are special cased in sphinx config to workaround lookup bugs.
 
 if sys.version_info < (3, 11):
     from exceptiongroup import BaseExceptionGroup
@@ -64,6 +65,7 @@ class _ExceptionInfo(Generic[MatchE]):
         """Return an unfilled ExceptionInfo."""
         return cls(None)
 
+    # Note, special cased in sphinx config, since "type" conflicts.
     @property
     def type(self) -> type[MatchE]:
         """The exception class."""


### PR DESCRIPTION
This causes annotations to default to `TaskStatus[None]`, `RaisesGroup[BaseException]` and `Matcher[BaseException]`, instead of `Any`. [`_socket`](https://github.com/python-trio/trio/blob/451393acec35c3a01cba0c19de6bf8f6f23dbc7b/src/trio/_socket.py#L41-L52) could also use this to make `SocketType` generic over `AddressFormat`, but I'm not really sure how that should behave.