### PR TITLE
Update old references to `master` branch to be `main`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@
    :target: https://anaconda.org/conda-forge/trio
    :alt: Latest conda-forge version
 
-.. image:: https://codecov.io/gh/python-trio/trio/branch/master/graph/badge.svg
+.. image:: https://codecov.io/gh/python-trio/trio/branch/main/graph/badge.svg
    :target: https://codecov.io/gh/python-trio/trio
    :alt: Test coverage
 
@@ -31,7 +31,7 @@ Trio – a friendly Python library for async concurrency and I/O
 
 The Trio project aims to produce a production-quality,
 `permissively licensed
-<https://github.com/python-trio/trio/blob/master/LICENSE>`__,
+<https://github.com/python-trio/trio/blob/main/LICENSE>`__,
 async/await-native I/O library for Python. Like all async libraries,
 its main purpose is to help you write programs that do **multiple
 things at the same time** with **parallelized I/O**. A web spider that
@@ -134,7 +134,7 @@ choices
 **I want to make sure my company's lawyers won't get angry at me!** No
 worries, Trio is permissively licensed under your choice of MIT or
 Apache 2. See `LICENSE
-<https://github.com/python-trio/trio/blob/master/LICENSE>`__ for details.
+<https://github.com/python-trio/trio/blob/main/LICENSE>`__ for details.
 
 
 Code of conduct

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -350,7 +350,7 @@ Basically, every pull request that has a user
 visible effect should add a short file to the ``newsfragments/``
 directory describing the change, with a name like ``<ISSUE
 NUMBER>.<TYPE>.rst``. See `newsfragments/README.rst
-<https://github.com/python-trio/trio/blob/master/newsfragments/README.rst>`__
+<https://github.com/python-trio/trio/blob/main/newsfragments/README.rst>`__
 for details. This way we can keep a good list of changes as we go,
 which makes the release manager happy, which means we get more
 frequent releases, which means your change gets into users' hands

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,7 +9,7 @@ Trio: a friendly Python library for async concurrency and I/O
 
 The Trio project's goal is to produce a production-quality,
 `permissively licensed
-<https://github.com/python-trio/trio/blob/master/LICENSE>`__,
+<https://github.com/python-trio/trio/blob/main/LICENSE>`__,
 async/await-native I/O library for Python. Like all async libraries,
 its main purpose is to help you write programs that do **multiple
 things at the same time** with **parallelized I/O**. A web spider that

--- a/docs/source/releasing.rst
+++ b/docs/source/releasing.rst
@@ -35,7 +35,7 @@ Things to do for releasing:
 
 * push to your personal repository
 
-* create pull request to ``python-trio/trio``'s "master" branch
+* create pull request to ``python-trio/trio``'s "main" branch
 
 * verify that all checks succeeded
 


### PR DESCRIPTION
This is just finishing what I already started.

Note: the old links still work so there isn't any rush on merging this.