### PR TITLE
Enable ruff's `flake8-commas` rule

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,4 @@
 # sorting all imports with isort
 933f77b96f0092e1baab4474a9208fc2e379aa32
+# enabling ruff's flake8-commas rule
+b25c02a94e2defcb0fad32976b02218be1133bdf

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -132,7 +132,8 @@ def autodoc_process_signature(
             # and insert the fully-qualified name.
             signature = signature.replace("+E", "~trio.testing._raises_group.E")
             signature = signature.replace(
-                "+MatchE", "~trio.testing._raises_group.MatchE"
+                "+MatchE",
+                "~trio.testing._raises_group.MatchE",
             )
         if "DTLS" in name:
             signature = signature.replace("SSL.Context", "OpenSSL.SSL.Context")

--- a/notes-to-self/afd-lab.py
+++ b/notes-to-self/afd-lab.py
@@ -125,7 +125,7 @@ class AFDLab:
                     ffi.sizeof("AFD_POLL_INFO"),
                     ffi.NULL,
                     lpOverlapped,
-                )
+                ),
             )
         except OSError as exc:
             if exc.winerror != ErrorCodes.ERROR_IO_PENDING:  # pragma: no cover

--- a/notes-to-self/blocking-read-hack.py
+++ b/notes-to-self/blocking-read-hack.py
@@ -12,7 +12,9 @@ class BlockingReadTimeoutError(Exception):
 
 
 async def blocking_read_with_timeout(
-    fd, count, timeout  # noqa: ASYNC109  # manual timeout
+    fd,
+    count,
+    timeout,  # noqa: ASYNC109  # manual timeout
 ):
     print("reading from fd", fd)
     cancel_requested = False

--- a/notes-to-self/file-read-latency.py
+++ b/notes-to-self/file-read-latency.py
@@ -23,5 +23,5 @@ with open("/etc/passwd", "rb") as f:  # , buffering=0)
         seek = (end - between) / COUNT * 1e9
         read = both - seek
         print(
-            f"{both:.2f} ns/(seek+read), {seek:.2f} ns/seek, estimate ~{read:.2f} ns/read"
+            f"{both:.2f} ns/(seek+read), {seek:.2f} ns/seek, estimate ~{read:.2f} ns/read",
         )

--- a/notes-to-self/how-does-windows-so-reuseaddr-work.py
+++ b/notes-to-self/how-does-windows-so-reuseaddr-work.py
@@ -49,7 +49,7 @@ print(
     """
                                                        second bind
                                | """
-    + " | ".join(["%-19s" % mode for mode in modes])
+    + " | ".join(["%-19s" % mode for mode in modes]),
 )
 
 print("""                              """, end="")
@@ -58,7 +58,7 @@ for _ in modes:
 
 print(
     """
-first bind                     -----------------------------------------------------------------"""
+first bind                     -----------------------------------------------------------------""",
     #            default | wildcard |    INUSE |  Success |   ACCESS |  Success |    INUSE |  Success
 )
 
@@ -72,5 +72,5 @@ for mode1 in modes:
                 # print(mode1, bind_type1, mode2, bind_type2, entry)
         print(
             f"{mode1:>19} | {bind_type1:>8} | "
-            + " | ".join(["%8s" % entry for entry in row])
+            + " | ".join(["%8s" % entry for entry in row]),
         )

--- a/notes-to-self/manual-signal-handler.py
+++ b/notes-to-self/manual-signal-handler.py
@@ -11,11 +11,12 @@ if os.name == "nt":
         """
         void* WINAPI GetProcAddress(void* hModule, char* lpProcName);
         typedef void (*PyOS_sighandler_t)(int);
-    """
+    """,
     )
     kernel32 = ffi.dlopen("kernel32.dll")
     PyOS_getsig_ptr = kernel32.GetProcAddress(
-        ffi.cast("void*", sys.dllhandle), b"PyOS_getsig"
+        ffi.cast("void*", sys.dllhandle),
+        b"PyOS_getsig",
     )
     PyOS_getsig = ffi.cast("PyOS_sighandler_t (*)(int)", PyOS_getsig_ptr)
 

--- a/notes-to-self/proxy-benchmarks.py
+++ b/notes-to-self/proxy-benchmarks.py
@@ -54,7 +54,7 @@ def add_wrapper(cls, method):
         f"""
         def wrapper(self, *args, **kwargs):
             return self._wrapped.{method}(*args, **kwargs)
-    """
+    """,
     )
     ns = {}
     exec(code, ns)
@@ -113,7 +113,7 @@ def add_wrapper(cls, attr):
 
         def deleter(self):
             del self._wrapped.{attr}
-    """
+    """,
     )
     ns = {}
     exec(code, ns)

--- a/notes-to-self/ssl-handshake/ssl-handshake.py
+++ b/notes-to-self/ssl-handshake/ssl-handshake.py
@@ -27,7 +27,9 @@ def echo_server_connection():
     client_sock, server_sock = socket.socketpair()
     with client_sock, server_sock:
         t = threading.Thread(
-            target=_ssl_echo_serve_sync, args=(server_sock,), daemon=True
+            target=_ssl_echo_serve_sync,
+            args=(server_sock,),
+            daemon=True,
         )
         t.start()
 
@@ -101,7 +103,9 @@ for wrap_socket in [
     with echo_server_connection() as client_sock:
         client_ctx = ssl.create_default_context(cafile="trio-test-CA.pem")
         wrapped = wrap_socket(
-            client_ctx, client_sock, server_hostname="trio-test-1.example.org"
+            client_ctx,
+            client_sock,
+            server_hostname="trio-test-1.example.org",
         )
         wrapped.do_handshake()
         wrapped.sendall(b"x")
@@ -113,7 +117,9 @@ for wrap_socket in [
     with echo_server_connection() as client_sock:
         client_ctx = ssl.create_default_context(cafile="trio-test-CA.pem")
         wrapped = wrap_socket(
-            client_ctx, client_sock, server_hostname="trio-test-2.example.org"
+            client_ctx,
+            client_sock,
+            server_hostname="trio-test-2.example.org",
         )
         try:
             wrapped.do_handshake()
@@ -126,7 +132,9 @@ for wrap_socket in [
     with echo_server_connection() as client_sock:
         client_ctx = ssl.create_default_context(cafile="trio-test-CA.pem")
         wrapped = wrap_socket(
-            client_ctx, client_sock, server_hostname="trio-test-2.example.org"
+            client_ctx,
+            client_sock,
+            server_hostname="trio-test-2.example.org",
         )
         # We forgot to call do_handshake
         # But the hostname is wrong so something had better error out...

--- a/notes-to-self/wakeup-fd-racer.py
+++ b/notes-to-self/wakeup-fd-racer.py
@@ -91,7 +91,7 @@ def main():
         if duration < 2:
             print(
                 f"Attempt {attempt}: OK, trying again "
-                f"(select_calls = {select_calls}, drained = {drained})"
+                f"(select_calls = {select_calls}, drained = {drained})",
             )
         else:
             print(f"Attempt {attempt}: FAILED, took {duration} seconds")

--- a/notes-to-self/win-waitable-timer.py
+++ b/notes-to-self/win-waitable-timer.py
@@ -49,7 +49,7 @@ typedef struct _SYSTEMTIME {
   WORD wSecond;
   WORD wMilliseconds;
 } SYSTEMTIME, *PSYSTEMTIME, *LPSYSTEMTIME;
-"""
+""",
     )
 
 ffi.cdef(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ select = [
     "ASYNC", # flake8-async
     "B",     # flake8-bugbear
     "C4",    # flake8-comprehensions
+    "COM",   # flake8-commas
     "E",     # Error
     "EXE",   # flake8-executable
     "F",     # pyflakes

--- a/src/trio/_abc.py
+++ b/src/trio/_abc.py
@@ -198,7 +198,9 @@ class HostnameResolver(ABC):
 
     @abstractmethod
     async def getnameinfo(
-        self, sockaddr: tuple[str, int] | tuple[str, int, int, int], flags: int
+        self,
+        sockaddr: tuple[str, int] | tuple[str, int, int, int],
+        flags: int,
     ) -> tuple[str, str]:
         """A custom implementation of :func:`~trio.socket.getnameinfo`.
 

--- a/src/trio/_channel.py
+++ b/src/trio/_channel.py
@@ -96,7 +96,8 @@ if TYPE_CHECKING:
     # Need to use Tuple instead of tuple due to CI check running on 3.8
     class open_memory_channel(Tuple["MemorySendChannel[T]", "MemoryReceiveChannel[T]"]):
         def __new__(  # type: ignore[misc]  # "must return a subtype"
-            cls, max_buffer_size: int | float  # noqa: PYI041
+            cls,
+            max_buffer_size: int | float,  # noqa: PYI041
         ) -> tuple[MemorySendChannel[T], MemoryReceiveChannel[T]]:
             return _open_memory_channel(max_buffer_size)
 

--- a/src/trio/_core/_asyncgens.py
+++ b/src/trio/_core/_asyncgens.py
@@ -60,7 +60,8 @@ class AsyncGenerators:
                     self.prev_hooks.firstiter(agen)
 
         def finalize_in_trio_context(
-            agen: AsyncGeneratorType[object, NoReturn], agen_name: str
+            agen: AsyncGeneratorType[object, NoReturn],
+            agen_name: str,
         ) -> None:
             try:
                 runner.spawn_system_task(
@@ -85,7 +86,9 @@ class AsyncGenerators:
 
             if is_ours:
                 runner.entry_queue.run_sync_soon(
-                    finalize_in_trio_context, agen, agen_name
+                    finalize_in_trio_context,
+                    agen,
+                    agen_name,
                 )
 
                 # Do this last, because it might raise an exception
@@ -123,7 +126,7 @@ class AsyncGenerators:
                         raise RuntimeError(
                             f"Non-Trio async generator {agen_name!r} awaited something "
                             "during finalization; install a finalization hook to "
-                            "support this, or wrap it in 'async with aclosing(...):'"
+                            "support this, or wrap it in 'async with aclosing(...):'",
                         )
 
         self.prev_hooks = sys.get_asyncgen_hooks()
@@ -146,7 +149,7 @@ class AsyncGenerators:
         # them was an asyncgen finalizer that snuck in under the wire.
         runner.entry_queue.run_sync_soon(runner.reschedule, runner.init_task)
         await _core.wait_task_rescheduled(
-            lambda _: _core.Abort.FAILED  # pragma: no cover
+            lambda _: _core.Abort.FAILED,  # pragma: no cover
         )
         self.alive.update(self.trailing_needs_finalize)
         self.trailing_needs_finalize.clear()
@@ -193,7 +196,9 @@ class AsyncGenerators:
         sys.set_asyncgen_hooks(*self.prev_hooks)
 
     async def _finalize_one(
-        self, agen: AsyncGeneratorType[object, NoReturn], name: object
+        self,
+        agen: AsyncGeneratorType[object, NoReturn],
+        name: object,
     ) -> None:
         try:
             # This shield ensures that finalize_asyncgen never exits

--- a/src/trio/_core/_concat_tb.py
+++ b/src/trio/_core/_concat_tb.py
@@ -104,7 +104,8 @@ else:
             return operation.delegate()  # Delegate is reverting to original behaviour
 
         return cast(
-            TracebackType, tputil.make_proxy(controller, type(base_tb), base_tb)
+            TracebackType,
+            tputil.make_proxy(controller, type(base_tb), base_tb),
         )  # Returns proxy to traceback
 
 
@@ -112,7 +113,8 @@ else:
 # `strict_exception_groups=False`. Once that is retired this function and its helper can
 # be removed as well.
 def concat_tb(
-    head: TracebackType | None, tail: TracebackType | None
+    head: TracebackType | None,
+    tail: TracebackType | None,
 ) -> TracebackType | None:
     # We have to use an iterative algorithm here, because in the worst case
     # this might be a RecursionError stack that is by definition too deep to

--- a/src/trio/_core/_entry_queue.py
+++ b/src/trio/_core/_entry_queue.py
@@ -77,7 +77,7 @@ class EntryQueue:
                     parent_nursery = _core.current_task().parent_nursery
                     if parent_nursery is None:
                         raise AssertionError(
-                            "Internal error: `parent_nursery` should never be `None`"
+                            "Internal error: `parent_nursery` should never be `None`",
                         ) from exc  # pragma: no cover
                     parent_nursery.start_soon(kill_everything, exc)
 

--- a/src/trio/_core/_generated_io_kqueue.py
+++ b/src/trio/_core/_generated_io_kqueue.py
@@ -42,7 +42,8 @@ def current_kqueue() -> select.kqueue:
 
 
 def monitor_kevent(
-    ident: int, filter: int
+    ident: int,
+    filter: int,
 ) -> ContextManager[_core.UnboundedQueue[select.kevent]]:
     """TODO: these are implemented, but are currently more of a sketch than
     anything real. See `#26
@@ -56,7 +57,9 @@ def monitor_kevent(
 
 
 async def wait_kevent(
-    ident: int, filter: int, abort_func: Callable[[RaiseCancelT], Abort]
+    ident: int,
+    filter: int,
+    abort_func: Callable[[RaiseCancelT], Abort],
 ) -> Abort:
     """TODO: these are implemented, but are currently more of a sketch than
     anything real. See `#26
@@ -65,7 +68,9 @@ async def wait_kevent(
     sys._getframe().f_locals[LOCALS_KEY_KI_PROTECTION_ENABLED] = True
     try:
         return await GLOBAL_RUN_CONTEXT.runner.io_manager.wait_kevent(
-            ident, filter, abort_func
+            ident,
+            filter,
+            abort_func,
         )
     except AttributeError:
         raise RuntimeError("must be called from async context") from None

--- a/src/trio/_core/_generated_io_windows.py
+++ b/src/trio/_core/_generated_io_windows.py
@@ -134,14 +134,17 @@ async def wait_overlapped(handle_: int | CData, lpOverlapped: CData | int) -> ob
     sys._getframe().f_locals[LOCALS_KEY_KI_PROTECTION_ENABLED] = True
     try:
         return await GLOBAL_RUN_CONTEXT.runner.io_manager.wait_overlapped(
-            handle_, lpOverlapped
+            handle_,
+            lpOverlapped,
         )
     except AttributeError:
         raise RuntimeError("must be called from async context") from None
 
 
 async def write_overlapped(
-    handle: int | CData, data: Buffer, file_offset: int = 0
+    handle: int | CData,
+    data: Buffer,
+    file_offset: int = 0,
 ) -> int:
     """TODO: these are implemented, but are currently more of a sketch than
     anything real. See `#26
@@ -151,14 +154,18 @@ async def write_overlapped(
     sys._getframe().f_locals[LOCALS_KEY_KI_PROTECTION_ENABLED] = True
     try:
         return await GLOBAL_RUN_CONTEXT.runner.io_manager.write_overlapped(
-            handle, data, file_offset
+            handle,
+            data,
+            file_offset,
         )
     except AttributeError:
         raise RuntimeError("must be called from async context") from None
 
 
 async def readinto_overlapped(
-    handle: int | CData, buffer: Buffer, file_offset: int = 0
+    handle: int | CData,
+    buffer: Buffer,
+    file_offset: int = 0,
 ) -> int:
     """TODO: these are implemented, but are currently more of a sketch than
     anything real. See `#26
@@ -168,7 +175,9 @@ async def readinto_overlapped(
     sys._getframe().f_locals[LOCALS_KEY_KI_PROTECTION_ENABLED] = True
     try:
         return await GLOBAL_RUN_CONTEXT.runner.io_manager.readinto_overlapped(
-            handle, buffer, file_offset
+            handle,
+            buffer,
+            file_offset,
         )
     except AttributeError:
         raise RuntimeError("must be called from async context") from None

--- a/src/trio/_core/_generated_run.py
+++ b/src/trio/_core/_generated_run.py
@@ -187,7 +187,10 @@ def spawn_system_task(
     sys._getframe().f_locals[LOCALS_KEY_KI_PROTECTION_ENABLED] = True
     try:
         return GLOBAL_RUN_CONTEXT.runner.spawn_system_task(
-            async_fn, *args, name=name, context=context
+            async_fn,
+            *args,
+            name=name,
+            context=context,
         )
     except AttributeError:
         raise RuntimeError("must be called from async context") from None

--- a/src/trio/_core/_io_epoll.py
+++ b/src/trio/_core/_io_epoll.py
@@ -205,7 +205,7 @@ class EpollIOManager:
     _epoll: select.epoll = attrs.Factory(lambda: select.epoll())
     # {fd: EpollWaiters}
     _registered: defaultdict[int, EpollWaiters] = attrs.Factory(
-        lambda: defaultdict(EpollWaiters)
+        lambda: defaultdict(EpollWaiters),
     )
     _force_wakeup: WakeupSocketpair = attrs.Factory(WakeupSocketpair)
     _force_wakeup_fd: int | None = None
@@ -298,7 +298,7 @@ class EpollIOManager:
         waiters = self._registered[fd]
         if getattr(waiters, attr_name) is not None:
             raise _core.BusyResourceError(
-                "another task is already reading / writing this fd"
+                "another task is already reading / writing this fd",
             )
         setattr(waiters, attr_name, _core.current_task())
         self._update_registrations(fd)

--- a/src/trio/_core/_io_kqueue.py
+++ b/src/trio/_core/_io_kqueue.py
@@ -43,7 +43,9 @@ class KqueueIOManager:
 
     def __attrs_post_init__(self) -> None:
         force_wakeup_event = select.kevent(
-            self._force_wakeup.wakeup_sock, select.KQ_FILTER_READ, select.KQ_EV_ADD
+            self._force_wakeup.wakeup_sock,
+            select.KQ_FILTER_READ,
+            select.KQ_EV_ADD,
         )
         self._kqueue.control([force_wakeup_event], 0)
         self._force_wakeup_fd = self._force_wakeup.wakeup_sock.fileno()
@@ -129,7 +131,7 @@ class KqueueIOManager:
         key = (ident, filter)
         if key in self._registered:
             raise _core.BusyResourceError(
-                "attempt to register multiple listeners for same ident/filter pair"
+                "attempt to register multiple listeners for same ident/filter pair",
             )
         q = _core.UnboundedQueue[select.kevent]()
         self._registered[key] = q
@@ -152,7 +154,7 @@ class KqueueIOManager:
         key = (ident, filter)
         if key in self._registered:
             raise _core.BusyResourceError(
-                "attempt to register multiple listeners for same ident/filter pair"
+                "attempt to register multiple listeners for same ident/filter pair",
             )
         self._registered[key] = _core.current_task()
 
@@ -286,5 +288,5 @@ class KqueueIOManager:
                 # XX this is an interesting example of a case where being able
                 # to close a queue would be useful...
                 raise NotImplementedError(
-                    "can't close an fd that monitor_kevent is using"
+                    "can't close an fd that monitor_kevent is using",
                 )

--- a/src/trio/_core/_io_windows.py
+++ b/src/trio/_core/_io_windows.py
@@ -303,7 +303,9 @@ def _check(success: T) -> T:
 
 
 def _get_underlying_socket(
-    sock: _HasFileNo | int | Handle, *, which: WSAIoctls = WSAIoctls.SIO_BASE_HANDLE
+    sock: _HasFileNo | int | Handle,
+    *,
+    which: WSAIoctls = WSAIoctls.SIO_BASE_HANDLE,
 ) -> Handle:
     if hasattr(sock, "fileno"):
         sock = sock.fileno()
@@ -354,7 +356,8 @@ def _get_base_socket(sock: _HasFileNo | int | Handle) -> Handle:
                 sock = sock.fileno()
             sock = _handle(sock)
             next_sock = _get_underlying_socket(
-                sock, which=WSAIoctls.SIO_BSP_HANDLE_POLL
+                sock,
+                which=WSAIoctls.SIO_BSP_HANDLE_POLL,
             )
             if next_sock == sock:
                 # If BSP_HANDLE_POLL returns the same socket we already had,
@@ -366,7 +369,7 @@ def _get_base_socket(sock: _HasFileNo | int | Handle) -> Handle:
                     "return a different socket. Please file a bug at "
                     "https://github.com/python-trio/trio/issues/new, "
                     "and include the output of running: "
-                    "netsh winsock show catalog"
+                    "netsh winsock show catalog",
                 ) from ex
             # Otherwise we've gotten at least one layer deeper, so
             # loop back around to keep digging.
@@ -421,7 +424,7 @@ class WindowsIOManager:
         self._all_afd_handles: list[Handle] = []
 
         self._iocp = _check(
-            kernel32.CreateIoCompletionPort(INVALID_HANDLE_VALUE, ffi.NULL, 0, 0)
+            kernel32.CreateIoCompletionPort(INVALID_HANDLE_VALUE, ffi.NULL, 0, 0),
         )
         self._events = ffi.new("OVERLAPPED_ENTRY[]", MAX_EVENTS)
 
@@ -454,7 +457,8 @@ class WindowsIOManager:
             # LSPs can in theory override this, but we believe that it never
             # actually happens in the wild (except Komodia)
             select_handle = _get_underlying_socket(
-                s, which=WSAIoctls.SIO_BSP_HANDLE_SELECT
+                s,
+                which=WSAIoctls.SIO_BSP_HANDLE_SELECT,
             )
             try:
                 # LSPs shouldn't override this...
@@ -472,7 +476,7 @@ class WindowsIOManager:
                         "Please file a bug at "
                         "https://github.com/python-trio/trio/issues/new, "
                         "and include the output of running: "
-                        "netsh winsock show catalog"
+                        "netsh winsock show catalog",
                     )
 
     def close(self) -> None:
@@ -508,8 +512,11 @@ class WindowsIOManager:
         assert self._iocp is not None
         _check(
             kernel32.PostQueuedCompletionStatus(
-                self._iocp, 0, CKeys.FORCE_WAKEUP, ffi.NULL
-            )
+                self._iocp,
+                0,
+                CKeys.FORCE_WAKEUP,
+                ffi.NULL,
+            ),
         )
 
     def get_events(self, timeout: float) -> EventResult:
@@ -521,8 +528,13 @@ class WindowsIOManager:
             assert self._iocp is not None
             _check(
                 kernel32.GetQueuedCompletionStatusEx(
-                    self._iocp, self._events, MAX_EVENTS, received, milliseconds, 0
-                )
+                    self._iocp,
+                    self._events,
+                    MAX_EVENTS,
+                    received,
+                    milliseconds,
+                    0,
+                ),
             )
         except OSError as exc:
             if exc.winerror != ErrorCodes.WAIT_TIMEOUT:  # pragma: no cover
@@ -563,7 +575,8 @@ class WindowsIOManager:
                 overlapped = entry.lpOverlapped
                 transferred = entry.dwNumberOfBytesTransferred
                 info = CompletionKeyEventInfo(
-                    lpOverlapped=overlapped, dwNumberOfBytesTransferred=transferred
+                    lpOverlapped=overlapped,
+                    dwNumberOfBytesTransferred=transferred,
                 )
                 _core.reschedule(waiter, Value(info))
             elif entry.lpCompletionKey == CKeys.LATE_CANCEL:
@@ -586,7 +599,7 @@ class WindowsIOManager:
                     exc = _core.TrioInternalError(
                         f"Failed to cancel overlapped I/O in {waiter.name} and didn't "
                         "receive the completion either. Did you forget to "
-                        "call register_with_iocp()?"
+                        "call register_with_iocp()?",
                     )
                     # Raising this out of handle_io ensures that
                     # the user will see our message even if some
@@ -608,7 +621,8 @@ class WindowsIOManager:
                 overlapped = int(ffi.cast("uintptr_t", entry.lpOverlapped))
                 transferred = entry.dwNumberOfBytesTransferred
                 info = CompletionKeyEventInfo(
-                    lpOverlapped=overlapped, dwNumberOfBytesTransferred=transferred
+                    lpOverlapped=overlapped,
+                    dwNumberOfBytesTransferred=transferred,
                 )
                 queue.put_nowait(info)
 
@@ -622,8 +636,9 @@ class WindowsIOManager:
         # Ref: http://www.lenholgate.com/blog/2009/09/interesting-blog-posts-on-high-performance-servers.html
         _check(
             kernel32.SetFileCompletionNotificationModes(
-                handle, CompletionModes.FILE_SKIP_SET_EVENT_ON_HANDLE
-            )
+                handle,
+                CompletionModes.FILE_SKIP_SET_EVENT_ON_HANDLE,
+            ),
         )
 
     ################################################################
@@ -637,8 +652,9 @@ class WindowsIOManager:
             try:
                 _check(
                     kernel32.CancelIoEx(
-                        afd_group.handle, waiters.current_op.lpOverlapped
-                    )
+                        afd_group.handle,
+                        waiters.current_op.lpOverlapped,
+                    ),
                 )
             except OSError as exc:
                 if exc.winerror != ErrorCodes.ERROR_NOT_FOUND:
@@ -687,7 +703,7 @@ class WindowsIOManager:
                         ffi.sizeof("AFD_POLL_INFO"),
                         ffi.NULL,
                         lpOverlapped,
-                    )
+                    ),
                 )
             except OSError as exc:
                 if exc.winerror != ErrorCodes.ERROR_IO_PENDING:
@@ -813,7 +829,9 @@ class WindowsIOManager:
 
     @_public
     async def wait_overlapped(
-        self, handle_: int | CData, lpOverlapped: CData | int
+        self,
+        handle_: int | CData,
+        lpOverlapped: CData | int,
     ) -> object:
         """TODO: these are implemented, but are currently more of a sketch than
         anything real. See `#26
@@ -825,7 +843,7 @@ class WindowsIOManager:
             lpOverlapped = ffi.cast("LPOVERLAPPED", lpOverlapped)
         if lpOverlapped in self._overlapped_waiters:
             raise _core.BusyResourceError(
-                "another task is already waiting on that lpOverlapped"
+                "another task is already waiting on that lpOverlapped",
             )
         task = _core.current_task()
         self._overlapped_waiters[lpOverlapped] = task
@@ -852,8 +870,11 @@ class WindowsIOManager:
                     # does, we'll assume the handle wasn't registered.
                     _check(
                         kernel32.PostQueuedCompletionStatus(
-                            self._iocp, 0, CKeys.LATE_CANCEL, lpOverlapped
-                        )
+                            self._iocp,
+                            0,
+                            CKeys.LATE_CANCEL,
+                            lpOverlapped,
+                        ),
                     )
                     # Keep the lpOverlapped referenced so its address
                     # doesn't get reused until our posted completion
@@ -863,7 +884,7 @@ class WindowsIOManager:
                     self._posted_too_late_to_cancel.add(lpOverlapped)
                 else:  # pragma: no cover
                     raise _core.TrioInternalError(
-                        "CancelIoEx failed with unexpected error"
+                        "CancelIoEx failed with unexpected error",
                     ) from exc
             return _core.Abort.FAILED
 
@@ -888,7 +909,9 @@ class WindowsIOManager:
         return info
 
     async def _perform_overlapped(
-        self, handle: int | CData, submit_fn: Callable[[_Overlapped], None]
+        self,
+        handle: int | CData,
+        submit_fn: Callable[[_Overlapped], None],
     ) -> _Overlapped:
         # submit_fn(lpOverlapped) submits some I/O
         # it may raise an OSError with ERROR_IO_PENDING
@@ -909,7 +932,10 @@ class WindowsIOManager:
 
     @_public
     async def write_overlapped(
-        self, handle: int | CData, data: Buffer, file_offset: int = 0
+        self,
+        handle: int | CData,
+        data: Buffer,
+        file_offset: int = 0,
     ) -> int:
         """TODO: these are implemented, but are currently more of a sketch than
         anything real. See `#26
@@ -930,7 +956,7 @@ class WindowsIOManager:
                         len(cbuf),
                         ffi.NULL,
                         lpOverlapped,
-                    )
+                    ),
                 )
 
             lpOverlapped = await self._perform_overlapped(handle, submit_write)
@@ -939,7 +965,10 @@ class WindowsIOManager:
 
     @_public
     async def readinto_overlapped(
-        self, handle: int | CData, buffer: Buffer, file_offset: int = 0
+        self,
+        handle: int | CData,
+        buffer: Buffer,
+        file_offset: int = 0,
     ) -> int:
         """TODO: these are implemented, but are currently more of a sketch than
         anything real. See `#26
@@ -959,7 +988,7 @@ class WindowsIOManager:
                         len(cbuf),
                         ffi.NULL,
                         lpOverlapped,
-                    )
+                    ),
                 )
 
             lpOverlapped = await self._perform_overlapped(handle, submit_read)

--- a/src/trio/_core/_parking_lot.py
+++ b/src/trio/_core/_parking_lot.py
@@ -182,7 +182,10 @@ class ParkingLot:
 
     @_core.enable_ki_protection
     def repark(
-        self, new_lot: ParkingLot, *, count: int | float = 1  # noqa: PYI041
+        self,
+        new_lot: ParkingLot,
+        *,
+        count: int | float = 1,  # noqa: PYI041
     ) -> None:
         """Move parked tasks from one :class:`ParkingLot` object to another.
 

--- a/src/trio/_core/_run.py
+++ b/src/trio/_core/_run.py
@@ -142,7 +142,7 @@ def _count_context_run_tb_frames() -> int:
             raise
         else:  # pragma: no cover
             raise TrioInternalError(
-                "A ZeroDivisionError should have been raised, but it wasn't."
+                "A ZeroDivisionError should have been raised, but it wasn't.",
             )
 
     ctx = copy_context()
@@ -160,7 +160,7 @@ def _count_context_run_tb_frames() -> int:
     else:  # pragma: no cover
         raise TrioInternalError(
             f"The purpose of {function_with_unique_name_xyzzy.__name__} is "
-            "to raise a ZeroDivisionError, but it didn't."
+            "to raise a ZeroDivisionError, but it didn't.",
         )
 
 
@@ -219,7 +219,8 @@ def collapse_exception_group(
         and NONSTRICT_EXCEPTIONGROUP_NOTE in getattr(excgroup, "__notes__", ())
     ):
         exceptions[0].__traceback__ = concat_tb(
-            excgroup.__traceback__, exceptions[0].__traceback__
+            excgroup.__traceback__,
+            exceptions[0].__traceback__,
         )
         return exceptions[0]
     elif modified:
@@ -550,7 +551,7 @@ class CancelScope:
         task = _core.current_task()
         if self._has_been_entered:
             raise RuntimeError(
-                "Each CancelScope may only be used for a single 'with' block"
+                "Each CancelScope may only be used for a single 'with' block",
             )
         self._has_been_entered = True
         if current_time() >= self._deadline:
@@ -564,7 +565,7 @@ class CancelScope:
         if self._cancel_status is None:
             new_exc = RuntimeError(
                 f"Cancel scope stack corrupted: attempted to exit {self!r} "
-                "which had already been exited"
+                "which had already been exited",
             )
             new_exc.__context__ = exc
             return new_exc
@@ -586,7 +587,7 @@ class CancelScope:
                 # without changing any state.
                 new_exc = RuntimeError(
                     f"Cancel scope stack corrupted: attempted to exit {self!r} "
-                    f"from unrelated {scope_task!r}\n{MISNESTING_ADVICE}"
+                    f"from unrelated {scope_task!r}\n{MISNESTING_ADVICE}",
                 )
                 new_exc.__context__ = exc
                 return new_exc
@@ -598,7 +599,7 @@ class CancelScope:
                 # pass silently.
                 new_exc = RuntimeError(
                     f"Cancel scope stack corrupted: attempted to exit {self!r} "
-                    f"in {scope_task!r} that's still within its child {scope_task._cancel_status._scope!r}\n{MISNESTING_ADVICE}"
+                    f"in {scope_task!r} that's still within its child {scope_task._cancel_status._scope!r}\n{MISNESTING_ADVICE}",
                 )
                 new_exc.__context__ = exc
                 exc = new_exc
@@ -932,7 +933,9 @@ class NurseryManager:
         self._scope = CancelScope()
         self._scope.__enter__()
         self._nursery = Nursery._create(
-            current_task(), self._scope, self.strict_exception_groups
+            current_task(),
+            self._scope,
+            self.strict_exception_groups,
         )
         return self._nursery
 
@@ -970,7 +973,7 @@ class NurseryManager:
 
         def __enter__(self) -> NoReturn:
             raise RuntimeError(
-                "use 'async with open_nursery(...)', not 'with open_nursery(...)'"
+                "use 'async with open_nursery(...)', not 'with open_nursery(...)'",
             )
 
         def __exit__(
@@ -1099,7 +1102,8 @@ class Nursery(metaclass=NoPublicConstructor):
         self._check_nursery_closed()
 
     async def _nested_child_finished(
-        self, nested_child_exc: BaseException | None
+        self,
+        nested_child_exc: BaseException | None,
     ) -> BaseException | None:
         # Returns ExceptionGroup instance (or any exception if the nursery is in loose mode
         # and there is just one contained exception) if there are pending exceptions
@@ -1138,7 +1142,8 @@ class Nursery(metaclass=NoPublicConstructor):
                 if not self._strict_exception_groups and len(self._pending_excs) == 1:
                     return self._pending_excs[0]
                 exception = BaseExceptionGroup(
-                    "Exceptions from Trio nursery", self._pending_excs
+                    "Exceptions from Trio nursery",
+                    self._pending_excs,
                 )
                 if not self._strict_exception_groups:
                     exception.add_note(NONSTRICT_EXCEPTIONGROUP_NOTE)
@@ -1255,7 +1260,10 @@ class Nursery(metaclass=NoPublicConstructor):
                     task_status: _TaskStatus[Any] = _TaskStatus(old_nursery, self)
                     thunk = functools.partial(async_fn, task_status=task_status)
                     task = GLOBAL_RUN_CONTEXT.runner.spawn_impl(
-                        thunk, args, old_nursery, name
+                        thunk,
+                        args,
+                        old_nursery,
+                        name,
                     )
                     task._eventual_parent_nursery = self
                     # Wait for either TaskStatus.started or an exception to
@@ -1266,7 +1274,7 @@ class Nursery(metaclass=NoPublicConstructor):
                 raise TrioInternalError(
                     "Internal nursery should not have multiple tasks. This can be "
                     'caused by the user managing to access the "old" nursery in '
-                    "`task_status` and spawning tasks in it."
+                    "`task_status` and spawning tasks in it.",
                 ) from exc
 
             # If we get here, then the child either got reparented or exited
@@ -1557,7 +1565,8 @@ class GuestState:
 
         # Optimization: try to skip going into the thread if we can avoid it
         events_outcome: Value[EventResult] | Error = capture(
-            self.runner.io_manager.get_events, 0
+            self.runner.io_manager.get_events,
+            0,
         )
         if timeout <= 0 or isinstance(events_outcome, Error) or events_outcome.value:
             # No need to go into the thread
@@ -1696,7 +1705,9 @@ class Runner:
 
     @_public  # Type-ignore due to use of Any here.
     def reschedule(  # type: ignore[misc]
-        self, task: Task, next_send: Outcome[Any] = _NO_SEND
+        self,
+        task: Task,
+        next_send: Outcome[Any] = _NO_SEND,
     ) -> None:
         """Reschedule the given task with the given
         :class:`outcome.Outcome`.
@@ -1789,7 +1800,11 @@ class Runner:
         # Set up the Task object
         ######
         task = Task._create(
-            coro=coro, parent_nursery=nursery, runner=self, name=name, context=context
+            coro=coro,
+            parent_nursery=nursery,
+            runner=self,
+            name=name,
+            context=context,
         )
 
         self.tasks.add(task)
@@ -1819,7 +1834,7 @@ class Runner:
                 # traceback frame included
                 raise RuntimeError(
                     "Cancel scope stack corrupted: cancel scope surrounding "
-                    f"{task!r} was closed before the task exited\n{MISNESTING_ADVICE}"
+                    f"{task!r} was closed before the task exited\n{MISNESTING_ADVICE}",
                 )
             except RuntimeError as new_exc:
                 if isinstance(outcome, Error):
@@ -1932,7 +1947,10 @@ class Runner:
                 async with open_nursery() as main_task_nursery:
                     try:
                         self.main_task = self.spawn_impl(
-                            async_fn, args, main_task_nursery, None
+                            async_fn,
+                            args,
+                            main_task_nursery,
+                            None,
                         )
                     except BaseException as exc:
                         self.main_task_outcome = Error(exc)
@@ -2424,7 +2442,8 @@ def start_guest_run(
     # this time, so it shouldn't be possible to get an exception here,
     # except for a TrioInternalError.
     next_send = cast(
-        EventResult, None
+        EventResult,
+        None,
     )  # First iteration must be `None`, every iteration after that is EventResult
     for _tick in range(5):  # expected need is 2 iterations + leave some wiggle room
         if runner.system_nursery is not None:
@@ -2434,13 +2453,13 @@ def start_guest_run(
             timeout = guest_state.unrolled_run_gen.send(next_send)
         except StopIteration:  # pragma: no cover
             raise TrioInternalError(
-                "Guest runner exited before system nursery was initialized"
+                "Guest runner exited before system nursery was initialized",
             ) from None
         if timeout != 0:  # pragma: no cover
             guest_state.unrolled_run_gen.throw(
                 TrioInternalError(
-                    "Guest runner blocked before system nursery was initialized"
-                )
+                    "Guest runner blocked before system nursery was initialized",
+                ),
             )
         # next_send should be the return value of
         # IOManager.get_events() if no I/O was waiting, which is
@@ -2454,8 +2473,8 @@ def start_guest_run(
         guest_state.unrolled_run_gen.throw(
             TrioInternalError(
                 "Guest runner yielded too many times before "
-                "system nursery was initialized"
-            )
+                "system nursery was initialized",
+            ),
         )
 
     guest_state.unrolled_run_next_send = Value(next_send)
@@ -2488,7 +2507,11 @@ def unrolled_run(
             runner.instruments.call("before_run")
         runner.clock.start_clock()
         runner.init_task = runner.spawn_impl(
-            runner.init, (async_fn, args), None, "<init>", system_task=True
+            runner.init,
+            (async_fn, args),
+            None,
+            "<init>",
+            system_task=True,
         )
 
         # You know how people talk about "event loops"? This 'while' loop right
@@ -2666,7 +2689,7 @@ def unrolled_run(
                             f"trio.run received unrecognized yield message {msg!r}. "
                             "Are you trying to use a library written for some "
                             "other framework like asyncio? That won't work "
-                            "without some kind of compatibility shim."
+                            "without some kind of compatibility shim.",
                         )
                         # The foreign library probably doesn't adhere to our
                         # protocol of unwrapping whatever outcome gets sent in.
@@ -2690,7 +2713,7 @@ def unrolled_run(
         warnings.warn(
             RuntimeWarning(
                 "Trio guest run got abandoned without properly finishing... "
-                "weird stuff might happen"
+                "weird stuff might happen",
             ),
             stacklevel=1,
         )

--- a/src/trio/_core/_tests/test_asyncgen.py
+++ b/src/trio/_core/_tests/test_asyncgen.py
@@ -43,7 +43,8 @@ def test_asyncgen_basics() -> None:
     async def async_main() -> None:
         # GC'ed before exhausted
         with pytest.warns(
-            ResourceWarning, match="Async generator.*collected before.*exhausted"
+            ResourceWarning,
+            match="Async generator.*collected before.*exhausted",
         ):
             assert await example("abandoned").asend(None) == 42
             gc_collect_harder()
@@ -153,7 +154,8 @@ def test_interdependent_asyncgen_cleanup_order() -> None:
             record.append("innermost")
 
     async def agen(
-        label: int, inner: AsyncGenerator[int, None]
+        label: int,
+        inner: AsyncGenerator[int, None],
     ) -> AsyncGenerator[int, None]:
         try:
             yield await inner.asend(None)
@@ -197,7 +199,8 @@ def test_last_minute_gc_edge_case() -> None:
         runner = _core._run.GLOBAL_RUN_CONTEXT.runner
         assert runner.system_nursery is not None
         if runner.system_nursery._closed and isinstance(
-            runner.asyncgens.alive, weakref.WeakSet
+            runner.asyncgens.alive,
+            weakref.WeakSet,
         ):
             saved.clear()
             record.append("final collection")
@@ -235,7 +238,7 @@ def test_last_minute_gc_edge_case() -> None:
     else:  # pragma: no cover
         pytest.fail(
             "Didn't manage to hit the trailing_finalizer_asyncgens case "
-            f"despite trying {_attempt} times"
+            f"despite trying {_attempt} times",
         )
 
 

--- a/src/trio/_core/_tests/test_exceptiongroup_gc.py
+++ b/src/trio/_core/_tests/test_exceptiongroup_gc.py
@@ -76,7 +76,8 @@ def test_concat_tb() -> None:
 # Unclear if this can still fail, removing the `del` from _concat_tb.copy_tb does not seem
 # to trigger it (on a platform where the `del` is executed)
 @pytest.mark.skipif(
-    sys.implementation.name != "cpython", reason="Only makes sense with refcounting GC"
+    sys.implementation.name != "cpython",
+    reason="Only makes sense with refcounting GC",
 )
 def test_ExceptionGroup_catch_doesnt_create_cyclic_garbage() -> None:
     # https://github.com/python-trio/trio/pull/2063

--- a/src/trio/_core/_tests/test_guest_mode.py
+++ b/src/trio/_core/_tests/test_guest_mode.py
@@ -62,7 +62,8 @@ def trivial_guest_run(
         nonlocal todo
         if host_thread is threading.current_thread():  # pragma: no cover
             crash = partial(
-                pytest.fail, "run_sync_soon_threadsafe called from host thread"
+                pytest.fail,
+                "run_sync_soon_threadsafe called from host thread",
             )
             todo.put(("run", crash))
         todo.put(("run", fn))
@@ -71,7 +72,8 @@ def trivial_guest_run(
         nonlocal todo
         if host_thread is not threading.current_thread():  # pragma: no cover
             crash = partial(
-                pytest.fail, "run_sync_soon_not_threadsafe called from worker thread"
+                pytest.fail,
+                "run_sync_soon_not_threadsafe called from worker thread",
             )
             todo.put(("run", crash))
         todo.put(("run", fn))
@@ -181,7 +183,9 @@ def test_guest_is_initialized_when_start_returns() -> None:
     # are raised out of start_guest_run, not out of the done_callback
     with pytest.raises(trio.TrioInternalError):
         trivial_guest_run(
-            trio_main, clock=BadClock(), in_host_after_start=after_start_never_runs
+            trio_main,
+            clock=BadClock(),
+            in_host_after_start=after_start_never_runs,
         )
 
 
@@ -331,7 +335,7 @@ def test_host_wakeup_doesnt_trigger_wait_all_tasks_blocked() -> None:
                 await trio.testing.wait_all_tasks_blocked(cushion=9999)
                 raise AssertionError(  # pragma: no cover
                     "wait_all_tasks_blocked should *not* return normally, "
-                    "only by cancellation."
+                    "only by cancellation.",
                 )
             assert watb_cscope.cancelled_caught
 
@@ -486,7 +490,8 @@ def test_guest_mode_on_asyncio() -> None:
         raise AssertionError("should never be reached")  # pragma: no cover
 
     async def aio_pingpong(
-        from_trio: asyncio.Queue[int], to_trio: MemorySendChannel[int]
+        from_trio: asyncio.Queue[int],
+        to_trio: MemorySendChannel[int],
     ) -> None:
         print("aio_pingpong!")
 
@@ -525,7 +530,8 @@ def test_guest_mode_on_asyncio() -> None:
 
 
 def test_guest_mode_internal_errors(
-    monkeypatch: pytest.MonkeyPatch, recwarn: pytest.WarningsRecorder
+    monkeypatch: pytest.MonkeyPatch,
+    recwarn: pytest.WarningsRecorder,
 ) -> None:
     with monkeypatch.context() as m:
 

--- a/src/trio/_core/_tests/test_io.py
+++ b/src/trio/_core/_tests/test_io.py
@@ -91,7 +91,9 @@ notify_closing_test = pytest.mark.parametrize(
 @read_socket_test
 @write_socket_test
 async def test_wait_basic(
-    socketpair: SocketPair, wait_readable: WaitSocket, wait_writable: WaitSocket
+    socketpair: SocketPair,
+    wait_readable: WaitSocket,
+    wait_writable: WaitSocket,
 ) -> None:
     a, b = socketpair
 
@@ -215,7 +217,9 @@ async def test_interrupted_by_close(
 @read_socket_test
 @write_socket_test
 async def test_socket_simultaneous_read_write(
-    socketpair: SocketPair, wait_readable: WaitSocket, wait_writable: WaitSocket
+    socketpair: SocketPair,
+    wait_readable: WaitSocket,
+    wait_writable: WaitSocket,
 ) -> None:
     record: list[str] = []
 
@@ -245,7 +249,9 @@ async def test_socket_simultaneous_read_write(
 @read_socket_test
 @write_socket_test
 async def test_socket_actual_streaming(
-    socketpair: SocketPair, wait_readable: WaitSocket, wait_writable: WaitSocket
+    socketpair: SocketPair,
+    wait_readable: WaitSocket,
+    wait_writable: WaitSocket,
 ) -> None:
     a, b = socketpair
 

--- a/src/trio/_core/_tests/test_parking_lot.py
+++ b/src/trio/_core/_tests/test_parking_lot.py
@@ -38,7 +38,8 @@ async def test_parking_lot_basic() -> None:
         assert len(record) == 6
 
     check_sequence_matches(
-        record, [{"sleep 0", "sleep 1", "sleep 2"}, {"wake 0", "wake 1", "wake 2"}]
+        record,
+        [{"sleep 0", "sleep 1", "sleep 2"}, {"wake 0", "wake 1", "wake 2"}],
     )
 
     async with _core.open_nursery() as nursery:
@@ -74,18 +75,23 @@ async def test_parking_lot_basic() -> None:
         lot.unpark(count=2)
         await wait_all_tasks_blocked()
         check_sequence_matches(
-            record, ["sleep 0", "sleep 1", "sleep 2", {"wake 0", "wake 1"}]
+            record,
+            ["sleep 0", "sleep 1", "sleep 2", {"wake 0", "wake 1"}],
         )
         lot.unpark_all()
 
     with pytest.raises(
-        ValueError, match=r"^Cannot pop a non-integer number of tasks\.$"
+        ValueError,
+        match=r"^Cannot pop a non-integer number of tasks\.$",
     ):
         lot.unpark(count=1.5)
 
 
 async def cancellable_waiter(
-    name: T, lot: ParkingLot, scopes: dict[T, _core.CancelScope], record: list[str]
+    name: T,
+    lot: ParkingLot,
+    scopes: dict[T, _core.CancelScope],
+    record: list[str],
 ) -> None:
     with _core.CancelScope() as scope:
         scopes[name] = scope
@@ -120,7 +126,8 @@ async def test_parking_lot_cancel() -> None:
         assert len(record) == 6
 
     check_sequence_matches(
-        record, ["sleep 1", "sleep 2", "sleep 3", "cancelled 2", {"wake 1", "wake 3"}]
+        record,
+        ["sleep 1", "sleep 2", "sleep 3", "cancelled 2", {"wake 1", "wake 3"}],
     )
 
 

--- a/src/trio/_core/_tests/test_run.py
+++ b/src/trio/_core/_tests/test_run.py
@@ -116,7 +116,7 @@ async def test_nursery_warn_use_async_with() -> None:
         with on:  # type: ignore
             pass  # pragma: no cover
     excinfo.match(
-        r"use 'async with open_nursery\(...\)', not 'with open_nursery\(...\)'"
+        r"use 'async with open_nursery\(...\)', not 'with open_nursery\(...\)'",
     )
 
     # avoid unawaited coro.
@@ -156,7 +156,8 @@ async def test_basic_interleave() -> None:
         nursery.start_soon(looper, "b", record)
 
     check_sequence_matches(
-        record, [{("a", 0), ("b", 0)}, {("a", 1), ("b", 1)}, {("a", 2), ("b", 2)}]
+        record,
+        [{("a", 0), ("b", 0)}, {("a", 1), ("b", 1)}, {("a", 2), ("b", 2)}],
     )
 
 
@@ -434,7 +435,10 @@ async def test_cancel_scope_exceptiongroup_filtering() -> None:
             # nursery block continue propagating to reach the
             # outer scope.
             with RaisesGroup(
-                _core.Cancelled, _core.Cancelled, _core.Cancelled, KeyError
+                _core.Cancelled,
+                _core.Cancelled,
+                _core.Cancelled,
+                KeyError,
             ) as excinfo:
                 async with _core.open_nursery() as nursery:
                     # Two children that get cancelled by the nursery scope
@@ -769,7 +773,8 @@ async def test_cancel_scope_misnesting() -> None:
         nursery.cancel_scope.__exit__(None, None, None)
     finally:
         with pytest.raises(
-            RuntimeError, match="which had already been exited"
+            RuntimeError,
+            match="which had already been exited",
         ) as exc_info:
             await nursery_mgr.__aexit__(*sys.exc_info())
 
@@ -946,7 +951,7 @@ def test_system_task_crash_ExceptionGroup() -> None:
     # the second exceptiongroup is from the second nursery opened in Runner.init()
     # the third exceptongroup is from the nursery defined in `system_task` above
     assert RaisesGroup(RaisesGroup(RaisesGroup(KeyError, ValueError))).matches(
-        excinfo.value.__cause__
+        excinfo.value.__cause__,
     )
 
 
@@ -976,7 +981,7 @@ def test_system_task_crash_plus_Cancelled() -> None:
 
     # See explanation for triple-wrap in test_system_task_crash_ExceptionGroup
     assert RaisesGroup(RaisesGroup(RaisesGroup(ValueError))).matches(
-        excinfo.value.__cause__
+        excinfo.value.__cause__,
     )
 
 
@@ -1126,13 +1131,18 @@ async def test_exception_chaining_after_throw() -> None:
             await sleep_forever()
 
     with RaisesGroup(
-        Matcher(ValueError, "error text", lambda e: isinstance(e.__context__, KeyError))
+        Matcher(
+            ValueError,
+            "error text",
+            lambda e: isinstance(e.__context__, KeyError),
+        ),
     ):
         async with _core.open_nursery() as nursery:
             nursery.start_soon(child)
             await wait_all_tasks_blocked()
             _core.reschedule(
-                not_none(child_task), outcome.Error(ValueError("error text"))
+                not_none(child_task),
+                outcome.Error(ValueError("error text")),
             )
 
 
@@ -1195,13 +1205,14 @@ async def test_exception_chaining_after_throw_to_inner() -> None:
             "^Unique Text$",
             lambda e: isinstance(e.__context__, IndexError)
             and isinstance(e.__context__.__context__, KeyError),
-        )
+        ),
     ):
         async with _core.open_nursery() as nursery:
             nursery.start_soon(child)
             await wait_all_tasks_blocked()
             _core.reschedule(
-                not_none(child_task), outcome.Error(ValueError("Unique Text"))
+                not_none(child_task),
+                outcome.Error(ValueError("Unique Text")),
             )
 
 
@@ -1680,7 +1691,8 @@ def test_nice_error_on_bad_calls_to_run_or_spawn() -> None:
     ):
         bad_call_run(f())  # type: ignore[arg-type]
     with pytest.raises(
-        TypeError, match="expected an async function but got an async generator"
+        TypeError,
+        match="expected an async function but got an async generator",
     ):
         bad_call_run(async_gen, 0)  # type: ignore
 
@@ -1690,7 +1702,7 @@ def test_nice_error_on_bad_calls_to_run_or_spawn() -> None:
         bad_call_spawn(f())  # type: ignore[arg-type]
 
     with RaisesGroup(
-        Matcher(TypeError, "expected an async function but got an async generator")
+        Matcher(TypeError, "expected an async function but got an async generator"),
     ):
         bad_call_spawn(async_gen, 0)  # type: ignore
 
@@ -1768,7 +1780,9 @@ async def test_nursery_start(autojump_clock: _core.MockClock) -> None:
             await nursery.start(no_args)
 
     async def sleep_then_start(
-        seconds: int, *, task_status: _core.TaskStatus[int] = _core.TASK_STATUS_IGNORED
+        seconds: int,
+        *,
+        task_status: _core.TaskStatus[int] = _core.TASK_STATUS_IGNORED,
     ) -> None:
         repr(task_status)  # smoke test
         await sleep(seconds)
@@ -1847,7 +1861,8 @@ async def test_nursery_start(autojump_clock: _core.MockClock) -> None:
     # but if the task does not execute any checkpoints, and exits, then start()
     # doesn't raise Cancelled, since the task completed successfully.
     async def started_with_no_checkpoint(
-        *, task_status: _core.TaskStatus[None] = _core.TASK_STATUS_IGNORED
+        *,
+        task_status: _core.TaskStatus[None] = _core.TASK_STATUS_IGNORED,
     ) -> None:
         task_status.started(None)
 
@@ -1861,7 +1876,8 @@ async def test_nursery_start(autojump_clock: _core.MockClock) -> None:
     # the child crashes after calling started(), the error can *still* come
     # out of start()
     async def raise_keyerror_after_started(
-        *, task_status: _core.TaskStatus[None] = _core.TASK_STATUS_IGNORED
+        *,
+        task_status: _core.TaskStatus[None] = _core.TASK_STATUS_IGNORED,
     ) -> None:
         task_status.started()
         raise KeyError("whoopsiedaisy")
@@ -1924,7 +1940,8 @@ async def test_nursery_start_with_cancelled_nursery() -> None:
     async with _core.open_nursery() as nursery:
         target_nursery: _core.Nursery = await nursery.start(setup_nursery)
         await target_nursery.start(
-            sleeping_children, target_nursery.cancel_scope.cancel
+            sleeping_children,
+            target_nursery.cancel_scope.cancel,
         )
 
     # Cancelling the setup_nursery just *after* calling started()
@@ -2014,7 +2031,10 @@ async def test_nursery_stop_async_iteration() -> None:
             self.nexts = [obj.__anext__ for obj in largs]
 
         async def _accumulate(
-            self, f: Callable[[], Awaitable[int]], items: list[int], i: int
+            self,
+            f: Callable[[], Awaitable[int]],
+            items: list[int],
+            i: int,
         ) -> None:
             items[i] = await f()
 
@@ -2036,7 +2056,8 @@ async def test_nursery_stop_async_iteration() -> None:
                 # We could also use RaisesGroup, but that's primarily meant as
                 # test infra, not as a runtime tool.
                 if len(e.exceptions) == 1 and isinstance(
-                    e.exceptions[0], StopAsyncIteration
+                    e.exceptions[0],
+                    StopAsyncIteration,
                 ):
                     raise e.exceptions[0] from None
                 else:  # pragma: no cover
@@ -2244,7 +2265,8 @@ async def test_permanently_detach_coroutine_object() -> None:
         nonlocal task, pdco_outcome
         task = _core.current_task()
         pdco_outcome = await outcome.acapture(
-            _core.permanently_detach_coroutine_object, task_outcome
+            _core.permanently_detach_coroutine_object,
+            task_outcome,
         )
         await async_yield(yield_value)
 
@@ -2308,7 +2330,8 @@ async def test_detach_and_reattach_coroutine_object() -> None:
 
         with pytest.raises(RuntimeError) as excinfo:
             await _core.reattach_detached_coroutine_object(
-                not_none(unrelated_task), None
+                not_none(unrelated_task),
+                None,
             )
         assert "does not match" in str(excinfo.value)
 
@@ -2409,7 +2432,8 @@ async def test_cancel_scope_deadline_duplicates() -> None:
 # refer to this only seems to break test_cancel_scope_exit_doesnt_create_cyclic_garbage
 # We're keeping it for now to cover Outcome and potential future refactoring
 @pytest.mark.skipif(
-    sys.implementation.name != "cpython", reason="Only makes sense with refcounting GC"
+    sys.implementation.name != "cpython",
+    reason="Only makes sense with refcounting GC",
 )
 async def test_simple_cancel_scope_usage_doesnt_create_cyclic_garbage() -> None:
     # https://github.com/python-trio/trio/issues/1770
@@ -2448,7 +2472,8 @@ async def test_simple_cancel_scope_usage_doesnt_create_cyclic_garbage() -> None:
 
 
 @pytest.mark.skipif(
-    sys.implementation.name != "cpython", reason="Only makes sense with refcounting GC"
+    sys.implementation.name != "cpython",
+    reason="Only makes sense with refcounting GC",
 )
 async def test_cancel_scope_exit_doesnt_create_cyclic_garbage() -> None:
     # https://github.com/python-trio/trio/pull/2063
@@ -2460,7 +2485,7 @@ async def test_cancel_scope_exit_doesnt_create_cyclic_garbage() -> None:
     old_flags = gc.get_debug()
     try:
         with RaisesGroup(
-            Matcher(ValueError, "^this is a crash$")
+            Matcher(ValueError, "^this is a crash$"),
         ), _core.CancelScope() as outer:
             async with _core.open_nursery() as nursery:
                 gc.collect()
@@ -2482,7 +2507,8 @@ async def test_cancel_scope_exit_doesnt_create_cyclic_garbage() -> None:
 
 
 @pytest.mark.skipif(
-    sys.implementation.name != "cpython", reason="Only makes sense with refcounting GC"
+    sys.implementation.name != "cpython",
+    reason="Only makes sense with refcounting GC",
 )
 async def test_nursery_cancel_doesnt_create_cyclic_garbage() -> None:
     collected = False
@@ -2518,7 +2544,8 @@ async def test_nursery_cancel_doesnt_create_cyclic_garbage() -> None:
 
 
 @pytest.mark.skipif(
-    sys.implementation.name != "cpython", reason="Only makes sense with refcounting GC"
+    sys.implementation.name != "cpython",
+    reason="Only makes sense with refcounting GC",
 )
 async def test_locals_destroyed_promptly_on_cancel() -> None:
     destroyed = False
@@ -2550,13 +2577,15 @@ def _create_kwargs(strictness: bool | None) -> dict[str, bool]:
 
 
 @pytest.mark.filterwarnings(
-    "ignore:.*strict_exception_groups=False:trio.TrioDeprecationWarning"
+    "ignore:.*strict_exception_groups=False:trio.TrioDeprecationWarning",
 )
 @pytest.mark.parametrize("run_strict", [True, False, None])
 @pytest.mark.parametrize("open_nursery_strict", [True, False, None])
 @pytest.mark.parametrize("multiple_exceptions", [True, False])
 def test_setting_strict_exception_groups(
-    run_strict: bool | None, open_nursery_strict: bool | None, multiple_exceptions: bool
+    run_strict: bool | None,
+    open_nursery_strict: bool | None,
+    multiple_exceptions: bool,
 ) -> None:
     """
     Test default values and that nurseries can both inherit and override the global context
@@ -2593,7 +2622,7 @@ def test_setting_strict_exception_groups(
 
 
 @pytest.mark.filterwarnings(
-    "ignore:.*strict_exception_groups=False:trio.TrioDeprecationWarning"
+    "ignore:.*strict_exception_groups=False:trio.TrioDeprecationWarning",
 )
 @pytest.mark.parametrize("strict", [True, False, None])
 async def test_nursery_collapse(strict: bool | None) -> None:
@@ -2635,7 +2664,7 @@ async def test_cancel_scope_no_cancellederror() -> None:
 
 
 @pytest.mark.filterwarnings(
-    "ignore:.*strict_exception_groups=False:trio.TrioDeprecationWarning"
+    "ignore:.*strict_exception_groups=False:trio.TrioDeprecationWarning",
 )
 @pytest.mark.parametrize("run_strict", [False, True])
 @pytest.mark.parametrize("start_raiser_strict", [False, True, None])
@@ -2670,7 +2699,7 @@ def test_trio_run_strict_before_started(
     async def start_raiser() -> None:
         try:
             async with _core.open_nursery(
-                strict_exception_groups=start_raiser_strict
+                strict_exception_groups=start_raiser_strict,
             ) as nursery:
                 await nursery.start(raiser)
         except BaseExceptionGroup as exc_group:
@@ -2680,7 +2709,8 @@ def test_trio_run_strict_before_started(
                 # exception group raised by trio with a more specific one (subtype,
                 # different message, etc.).
                 raise BaseExceptionGroup(
-                    "start_raiser nursery custom message", exc_group.exceptions
+                    "start_raiser nursery custom message",
+                    exc_group.exceptions,
                 ) from None
             raise
 

--- a/src/trio/_core/_tests/test_unbounded_queue.py
+++ b/src/trio/_core/_tests/test_unbounded_queue.py
@@ -8,7 +8,7 @@ from ... import _core
 from ...testing import assert_checkpoints, wait_all_tasks_blocked
 
 pytestmark = pytest.mark.filterwarnings(
-    "ignore:.*UnboundedQueue:trio.TrioDeprecationWarning"
+    "ignore:.*UnboundedQueue:trio.TrioDeprecationWarning",
 )
 
 

--- a/src/trio/_core/_tests/test_windows.py
+++ b/src/trio/_core/_tests/test_windows.py
@@ -54,7 +54,8 @@ def test_winerror(monkeypatch: pytest.MonkeyPatch) -> None:
 
     mock.return_value = (12, "test error")
     with pytest.raises(
-        OSError, match=r"^\[WinError 12\] test error: 'file_1' -> 'file_2'$"
+        OSError,
+        match=r"^\[WinError 12\] test error: 'file_1' -> 'file_2'$",
     ) as exc:
         raise_winerror(filename="file_1", filename2="file_2")
     mock.assert_called_once_with()
@@ -66,7 +67,8 @@ def test_winerror(monkeypatch: pytest.MonkeyPatch) -> None:
 
     # With an explicit number passed in, it overrides what getwinerror() returns.
     with pytest.raises(
-        OSError, match=r"^\[WinError 18\] test error: 'a/file' -> 'b/file'$"
+        OSError,
+        match=r"^\[WinError 18\] test error: 'a/file' -> 'b/file'$",
     ) as exc:
         raise_winerror(18, filename="a/file", filename2="b/file")
     mock.assert_called_once_with(18)
@@ -117,7 +119,8 @@ async def test_readinto_overlapped() -> None:
     with tempfile.TemporaryDirectory() as tdir:
         tfile = os.path.join(tdir, "numbers.txt")
         with open(  # noqa: ASYNC230  # This is a test, synchronous is ok
-            tfile, "wb"
+            tfile,
+            "wb",
         ) as fp:
             fp.write(data)
             fp.flush()
@@ -141,7 +144,9 @@ async def test_readinto_overlapped() -> None:
 
                 async def read_region(start: int, end: int) -> None:
                     await _core.readinto_overlapped(
-                        handle, buffer_view[start:end], start
+                        handle,
+                        buffer_view[start:end],
+                        start,
                     )
 
                 _core.register_with_iocp(handle)
@@ -184,7 +189,10 @@ def test_forgot_to_register_with_iocp() -> None:
             try:
                 async with _core.open_nursery() as nursery:
                     nursery.start_soon(
-                        _core.readinto_overlapped, read_handle, target, name="xyz"
+                        _core.readinto_overlapped,
+                        read_handle,
+                        target,
+                        name="xyz",
                     )
                     await wait_all_tasks_blocked()
                     nursery.cancel_scope.cancel()
@@ -241,7 +249,9 @@ def test_lsp_that_hooks_select_gives_good_error(
     from .._windows_cffi import CData, WSAIoctls, _handle
 
     def patched_get_underlying(
-        sock: int | CData, *, which: int = WSAIoctls.SIO_BASE_HANDLE
+        sock: int | CData,
+        *,
+        which: int = WSAIoctls.SIO_BASE_HANDLE,
     ) -> CData:
         if hasattr(sock, "fileno"):  # pragma: no branch
             sock = sock.fileno()
@@ -252,7 +262,8 @@ def test_lsp_that_hooks_select_gives_good_error(
 
     monkeypatch.setattr(_io_windows, "_get_underlying_socket", patched_get_underlying)
     with pytest.raises(
-        RuntimeError, match="SIO_BASE_HANDLE and SIO_BSP_HANDLE_SELECT differ"
+        RuntimeError,
+        match="SIO_BASE_HANDLE and SIO_BSP_HANDLE_SELECT differ",
     ):
         _core.run(sleep, 0)
 
@@ -269,7 +280,9 @@ def test_lsp_that_completely_hides_base_socket_gives_good_error(
     from .._windows_cffi import CData, WSAIoctls, _handle
 
     def patched_get_underlying(
-        sock: int | CData, *, which: int = WSAIoctls.SIO_BASE_HANDLE
+        sock: int | CData,
+        *,
+        which: int = WSAIoctls.SIO_BASE_HANDLE,
     ) -> CData:
         if hasattr(sock, "fileno"):  # pragma: no branch
             sock = sock.fileno()

--- a/src/trio/_core/_tests/type_tests/run.py
+++ b/src/trio/_core/_tests/type_tests/run.py
@@ -29,7 +29,9 @@ async def foo_overloaded(arg: int | str) -> int | str:
 
 
 v = trio.run(
-    sleep_sort, (1, 3, 5, 2, 4), clock=trio.testing.MockClock(autojump_threshold=0)
+    sleep_sort,
+    (1, 3, 5, 2, 4),
+    clock=trio.testing.MockClock(autojump_threshold=0),
 )
 assert_type(v, "list[float]")
 trio.run(sleep_sort, ["hi", "there"])  # type: ignore[arg-type]

--- a/src/trio/_core/_thread_cache.py
+++ b/src/trio/_core/_thread_cache.py
@@ -23,7 +23,9 @@ def _to_os_thread_name(name: str) -> bytes:
 # called once on import
 def get_os_thread_name_func() -> Callable[[int | None, str], None] | None:
     def namefunc(
-        setname: Callable[[int, bytes], int], ident: int | None, name: str
+        setname: Callable[[int, bytes], int],
+        ident: int | None,
+        name: str,
     ) -> None:
         # Thread.ident is None "if it has not been started". Unclear if that can happen
         # with current usage.
@@ -33,7 +35,9 @@ def get_os_thread_name_func() -> Callable[[int | None, str], None] | None:
     # namefunc on Mac also takes an ident, even if pthread_setname_np doesn't/can't use it
     # so the caller don't need to care about platform.
     def darwin_namefunc(
-        setname: Callable[[bytes], int], ident: int | None, name: str
+        setname: Callable[[bytes], int],
+        ident: int | None,
+        name: str,
     ) -> None:
         # I don't know if Mac can rename threads that hasn't been started, but default
         # to no to be on the safe side.

--- a/src/trio/_core/_traps.py
+++ b/src/trio/_core/_traps.py
@@ -213,13 +213,13 @@ async def permanently_detach_coroutine_object(
     """
     if _run.current_task().child_nurseries:
         raise RuntimeError(
-            "can't permanently detach a coroutine object with open nurseries"
+            "can't permanently detach a coroutine object with open nurseries",
         )
     return await _async_yield(PermanentlyDetachCoroutineObject(final_outcome))
 
 
 async def temporarily_detach_coroutine_object(
-    abort_func: Callable[[RaiseCancelT], Abort]
+    abort_func: Callable[[RaiseCancelT], Abort],
 ) -> Any:
     """Temporarily detach the current coroutine object from the Trio
     scheduler.

--- a/src/trio/_core/_unbounded_queue.py
+++ b/src/trio/_core/_unbounded_queue.py
@@ -152,7 +152,8 @@ class UnboundedQueue(Generic[T]):
     def statistics(self) -> UnboundedQueueStatistics:
         """Return an :class:`UnboundedQueueStatistics` object containing debugging information."""
         return UnboundedQueueStatistics(
-            qsize=len(self._data), tasks_waiting=self._lot.statistics().tasks_waiting
+            qsize=len(self._data),
+            tasks_waiting=self._lot.statistics().tasks_waiting,
         )
 
     def __aiter__(self) -> Self:

--- a/src/trio/_core/_wakeup_socketpair.py
+++ b/src/trio/_core/_wakeup_socketpair.py
@@ -63,7 +63,7 @@ class WakeupSocketpair:
                     "running Trio in guest mode, then this might mean you "
                     "should set host_uses_signal_set_wakeup_fd=True. "
                     "Otherwise, file a bug on Trio and we'll help you figure "
-                    "out what's going on."
+                    "out what's going on.",
                 ),
                 stacklevel=1,
             )

--- a/src/trio/_core/_windows_cffi.py
+++ b/src/trio/_core/_windows_cffi.py
@@ -210,7 +210,7 @@ typedef struct _AFD_POLL_INFO {
 # cribbed from pywincffi
 # programmatically strips out those annotations MSDN likes, like _In_
 REGEX_SAL_ANNOTATION = re.compile(
-    r"\b(_In_|_Inout_|_Out_|_Outptr_|_Reserved_)(opt_)?\b"
+    r"\b(_In_|_Inout_|_Out_|_Outptr_|_Reserved_)(opt_)?\b",
 )
 LIB = REGEX_SAL_ANNOTATION.sub(" ", LIB)
 
@@ -253,7 +253,10 @@ class _Kernel32(Protocol):
     ) -> Handle: ...
 
     def SetFileCompletionNotificationModes(
-        self, handle: Handle, flags: CompletionModes, /
+        self,
+        handle: Handle,
+        flags: CompletionModes,
+        /,
     ) -> int: ...
 
     def PostQueuedCompletionStatus(

--- a/src/trio/_file_io.py
+++ b/src/trio/_file_io.py
@@ -465,8 +465,16 @@ async def open_file(
     """
     _file = wrap_file(
         await trio.to_thread.run_sync(
-            io.open, file, mode, buffering, encoding, errors, newline, closefd, opener
-        )
+            io.open,
+            file,
+            mode,
+            buffering,
+            encoding,
+            errors,
+            newline,
+            closefd,
+            opener,
+        ),
     )
     return _file
 
@@ -495,7 +503,7 @@ def wrap_file(file: FileT) -> AsyncIOWrapper[FileT]:
     if not (has("close") and (has("read") or has("write"))):
         raise TypeError(
             f"{file} does not implement required duck-file methods: "
-            "close and (read or write)"
+            "close and (read or write)",
         )
 
     return AsyncIOWrapper(file)

--- a/src/trio/_highlevel_open_tcp_listeners.py
+++ b/src/trio/_highlevel_open_tcp_listeners.py
@@ -112,7 +112,10 @@ async def open_tcp_listeners(
     computed_backlog = _compute_backlog(backlog)
 
     addresses = await tsocket.getaddrinfo(
-        host, port, type=tsocket.SOCK_STREAM, flags=tsocket.AI_PASSIVE
+        host,
+        port,
+        type=tsocket.SOCK_STREAM,
+        flags=tsocket.AI_PASSIVE,
     )
 
     listeners = []
@@ -159,7 +162,8 @@ async def open_tcp_listeners(
             "socket that that address could use"
         )
         raise OSError(errno.EAFNOSUPPORT, msg) from ExceptionGroup(
-            msg, unsupported_address_families
+            msg,
+            unsupported_address_families,
         )
 
     return listeners
@@ -240,5 +244,8 @@ async def serve_tcp(
     """
     listeners = await trio.open_tcp_listeners(port, host=host, backlog=backlog)
     await trio.serve_listeners(
-        handler, listeners, handler_nursery=handler_nursery, task_status=task_status
+        handler,
+        listeners,
+        handler_nursery=handler_nursery,
+        task_status=task_status,
     )

--- a/src/trio/_highlevel_open_tcp_stream.py
+++ b/src/trio/_highlevel_open_tcp_stream.py
@@ -141,7 +141,7 @@ def reorder_for_rfc_6555_section_5_4(
             str,
             Any,
         ]
-    ]
+    ],
 ) -> None:
     # RFC 6555 section 5.4 says that if getaddrinfo returns multiple address
     # families (e.g. IPv4 and IPv6), then you should make sure that your first
@@ -346,14 +346,16 @@ async def open_tcp_stream(
                 # better job of it because it knows the remote IP/port.
                 with suppress(OSError, AttributeError):
                     sock.setsockopt(
-                        trio.socket.IPPROTO_IP, trio.socket.IP_BIND_ADDRESS_NO_PORT, 1
+                        trio.socket.IPPROTO_IP,
+                        trio.socket.IP_BIND_ADDRESS_NO_PORT,
+                        1,
                     )
                 try:
                     await sock.bind((local_address, 0))
                 except OSError:
                     raise OSError(
                         f"local_address={local_address!r} is incompatible "
-                        f"with remote address {sockaddr!r}"
+                        f"with remote address {sockaddr!r}",
                     ) from None
 
             await sock.connect(sockaddr)
@@ -382,7 +384,9 @@ async def open_tcp_stream(
                 # workaround to check types until typing of nursery.start_soon improved
                 if TYPE_CHECKING:
                     await attempt_connect(
-                        (address_family, socket_type, proto), addr, attempt_failed
+                        (address_family, socket_type, proto),
+                        addr,
+                        attempt_failed,
                     )
 
                 nursery.start_soon(

--- a/src/trio/_highlevel_serve_listeners.py
+++ b/src/trio/_highlevel_serve_listeners.py
@@ -143,5 +143,5 @@ async def serve_listeners(
         task_status.started(listeners)
 
     raise AssertionError(
-        "_serve_one_listener should never complete"
+        "_serve_one_listener should never complete",
     )  # pragma: no cover

--- a/src/trio/_highlevel_socket.py
+++ b/src/trio/_highlevel_socket.py
@@ -76,7 +76,7 @@ class SocketStream(HalfCloseableStream):
 
         self.socket = socket
         self._send_conflict_detector = ConflictDetector(
-            "another task is currently sending data on this SocketStream"
+            "another task is currently sending data on this SocketStream",
         )
 
         # Socket defaults:
@@ -167,12 +167,12 @@ class SocketStream(HalfCloseableStream):
         if length is None:
             if value is None:
                 raise TypeError(
-                    "invalid value for argument 'value', must not be None when specifying length"
+                    "invalid value for argument 'value', must not be None when specifying length",
                 )
             return self.socket.setsockopt(level, option, value)
         if value is not None:
             raise TypeError(
-                f"invalid value for argument 'value': {value!r}, must be None when specifying optlen"
+                f"invalid value for argument 'value': {value!r}, must be None when specifying optlen",
             )
         return self.socket.setsockopt(level, option, value, length)
 

--- a/src/trio/_highlevel_ssl_helpers.py
+++ b/src/trio/_highlevel_ssl_helpers.py
@@ -59,7 +59,9 @@ async def open_ssl_over_tcp_stream(
 
     """
     tcp_stream = await trio.open_tcp_stream(
-        host, port, happy_eyeballs_delay=happy_eyeballs_delay
+        host,
+        port,
+        happy_eyeballs_delay=happy_eyeballs_delay,
     )
     if ssl_context is None:
         ssl_context = ssl.create_default_context()
@@ -68,7 +70,10 @@ async def open_ssl_over_tcp_stream(
             ssl_context.options &= ~ssl.OP_IGNORE_UNEXPECTED_EOF
 
     return trio.SSLStream(
-        tcp_stream, ssl_context, server_hostname=host, https_compatible=https_compatible
+        tcp_stream,
+        ssl_context,
+        server_hostname=host,
+        https_compatible=https_compatible,
     )
 
 
@@ -168,5 +173,8 @@ async def serve_ssl_over_tcp(
         backlog=backlog,
     )
     await trio.serve_listeners(
-        handler, listeners, handler_nursery=handler_nursery, task_status=task_status
+        handler,
+        listeners,
+        handler_nursery=handler_nursery,
+        task_status=task_status,
     )

--- a/src/trio/_path.py
+++ b/src/trio/_path.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 
 
 def _wraps_async(
-    wrapped: Callable[..., Any]
+    wrapped: Callable[..., Any],
 ) -> Callable[[Callable[P, T]], Callable[P, Awaitable[T]]]:
     def decorator(fn: Callable[P, T]) -> Callable[P, Awaitable[T]]:
         async def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:

--- a/src/trio/_signals.py
+++ b/src/trio/_signals.py
@@ -72,7 +72,7 @@ class SignalReceiver:
         self._pending: OrderedDict[int, None] = OrderedDict()
         self._lot = trio.lowlevel.ParkingLot()
         self._conflict_detector = ConflictDetector(
-            "only one task can iterate on a signal receiver at a time"
+            "only one task can iterate on a signal receiver at a time",
         )
         self._closed = False
 
@@ -170,7 +170,7 @@ def open_signal_receiver(
     if not is_main_thread():
         raise RuntimeError(
             "Sorry, open_signal_receiver is only possible when running in "
-            "Python interpreter's main thread"
+            "Python interpreter's main thread",
         )
     token = trio.lowlevel.current_trio_token()
     queue = SignalReceiver()

--- a/src/trio/_socket.py
+++ b/src/trio/_socket.py
@@ -62,7 +62,8 @@ AddressFormat: TypeAlias = Any
 #
 class _try_sync:
     def __init__(
-        self, blocking_exc_override: Callable[[BaseException], bool] | None = None
+        self,
+        blocking_exc_override: Callable[[BaseException], bool] | None = None,
     ):
         self._blocking_exc_override = blocking_exc_override
 
@@ -179,7 +180,11 @@ async def getaddrinfo(
     flags: int = 0,
 ) -> list[
     tuple[
-        AddressFamily, SocketKind, int, str, tuple[str, int] | tuple[str, int, int, int]
+        AddressFamily,
+        SocketKind,
+        int,
+        str,
+        tuple[str, int] | tuple[str, int, int, int],
     ]
 ]:
     """Look up a numeric address given a name.
@@ -210,7 +215,12 @@ async def getaddrinfo(
 
     async with _try_sync(numeric_only_failure):
         return _stdlib_socket.getaddrinfo(
-            host, port, family, type, proto, flags | _NUMERIC_ONLY
+            host,
+            port,
+            family,
+            type,
+            proto,
+            flags | _NUMERIC_ONLY,
         )
     # That failed; it's a real hostname. We better use a thread.
     #
@@ -245,7 +255,8 @@ async def getaddrinfo(
 
 
 async def getnameinfo(
-    sockaddr: tuple[str, int] | tuple[str, int, int, int], flags: int
+    sockaddr: tuple[str, int] | tuple[str, int, int, int],
+    flags: int,
 ) -> tuple[str, str]:
     """Look up a name given a numeric address.
 
@@ -261,7 +272,10 @@ async def getnameinfo(
         return await hr.getnameinfo(sockaddr, flags)
     else:
         return await trio.to_thread.run_sync(
-            _stdlib_socket.getnameinfo, sockaddr, flags, abandon_on_cancel=True
+            _stdlib_socket.getnameinfo,
+            sockaddr,
+            flags,
+            abandon_on_cancel=True,
         )
 
 
@@ -272,7 +286,9 @@ async def getprotobyname(name: str) -> int:
 
     """
     return await trio.to_thread.run_sync(
-        _stdlib_socket.getprotobyname, name, abandon_on_cancel=True
+        _stdlib_socket.getprotobyname,
+        name,
+        abandon_on_cancel=True,
     )
 
 
@@ -357,7 +373,10 @@ def socket(
             return sf.socket(family, type, proto)
     else:
         family, type, proto = _sniff_sockopts_for_fileno(  # noqa: A001
-            family, type, proto, fileno
+            family,
+            type,
+            proto,
+            fileno,
         )
     stdlib_socket = _stdlib_socket.socket(family, type, proto, fileno)
     return from_stdlib_socket(stdlib_socket)
@@ -465,7 +484,7 @@ async def _resolve_address_nocp(
     elif family == _stdlib_socket.AF_INET6:
         if not isinstance(address, tuple) or not 2 <= len(address) <= 4:
             raise ValueError(
-                "address should be a (host, port, [flowinfo, [scopeid]]) tuple"
+                "address should be a (host, port, [flowinfo, [scopeid]]) tuple",
             )
     elif hasattr(_stdlib_socket, "AF_UNIX") and family == _stdlib_socket.AF_UNIX:
         # unwrap path-likes
@@ -531,7 +550,7 @@ class SocketType:
         if type(self) is SocketType:
             raise TypeError(
                 "SocketType is an abstract class; use trio.socket.socket if you "
-                "want to construct a socket object"
+                "want to construct a socket object",
             )
 
     def detach(self) -> int:
@@ -553,7 +572,11 @@ class SocketType:
     def getsockopt(self, /, level: int, optname: int, buflen: int) -> bytes: ...
 
     def getsockopt(
-        self, /, level: int, optname: int, buflen: int | None = None
+        self,
+        /,
+        level: int,
+        optname: int,
+        buflen: int | None = None,
     ) -> int | bytes:
         raise NotImplementedError
 
@@ -562,7 +585,12 @@ class SocketType:
 
     @overload
     def setsockopt(
-        self, /, level: int, optname: int, value: None, optlen: int
+        self,
+        /,
+        level: int,
+        optname: int,
+        value: None,
+        optlen: int,
     ) -> None: ...
 
     def setsockopt(
@@ -653,19 +681,27 @@ class SocketType:
         raise NotImplementedError
 
     def recv_into(
-        __self, buffer: Buffer, nbytes: int = 0, flags: int = 0
+        __self,
+        buffer: Buffer,
+        nbytes: int = 0,
+        flags: int = 0,
     ) -> Awaitable[int]:
         raise NotImplementedError
 
     # return type of socket.socket.recvfrom in typeshed is tuple[bytes, Any]
     def recvfrom(
-        __self, __bufsize: int, __flags: int = 0
+        __self,
+        __bufsize: int,
+        __flags: int = 0,
     ) -> Awaitable[tuple[bytes, AddressFormat]]:
         raise NotImplementedError
 
     # return type of socket.socket.recvfrom_into in typeshed is tuple[bytes, Any]
     def recvfrom_into(
-        __self, buffer: Buffer, nbytes: int = 0, flags: int = 0
+        __self,
+        buffer: Buffer,
+        nbytes: int = 0,
+        flags: int = 0,
     ) -> Awaitable[tuple[int, AddressFormat]]:
         raise NotImplementedError
 
@@ -698,7 +734,9 @@ class SocketType:
 
     @overload
     async def sendto(
-        self, __data: Buffer, __address: tuple[object, ...] | str | Buffer
+        self,
+        __data: Buffer,
+        __address: tuple[object, ...] | str | Buffer,
     ) -> int: ...
 
     @overload
@@ -748,7 +786,7 @@ class _SocketType(SocketType):
             # For example, ssl.SSLSocket subclasses socket.socket, but we
             # certainly don't want to blindly wrap one of those.
             raise TypeError(
-                f"expected object of type 'socket.socket', not '{type(sock).__name__}'"
+                f"expected object of type 'socket.socket', not '{type(sock).__name__}'",
             )
         self._sock = sock
         self._sock.setblocking(False)
@@ -778,7 +816,11 @@ class _SocketType(SocketType):
     def getsockopt(self, /, level: int, optname: int, buflen: int) -> bytes: ...
 
     def getsockopt(
-        self, /, level: int, optname: int, buflen: int | None = None
+        self,
+        /,
+        level: int,
+        optname: int,
+        buflen: int | None = None,
     ) -> int | bytes:
         if buflen is None:
             return self._sock.getsockopt(level, optname)
@@ -789,7 +831,12 @@ class _SocketType(SocketType):
 
     @overload
     def setsockopt(
-        self, /, level: int, optname: int, value: None, optlen: int
+        self,
+        /,
+        level: int,
+        optname: int,
+        value: None,
+        optlen: int,
     ) -> None: ...
 
     def setsockopt(
@@ -803,12 +850,12 @@ class _SocketType(SocketType):
         if optlen is None:
             if value is None:
                 raise TypeError(
-                    "invalid value for argument 'value', must not be None when specifying optlen"
+                    "invalid value for argument 'value', must not be None when specifying optlen",
                 )
             return self._sock.setsockopt(level, optname, value)
         if value is not None:
             raise TypeError(
-                f"invalid value for argument 'value': {value!r}, must be None when specifying optlen"
+                f"invalid value for argument 'value': {value!r}, must be None when specifying optlen",
             )
 
         # Note: PyPy may crash here due to setsockopt only supporting
@@ -915,7 +962,8 @@ class _SocketType(SocketType):
     ) -> AddressFormat:
         if self.family == _stdlib_socket.AF_INET6:
             ipv6_v6only = self._sock.getsockopt(
-                _stdlib_socket.IPPROTO_IPV6, _stdlib_socket.IPV6_V6ONLY
+                _stdlib_socket.IPPROTO_IPV6,
+                _stdlib_socket.IPV6_V6ONLY,
             )
         else:
             ipv6_v6only = False
@@ -977,7 +1025,8 @@ class _SocketType(SocketType):
     ################################################################
 
     _accept = _make_simple_sock_method_wrapper(
-        _stdlib_socket.socket.accept, _core.wait_readable
+        _stdlib_socket.socket.accept,
+        _core.wait_readable,
     )
 
     async def accept(self) -> tuple[SocketType, AddressFormat]:
@@ -1075,7 +1124,8 @@ class _SocketType(SocketType):
     # this requires that we refrain from using `/` to specify pos-only
     # args, or mypy thinks the signature differs from typeshed.
     recv = _make_simple_sock_method_wrapper(
-        _stdlib_socket.socket.recv, _core.wait_readable
+        _stdlib_socket.socket.recv,
+        _core.wait_readable,
     )
 
     ################################################################
@@ -1085,11 +1135,15 @@ class _SocketType(SocketType):
     if TYPE_CHECKING:
 
         def recv_into(
-            __self, buffer: Buffer, nbytes: int = 0, flags: int = 0
+            __self,
+            buffer: Buffer,
+            nbytes: int = 0,
+            flags: int = 0,
         ) -> Awaitable[int]: ...
 
     recv_into = _make_simple_sock_method_wrapper(
-        _stdlib_socket.socket.recv_into, _core.wait_readable
+        _stdlib_socket.socket.recv_into,
+        _core.wait_readable,
     )
 
     ################################################################
@@ -1099,11 +1153,14 @@ class _SocketType(SocketType):
     if TYPE_CHECKING:
         # return type of socket.socket.recvfrom in typeshed is tuple[bytes, Any]
         def recvfrom(
-            __self, __bufsize: int, __flags: int = 0
+            __self,
+            __bufsize: int,
+            __flags: int = 0,
         ) -> Awaitable[tuple[bytes, AddressFormat]]: ...
 
     recvfrom = _make_simple_sock_method_wrapper(
-        _stdlib_socket.socket.recvfrom, _core.wait_readable
+        _stdlib_socket.socket.recvfrom,
+        _core.wait_readable,
     )
 
     ################################################################
@@ -1113,11 +1170,15 @@ class _SocketType(SocketType):
     if TYPE_CHECKING:
         # return type of socket.socket.recvfrom_into in typeshed is tuple[bytes, Any]
         def recvfrom_into(
-            __self, buffer: Buffer, nbytes: int = 0, flags: int = 0
+            __self,
+            buffer: Buffer,
+            nbytes: int = 0,
+            flags: int = 0,
         ) -> Awaitable[tuple[int, AddressFormat]]: ...
 
     recvfrom_into = _make_simple_sock_method_wrapper(
-        _stdlib_socket.socket.recvfrom_into, _core.wait_readable
+        _stdlib_socket.socket.recvfrom_into,
+        _core.wait_readable,
     )
 
     ################################################################
@@ -1130,11 +1191,16 @@ class _SocketType(SocketType):
         if TYPE_CHECKING:
 
             def recvmsg(
-                __self, __bufsize: int, __ancbufsize: int = 0, __flags: int = 0
+                __self,
+                __bufsize: int,
+                __ancbufsize: int = 0,
+                __flags: int = 0,
             ) -> Awaitable[tuple[bytes, list[tuple[int, int, bytes]], int, Any]]: ...
 
         recvmsg = _make_simple_sock_method_wrapper(
-            _stdlib_socket.socket.recvmsg, _core.wait_readable, maybe_avail=True
+            _stdlib_socket.socket.recvmsg,
+            _core.wait_readable,
+            maybe_avail=True,
         )
 
     ################################################################
@@ -1154,7 +1220,9 @@ class _SocketType(SocketType):
             ) -> Awaitable[tuple[int, list[tuple[int, int, bytes]], int, Any]]: ...
 
         recvmsg_into = _make_simple_sock_method_wrapper(
-            _stdlib_socket.socket.recvmsg_into, _core.wait_readable, maybe_avail=True
+            _stdlib_socket.socket.recvmsg_into,
+            _core.wait_readable,
+            maybe_avail=True,
         )
 
     ################################################################
@@ -1166,7 +1234,8 @@ class _SocketType(SocketType):
         def send(__self, __bytes: Buffer, __flags: int = 0) -> Awaitable[int]: ...
 
     send = _make_simple_sock_method_wrapper(
-        _stdlib_socket.socket.send, _core.wait_writable
+        _stdlib_socket.socket.send,
+        _core.wait_writable,
     )
 
     ################################################################
@@ -1175,12 +1244,17 @@ class _SocketType(SocketType):
 
     @overload
     async def sendto(
-        self, __data: Buffer, __address: tuple[object, ...] | str | Buffer
+        self,
+        __data: Buffer,
+        __address: tuple[object, ...] | str | Buffer,
     ) -> int: ...
 
     @overload
     async def sendto(
-        self, __data: Buffer, __flags: int, __address: tuple[object, ...] | str | Buffer
+        self,
+        __data: Buffer,
+        __flags: int,
+        __address: tuple[object, ...] | str | Buffer,
     ) -> int: ...
 
     @_wraps(_stdlib_socket.socket.sendto, assigned=(), updated=())  # type: ignore[misc]

--- a/src/trio/_ssl.py
+++ b/src/trio/_ssl.py
@@ -376,10 +376,10 @@ class SSLStream(Stream, Generic[T_Stream]):
         # multiple concurrent calls to send_all/wait_send_all_might_not_block
         # or to receive_some.
         self._outer_send_conflict_detector = ConflictDetector(
-            "another task is currently sending data on this SSLStream"
+            "another task is currently sending data on this SSLStream",
         )
         self._outer_recv_conflict_detector = ConflictDetector(
-            "another task is currently receiving data on this SSLStream"
+            "another task is currently receiving data on this SSLStream",
         )
 
         self._estimated_receive_size = STARTING_RECEIVE_SIZE
@@ -615,7 +615,8 @@ class SSLStream(Stream, Generic[T_Stream]):
                             self._incoming.write_eof()
                         else:
                             self._estimated_receive_size = max(
-                                self._estimated_receive_size, len(data)
+                                self._estimated_receive_size,
+                                len(data),
                             )
                             self._incoming.write(data)
                         self._inner_recv_count += 1

--- a/src/trio/_subprocess.py
+++ b/src/trio/_subprocess.py
@@ -36,7 +36,10 @@ if sys.version_info >= (3, 9):
     StrOrBytesPath: TypeAlias = Union[str, bytes, os.PathLike[str], os.PathLike[bytes]]
 else:
     StrOrBytesPath: TypeAlias = Union[
-        str, bytes, "os.PathLike[str]", "os.PathLike[bytes]"
+        str,
+        bytes,
+        "os.PathLike[str]",
+        "os.PathLike[bytes]",
     ]
 
 
@@ -238,7 +241,7 @@ class Process(metaclass=NoPublicConstructor):
             if self.poll() is None:
                 if self._pidfd is not None:
                     with contextlib.suppress(
-                        ClosedResourceError
+                        ClosedResourceError,
                     ):  # something else (probably a call to poll) already closed the pidfd
                         await trio.lowlevel.wait_readable(self._pidfd.fileno())
                 else:
@@ -362,19 +365,19 @@ async def _open_process(
         if options.get(key):
             raise TypeError(
                 "trio.Process only supports communicating over "
-                f"unbuffered byte streams; the '{key}' option is not supported"
+                f"unbuffered byte streams; the '{key}' option is not supported",
             )
 
     if os.name == "posix":
         if isinstance(command, str) and not options.get("shell"):
             raise TypeError(
                 "command must be a sequence (not a string) if shell=False "
-                "on UNIX systems"
+                "on UNIX systems",
             )
         if not isinstance(command, str) and options.get("shell"):
             raise TypeError(
                 "command must be a string (not a sequence) if shell=True "
-                "on UNIX systems"
+                "on UNIX systems",
             )
 
     trio_stdin: ClosableSendStream | None = None
@@ -417,7 +420,7 @@ async def _open_process(
                 stdout=stdout,
                 stderr=stderr,
                 **options,
-            )
+            ),
         )
         # We did not fail, so dismiss the stack for the trio ends
         cleanup_on_fail.pop_all()
@@ -443,7 +446,7 @@ async def _posix_deliver_cancel(p: Process) -> None:
             RuntimeWarning(
                 f"process {p!r} ignored SIGTERM for 5 seconds. "
                 "(Maybe you should pass a custom deliver_cancel?) "
-                "Trying SIGKILL."
+                "Trying SIGKILL.",
             ),
             stacklevel=1,
         )
@@ -671,17 +674,17 @@ async def _run_process(
             raise ValueError(
                 "stdout=subprocess.PIPE is only valid with nursery.start, "
                 "since that's the only way to access the pipe; use nursery.start "
-                "or pass the data you want to write directly"
+                "or pass the data you want to write directly",
             )
         if options.get("stdout") is subprocess.PIPE:
             raise ValueError(
                 "stdout=subprocess.PIPE is only valid with nursery.start, "
-                "since that's the only way to access the pipe"
+                "since that's the only way to access the pipe",
             )
         if options.get("stderr") is subprocess.PIPE:
             raise ValueError(
                 "stderr=subprocess.PIPE is only valid with nursery.start, "
-                "since that's the only way to access the pipe"
+                "since that's the only way to access the pipe",
             )
     if isinstance(stdin, (bytes, bytearray, memoryview)):
         input_ = stdin
@@ -768,7 +771,10 @@ async def _run_process(
 
     if proc.returncode and check:
         raise subprocess.CalledProcessError(
-            proc.returncode, proc.args, output=stdout, stderr=stderr
+            proc.returncode,
+            proc.args,
+            output=stdout,
+            stderr=stderr,
         )
     else:
         assert proc.returncode is not None

--- a/src/trio/_subprocess_platform/kqueue.py
+++ b/src/trio/_subprocess_platform/kqueue.py
@@ -21,7 +21,10 @@ async def wait_child_exiting(process: _subprocess.Process) -> None:
 
     def make_event(flags: int) -> select.kevent:
         return select.kevent(
-            process.pid, filter=select.KQ_FILTER_PROC, flags=flags, fflags=KQ_NOTE_EXIT
+            process.pid,
+            filter=select.KQ_FILTER_PROC,
+            flags=flags,
+            fflags=KQ_NOTE_EXIT,
         )
 
     try:

--- a/src/trio/_subprocess_platform/waitid.py
+++ b/src/trio/_subprocess_platform/waitid.py
@@ -40,7 +40,7 @@ typedef struct siginfo_s {
     int pad[26];
 } siginfo_t;
 int waitid(int idtype, int id, siginfo_t* result, int options);
-"""
+""",
     )
     waitid_cffi = waitid_ffi.dlopen(None).waitid  # type: ignore[attr-defined]
 
@@ -79,7 +79,10 @@ async def _waitid_system_task(pid: int, event: Event) -> None:
 
     try:
         await to_thread_run_sync(
-            sync_wait_reapable, pid, abandon_on_cancel=True, limiter=waitid_limiter
+            sync_wait_reapable,
+            pid,
+            abandon_on_cancel=True,
+            limiter=waitid_limiter,
         )
     except OSError:
         # If waitid fails, waitpid will fail too, so it still makes

--- a/src/trio/_sync.py
+++ b/src/trio/_sync.py
@@ -297,7 +297,7 @@ class CapacityLimiter(AsyncContextManagerMixin):
         """
         if borrower in self._borrowers:
             raise RuntimeError(
-                "this borrower is already holding one of this CapacityLimiter's tokens"
+                "this borrower is already holding one of this CapacityLimiter's tokens",
             )
         if len(self._borrowers) < self._total_tokens and not self._lot:
             self._borrowers.add(borrower)
@@ -366,7 +366,7 @@ class CapacityLimiter(AsyncContextManagerMixin):
         """
         if borrower not in self._borrowers:
             raise RuntimeError(
-                "this borrower isn't holding any of this CapacityLimiter's tokens"
+                "this borrower isn't holding any of this CapacityLimiter's tokens",
             )
         self._borrowers.remove(borrower)
         self._wake_waiters()
@@ -622,7 +622,9 @@ class _LockImpl(AsyncContextManagerMixin):
 
         """
         return LockStatistics(
-            locked=self.locked(), owner=self._owner, tasks_waiting=len(self._lot)
+            locked=self.locked(),
+            owner=self._owner,
+            tasks_waiting=len(self._lot),
         )
 
 
@@ -845,5 +847,6 @@ class Condition(AsyncContextManagerMixin):
 
         """
         return ConditionStatistics(
-            tasks_waiting=len(self._lot), lock_statistics=self._lock.statistics()
+            tasks_waiting=len(self._lot),
+            lock_statistics=self._lock.statistics(),
         )

--- a/src/trio/_tests/check_type_completeness.py
+++ b/src/trio/_tests/check_type_completeness.py
@@ -111,7 +111,9 @@ def has_docstring_at_runtime(name: str) -> bool:
 
 
 def check_type(
-    platform: str, full_diagnostics_file: Path | None, expected_errors: list[object]
+    platform: str,
+    full_diagnostics_file: Path | None,
+    expected_errors: list[object],
 ) -> list[object]:
     # convince isort we use the trio import
     assert trio
@@ -144,7 +146,7 @@ def check_type(
                 if message.startswith("No docstring found for"):
                     continue
                 if message.startswith(
-                    "Type is missing type annotation and could be inferred differently by type checkers"
+                    "Type is missing type annotation and could be inferred differently by type checkers",
                 ):
                     continue
 

--- a/src/trio/_tests/module_with_deprecations.py
+++ b/src/trio/_tests/module_with_deprecations.py
@@ -16,6 +16,9 @@ assert not hasattr(this_mod, "dep1")
 __deprecated_attributes__ = {
     "dep1": _deprecate.DeprecatedAttribute("value1", "1.1", issue=1),
     "dep2": _deprecate.DeprecatedAttribute(
-        "value2", "1.2", issue=1, instead="instead-string"
+        "value2",
+        "1.2",
+        issue=1,
+        instead="instead-string",
     ),
 }

--- a/src/trio/_tests/test_channel.py
+++ b/src/trio/_tests/test_channel.py
@@ -107,7 +107,8 @@ async def test_channel_multiple_consumers() -> None:
 
 async def test_close_basics() -> None:
     async def send_block(
-        s: trio.MemorySendChannel[None], expect: type[BaseException]
+        s: trio.MemorySendChannel[None],
+        expect: type[BaseException],
     ) -> None:
         with pytest.raises(expect):
             await s.send(None)
@@ -164,7 +165,8 @@ async def test_close_basics() -> None:
 
 async def test_close_sync() -> None:
     async def send_block(
-        s: trio.MemorySendChannel[None], expect: type[BaseException]
+        s: trio.MemorySendChannel[None],
+        expect: type[BaseException],
     ) -> None:
         with pytest.raises(expect):
             await s.send(None)

--- a/src/trio/_tests/test_contextvars.py
+++ b/src/trio/_tests/test_contextvars.py
@@ -5,7 +5,7 @@ import contextvars
 from .. import _core
 
 trio_testing_contextvar: contextvars.ContextVar[str] = contextvars.ContextVar(
-    "trio_testing_contextvar"
+    "trio_testing_contextvar",
 )
 
 

--- a/src/trio/_tests/test_deprecate.py
+++ b/src/trio/_tests/test_deprecate.py
@@ -161,7 +161,10 @@ class Alias:
         return "new hotness method"
 
     old_hotness_method = deprecated_alias(
-        "Alias.old_hotness_method", new_hotness_method, "3.21", issue=1
+        "Alias.old_hotness_method",
+        new_hotness_method,
+        "3.21",
+        issue=1,
     )
 
 
@@ -272,5 +275,9 @@ def test_warning_class() -> None:
 
     with pytest.warns(TrioDeprecationWarning):
         warn_deprecated(
-            "foo", "bar", issue=None, instead=None, use_triodeprecationwarning=True
+            "foo",
+            "bar",
+            issue=None,
+            instead=None,
+            use_triodeprecationwarning=True,
         )

--- a/src/trio/_tests/test_deprecate_strict_exception_groups_false.py
+++ b/src/trio/_tests/test_deprecate_strict_exception_groups_false.py
@@ -7,7 +7,8 @@ import trio
 
 async def test_deprecation_warning_open_nursery() -> None:
     with pytest.warns(
-        trio.TrioDeprecationWarning, match="strict_exception_groups=False"
+        trio.TrioDeprecationWarning,
+        match="strict_exception_groups=False",
     ) as record:
         async with trio.open_nursery(strict_exception_groups=False):
             ...
@@ -33,7 +34,8 @@ def test_deprecation_warning_run() -> None:
 
     def helper(fun: Callable[..., Awaitable[None]], num: int) -> None:
         with pytest.warns(
-            trio.TrioDeprecationWarning, match="strict_exception_groups=False"
+            trio.TrioDeprecationWarning,
+            match="strict_exception_groups=False",
         ) as record:
             trio.run(fun, strict_exception_groups=False)
         assert len(record) == num
@@ -52,7 +54,8 @@ def test_deprecation_warning_start_guest_run() -> None:
         return "ok"
 
     with pytest.warns(
-        trio.TrioDeprecationWarning, match="strict_exception_groups=False"
+        trio.TrioDeprecationWarning,
+        match="strict_exception_groups=False",
     ) as record:
         trivial_guest_run(
             trio_return,

--- a/src/trio/_tests/test_dtls.py
+++ b/src/trio/_tests/test_dtls.py
@@ -38,7 +38,9 @@ ca.configure_trust(client_ctx)
 
 
 parametrize_ipv6 = pytest.mark.parametrize(
-    "ipv6", [False, pytest.param(True, marks=binds_ipv6)], ids=["ipv4", "ipv6"]
+    "ipv6",
+    [False, pytest.param(True, marks=binds_ipv6)],
+    ids=["ipv4", "ipv6"],
 )
 
 
@@ -51,7 +53,10 @@ def endpoint(**kwargs: int | bool) -> DTLSEndpoint:
 
 @asynccontextmanager
 async def dtls_echo_server(
-    *, autocancel: bool = True, mtu: int | None = None, ipv6: bool = False
+    *,
+    autocancel: bool = True,
+    mtu: int | None = None,
+    ipv6: bool = False,
 ) -> AsyncGenerator[tuple[DTLSEndpoint, tuple[str, int]], None]:
     with endpoint(ipv6=ipv6) as server:
         localhost = "::1" if ipv6 else "127.0.0.1"
@@ -62,7 +67,7 @@ async def dtls_echo_server(
                 print(
                     "echo handler started: "
                     f"server {dtls_channel.endpoint.socket.getsockname()!r} "
-                    f"client {dtls_channel.peer_address!r}"
+                    f"client {dtls_channel.peer_address!r}",
                 )
                 if mtu is not None:
                     dtls_channel.set_ciphertext_mtu(mtu)
@@ -99,7 +104,8 @@ async def test_smoke(ipv6: bool) -> None:
             assert await client_channel.receive() == b"goodbye"
 
             with pytest.raises(
-                ValueError, match="^openssl doesn't support sending empty DTLS packets$"
+                ValueError,
+                match="^openssl doesn't support sending empty DTLS packets$",
             ):
                 await client_channel.send(b"")
 
@@ -165,7 +171,7 @@ async def test_handshake_over_terrible_network(
                         assert op == "deliver"
                         print(
                             f"{packet.source} -> {packet.destination}: delivered"
-                            f" {packet.payload.hex()}"
+                            f" {packet.payload.hex()}",
                         )
                         fn.deliver_packet(packet)
                         break
@@ -225,7 +231,8 @@ async def test_full_duplex() -> None:
             await server_nursery.start(server_endpoint.serve, server_ctx, handler)
 
             client = client_endpoint.connect(
-                server_endpoint.socket.getsockname(), client_ctx
+                server_endpoint.socket.getsockname(),
+                client_ctx,
             )
             async with trio.open_nursery() as nursery:
                 nursery.start_soon(client.send, b"from client")
@@ -372,9 +379,9 @@ async def test_server_socket_doesnt_crash_on_garbage(
                     frag_offset=0,
                     frag_len=10,
                     frag=bytes(10),
-                )
+                ),
             ),
-        )
+        ),
     )
 
     client_hello_extended = client_hello + b"\x00"
@@ -397,9 +404,9 @@ async def test_server_socket_doesnt_crash_on_garbage(
                     frag_offset=0,
                     frag_len=10,
                     frag=bytes(10),
-                )
+                ),
             ),
-        )
+        ),
     )
 
     client_hello_trailing_data_in_record = encode_record(
@@ -415,10 +422,10 @@ async def test_server_socket_doesnt_crash_on_garbage(
                     frag_offset=0,
                     frag_len=10,
                     frag=bytes(10),
-                )
+                ),
             )
             + b"\x00",
-        )
+        ),
     )
 
     handshake_empty = encode_record(
@@ -427,7 +434,7 @@ async def test_server_socket_doesnt_crash_on_garbage(
             version=ProtocolVersion.DTLS10,
             epoch_seqno=0,
             payload=b"",
-        )
+        ),
     )
 
     client_hello_truncated_in_cookie = encode_record(
@@ -436,7 +443,7 @@ async def test_server_socket_doesnt_crash_on_garbage(
             version=ProtocolVersion.DTLS10,
             epoch_seqno=0,
             payload=bytes(2 + 32 + 1) + b"\xff",
-        )
+        ),
     )
 
     async with dtls_echo_server() as (_, address):
@@ -620,7 +627,8 @@ async def test_openssl_retransmit_doesnt_break_stuff() -> None:
                 # notices the timeout has expired
                 blackholed = False
                 await server_endpoint.socket.sendto(
-                    b"xxx", client_endpoint.socket.getsockname()
+                    b"xxx",
+                    client_endpoint.socket.getsockname(),
                 )
                 # now the client task should finish connecting and exit cleanly
 
@@ -682,7 +690,8 @@ async def test_explicit_tiny_mtu_is_respected() -> None:
 
 @parametrize_ipv6
 async def test_handshake_handles_minimum_network_mtu(
-    ipv6: bool, autojump_clock: trio.abc.Clock
+    ipv6: bool,
+    autojump_clock: trio.abc.Clock,
 ) -> None:
     # Fake network that has the minimum allowable MTU for whatever protocol we're using.
     fn = FakeNet()

--- a/src/trio/_tests/test_exports.py
+++ b/src/trio/_tests/test_exports.py
@@ -55,7 +55,7 @@ def _ensure_mypy_cache_updated() -> None:
                 "--no-error-summary",
                 "-c",
                 "import trio",
-            ]
+            ],
         )
         assert not result[1]  # stderr
         assert not result[0]  # stdout
@@ -72,7 +72,8 @@ def test_core_is_properly_reexported() -> None:
         found = 0
         for source in sources:
             if symbol in dir(source) and getattr(source, symbol) is getattr(
-                _core, symbol
+                _core,
+                symbol,
             ):
                 found += 1
         print(symbol, found)
@@ -254,7 +255,9 @@ def test_static_tool_sees_all_symbols(tool: str, modname: str, tmp_path: Path) -
 @pytest.mark.parametrize("module_name", PUBLIC_MODULE_NAMES)
 @pytest.mark.parametrize("tool", ["jedi", "mypy"])
 def test_static_tool_sees_class_members(
-    tool: str, module_name: str, tmp_path: Path
+    tool: str,
+    module_name: str,
+    tmp_path: Path,
 ) -> None:
     module = PUBLIC_MODULES[PUBLIC_MODULE_NAMES.index(module_name)]
 
@@ -376,7 +379,7 @@ def test_static_tool_sees_class_members(
                 skip_if_optional_else_raise(error)
 
             script = jedi.Script(
-                f"from {module_name} import {class_name}; {class_name}."
+                f"from {module_name} import {class_name}; {class_name}.",
             )
             completions = script.complete()
             static_names = no_hidden(c.name for c in completions) - ignore_names

--- a/src/trio/_tests/test_fakenet.py
+++ b/src/trio/_tests/test_fakenet.py
@@ -34,14 +34,16 @@ async def test_basic_udp() -> None:
     assert port != 0
 
     with pytest.raises(
-        OSError, match=r"^\[\w+ \d+\] Invalid argument$"
+        OSError,
+        match=r"^\[\w+ \d+\] Invalid argument$",
     ) as exc:  # Cannot rebind.
         await s1.bind(("192.0.2.1", 0))
     assert exc.value.errno == errno.EINVAL
 
     # Cannot bind multiple sockets to the same address
     with pytest.raises(
-        OSError, match=r"^\[\w+ \d+\] (Address (already )?in use|Unknown error)$"
+        OSError,
+        match=r"^\[\w+ \d+\] (Address (already )?in use|Unknown error)$",
     ) as exc:
         await s2.bind(("127.0.0.1", port))
     assert exc.value.errno == errno.EADDRINUSE
@@ -131,7 +133,8 @@ async def test_recv_methods() -> None:
 
 
 @pytest.mark.skipif(
-    sys.platform == "win32", reason="functions not in socket on windows"
+    sys.platform == "win32",
+    reason="functions not in socket on windows",
 )
 async def test_nonwindows_functionality() -> None:
     # mypy doesn't support a good way of aborting typechecking on different platforms
@@ -180,13 +183,15 @@ async def test_nonwindows_functionality() -> None:
         assert addr == s1.getsockname()
 
         with pytest.raises(
-            AttributeError, match="^'FakeSocket' object has no attribute 'share'$"
+            AttributeError,
+            match="^'FakeSocket' object has no attribute 'share'$",
         ):
             await s1.share(0)  # type: ignore[attr-defined]
 
 
 @pytest.mark.skipif(
-    sys.platform != "win32", reason="windows-specific fakesocket testing"
+    sys.platform != "win32",
+    reason="windows-specific fakesocket testing",
 )
 async def test_windows_functionality() -> None:
     # mypy doesn't support a good way of aborting typechecking on different platforms
@@ -196,11 +201,13 @@ async def test_windows_functionality() -> None:
         s2 = trio.socket.socket(type=trio.socket.SOCK_DGRAM)
         await s1.bind(("127.0.0.1", 0))
         with pytest.raises(
-            AttributeError, match="^'FakeSocket' object has no attribute 'sendmsg'$"
+            AttributeError,
+            match="^'FakeSocket' object has no attribute 'sendmsg'$",
         ):
             await s1.sendmsg([b"jkl"], (), 0, s2.getsockname())  # type: ignore[attr-defined]
         with pytest.raises(
-            AttributeError, match="^'FakeSocket' object has no attribute 'recvmsg'$"
+            AttributeError,
+            match="^'FakeSocket' object has no attribute 'recvmsg'$",
         ):
             s2.recvmsg(0)  # type: ignore[attr-defined]
         with pytest.raises(
@@ -224,28 +231,33 @@ async def test_not_implemented_functions() -> None:
 
     # getsockopt
     with pytest.raises(
-        OSError, match=r"^FakeNet doesn't implement getsockopt\(\d, \d\)$"
+        OSError,
+        match=r"^FakeNet doesn't implement getsockopt\(\d, \d\)$",
     ):
         s1.getsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY)
 
     # setsockopt
     with pytest.raises(
-        NotImplementedError, match="^FakeNet always has IPV6_V6ONLY=True$"
+        NotImplementedError,
+        match="^FakeNet always has IPV6_V6ONLY=True$",
     ):
         s1.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, False)
     with pytest.raises(
-        OSError, match=r"^FakeNet doesn't implement setsockopt\(\d+, \d+, \.\.\.\)$"
+        OSError,
+        match=r"^FakeNet doesn't implement setsockopt\(\d+, \d+, \.\.\.\)$",
     ):
         s1.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, True)
     with pytest.raises(
-        OSError, match=r"^FakeNet doesn't implement setsockopt\(\d+, \d+, \.\.\.\)$"
+        OSError,
+        match=r"^FakeNet doesn't implement setsockopt\(\d+, \d+, \.\.\.\)$",
     ):
         s1.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 
     # set_inheritable
     s1.set_inheritable(False)
     with pytest.raises(
-        NotImplementedError, match="^FakeNet can't make inheritable sockets$"
+        NotImplementedError,
+        match="^FakeNet can't make inheritable sockets$",
     ):
         s1.set_inheritable(True)
 
@@ -274,7 +286,7 @@ async def test_init() -> None:
     with pytest.raises(
         NotImplementedError,
         match=re.escape(
-            f"FakeNet doesn't (yet) support type={trio.socket.SOCK_STREAM}"
+            f"FakeNet doesn't (yet) support type={trio.socket.SOCK_STREAM}",
         ),
     ):
         s1 = trio.socket.socket()

--- a/src/trio/_tests/test_file_io.py
+++ b/src/trio/_tests/test_file_io.py
@@ -59,13 +59,15 @@ def test_wrap_non_iobase() -> None:
 
 
 def test_wrapped_property(
-    async_file: AsyncIOWrapper[mock.Mock], wrapped: mock.Mock
+    async_file: AsyncIOWrapper[mock.Mock],
+    wrapped: mock.Mock,
 ) -> None:
     assert async_file.wrapped is wrapped
 
 
 def test_dir_matches_wrapped(
-    async_file: AsyncIOWrapper[mock.Mock], wrapped: mock.Mock
+    async_file: AsyncIOWrapper[mock.Mock],
+    wrapped: mock.Mock,
 ) -> None:
     attrs = _FILE_SYNC_ATTRS.union(_FILE_ASYNC_METHODS)
 
@@ -132,7 +134,8 @@ def test_type_stubs_match_lists() -> None:
 
 
 def test_sync_attrs_forwarded(
-    async_file: AsyncIOWrapper[mock.Mock], wrapped: mock.Mock
+    async_file: AsyncIOWrapper[mock.Mock],
+    wrapped: mock.Mock,
 ) -> None:
     for attr_name in _FILE_SYNC_ATTRS:
         if attr_name not in dir(async_file):
@@ -142,7 +145,8 @@ def test_sync_attrs_forwarded(
 
 
 def test_sync_attrs_match_wrapper(
-    async_file: AsyncIOWrapper[mock.Mock], wrapped: mock.Mock
+    async_file: AsyncIOWrapper[mock.Mock],
+    wrapped: mock.Mock,
 ) -> None:
     for attr_name in _FILE_SYNC_ATTRS:
         if attr_name in dir(async_file):
@@ -174,7 +178,8 @@ def test_async_methods_signature(async_file: AsyncIOWrapper[mock.Mock]) -> None:
 
 
 async def test_async_methods_wrap(
-    async_file: AsyncIOWrapper[mock.Mock], wrapped: mock.Mock
+    async_file: AsyncIOWrapper[mock.Mock],
+    wrapped: mock.Mock,
 ) -> None:
     for meth_name in _FILE_ASYNC_METHODS:
         if meth_name not in dir(async_file):
@@ -186,7 +191,8 @@ async def test_async_methods_wrap(
         value = await meth(sentinel.argument, keyword=sentinel.keyword)
 
         wrapped_meth.assert_called_once_with(
-            sentinel.argument, keyword=sentinel.keyword
+            sentinel.argument,
+            keyword=sentinel.keyword,
         )
         assert value == wrapped_meth()
 
@@ -194,7 +200,8 @@ async def test_async_methods_wrap(
 
 
 async def test_async_methods_match_wrapper(
-    async_file: AsyncIOWrapper[mock.Mock], wrapped: mock.Mock
+    async_file: AsyncIOWrapper[mock.Mock],
+    wrapped: mock.Mock,
 ) -> None:
     for meth_name in _FILE_ASYNC_METHODS:
         if meth_name in dir(async_file):

--- a/src/trio/_tests/test_highlevel_open_tcp_listeners.py
+++ b/src/trio/_tests/test_highlevel_open_tcp_listeners.py
@@ -160,7 +160,11 @@ class FakeSocket(tsocket.SocketType):
     def getsockopt(self, /, level: int, optname: int, buflen: int) -> bytes: ...
 
     def getsockopt(
-        self, /, level: int, optname: int, buflen: int | None = None
+        self,
+        /,
+        level: int,
+        optname: int,
+        buflen: int | None = None,
     ) -> int | bytes:
         if (level, optname) == (tsocket.SOL_SOCKET, tsocket.SO_ACCEPTCONN):
             return True
@@ -171,7 +175,12 @@ class FakeSocket(tsocket.SocketType):
 
     @overload
     def setsockopt(
-        self, /, level: int, optname: int, value: None, optlen: int
+        self,
+        /,
+        level: int,
+        optname: int,
+        value: None,
+        optlen: int,
     ) -> None: ...
 
     def setsockopt(
@@ -252,7 +261,9 @@ class FakeHostnameResolver(HostnameResolver):
         ]
 
     async def getnameinfo(
-        self, sockaddr: tuple[str, int] | tuple[str, int, int, int], flags: int
+        self,
+        sockaddr: tuple[str, int] | tuple[str, int, int, int],
+        flags: int,
     ) -> tuple[str, str]:
         raise NotImplementedError()
 
@@ -268,8 +279,8 @@ async def test_open_tcp_listeners_multiple_host_cleanup_on_error() -> None:
                 (tsocket.AF_INET, "1.1.1.1"),
                 (tsocket.AF_INET, "2.2.2.2"),
                 (tsocket.AF_INET, "3.3.3.3"),
-            ]
-        )
+            ],
+        ),
     )
 
     with pytest.raises(FakeOSError):
@@ -313,14 +324,16 @@ async def test_serve_tcp() -> None:
     [{tsocket.AF_INET}, {tsocket.AF_INET6}, {tsocket.AF_INET, tsocket.AF_INET6}],
 )
 async def test_open_tcp_listeners_some_address_families_unavailable(
-    try_families: set[AddressFamily], fail_families: set[AddressFamily]
+    try_families: set[AddressFamily],
+    fail_families: set[AddressFamily],
 ) -> None:
     fsf = FakeSocketFactory(
-        10, raise_on_family={family: errno.EAFNOSUPPORT for family in fail_families}
+        10,
+        raise_on_family={family: errno.EAFNOSUPPORT for family in fail_families},
     )
     tsocket.set_custom_socket_factory(fsf)
     tsocket.set_custom_hostname_resolver(
-        FakeHostnameResolver([(family, "foo") for family in try_families])
+        FakeHostnameResolver([(family, "foo") for family in try_families]),
     )
 
     should_succeed = try_families - fail_families
@@ -352,7 +365,7 @@ async def test_open_tcp_listeners_socket_fails_not_afnosupport() -> None:
     )
     tsocket.set_custom_socket_factory(fsf)
     tsocket.set_custom_hostname_resolver(
-        FakeHostnameResolver([(tsocket.AF_INET, "foo"), (tsocket.AF_INET6, "bar")])
+        FakeHostnameResolver([(tsocket.AF_INET, "foo"), (tsocket.AF_INET6, "bar")]),
     )
 
     with pytest.raises(OSError, match="nope") as exc_info:
@@ -391,6 +404,7 @@ async def test_open_tcp_listeners_backlog_float_error() -> None:
     tsocket.set_custom_socket_factory(fsf)
     for should_fail in (0.0, 2.18, 3.14, 9.75):
         with pytest.raises(
-            TypeError, match=f"backlog must be an int or None, not {should_fail!r}"
+            TypeError,
+            match=f"backlog must be an int or None, not {should_fail!r}",
         ):
             await open_tcp_listeners(0, backlog=should_fail)  # type: ignore[arg-type]

--- a/src/trio/_tests/test_highlevel_open_tcp_stream.py
+++ b/src/trio/_tests/test_highlevel_open_tcp_stream.py
@@ -156,12 +156,14 @@ async def test_local_address_real() -> None:
         local_address = "127.0.0.2" if can_bind_127_0_0_2() else "127.0.0.1"
 
         async with await open_tcp_stream(
-            *listener.getsockname(), local_address=local_address
+            *listener.getsockname(),
+            local_address=local_address,
         ) as client_stream:
             assert client_stream.socket.getsockname()[0] == local_address
             if hasattr(trio.socket, "IP_BIND_ADDRESS_NO_PORT"):
                 assert client_stream.socket.getsockopt(
-                    trio.socket.IPPROTO_IP, trio.socket.IP_BIND_ADDRESS_NO_PORT
+                    trio.socket.IPPROTO_IP,
+                    trio.socket.IP_BIND_ADDRESS_NO_PORT,
                 )
             server_sock, remote_addr = await listener.accept()
             await client_stream.aclose()
@@ -172,13 +174,15 @@ async def test_local_address_real() -> None:
         # Trying to connect to an ipv4 address with the ipv6 wildcard
         # local_address should fail
         with pytest.raises(
-            OSError, match=r"^all attempts to connect* to *127\.0\.0\.\d:\d+ failed$"
+            OSError,
+            match=r"^all attempts to connect* to *127\.0\.0\.\d:\d+ failed$",
         ):
             await open_tcp_stream(*listener.getsockname(), local_address="::")
 
         # But the ipv4 wildcard address should work
         async with await open_tcp_stream(
-            *listener.getsockname(), local_address="0.0.0.0"
+            *listener.getsockname(),
+            local_address="0.0.0.0",
         ) as client_stream:
             server_sock, remote_addr = await listener.accept()
             server_sock.close()
@@ -318,7 +322,9 @@ class Scenario(trio.abc.SocketFactory, trio.abc.HostnameResolver):
         return [self._ip_to_gai_entry(ip) for ip in self.ip_order]
 
     async def getnameinfo(
-        self, sockaddr: tuple[str, int] | tuple[str, int, int, int], flags: int
+        self,
+        sockaddr: tuple[str, int] | tuple[str, int, int, int],
+        flags: int,
     ) -> tuple[str, str]:
         raise NotImplementedError
 
@@ -391,7 +397,9 @@ async def test_one_host_slow_success(autojump_clock: MockClock) -> None:
 
 async def test_one_host_quick_fail(autojump_clock: MockClock) -> None:
     exc, scenario = await run_scenario(
-        82, [("1.2.3.4", 0.123, "error")], expect_error=OSError
+        82,
+        [("1.2.3.4", 0.123, "error")],
+        expect_error=OSError,
     )
     assert isinstance(exc, OSError)
     assert trio.current_time() == 0.123
@@ -399,7 +407,9 @@ async def test_one_host_quick_fail(autojump_clock: MockClock) -> None:
 
 async def test_one_host_slow_fail(autojump_clock: MockClock) -> None:
     exc, scenario = await run_scenario(
-        83, [("1.2.3.4", 100, "error")], expect_error=OSError
+        83,
+        [("1.2.3.4", 100, "error")],
+        expect_error=OSError,
     )
     assert isinstance(exc, OSError)
     assert trio.current_time() == 100
@@ -407,7 +417,9 @@ async def test_one_host_slow_fail(autojump_clock: MockClock) -> None:
 
 async def test_one_host_failed_after_connect(autojump_clock: MockClock) -> None:
     exc, scenario = await run_scenario(
-        83, [("1.2.3.4", 1, "postconnect_fail")], expect_error=KeyboardInterrupt
+        83,
+        [("1.2.3.4", 1, "postconnect_fail")],
+        expect_error=KeyboardInterrupt,
     )
     assert isinstance(exc, KeyboardInterrupt)
 
@@ -532,7 +544,8 @@ async def test_all_fail(autojump_clock: MockClock) -> None:
 
     subexceptions = (Matcher(OSError, match="^sorry$"),) * 4
     assert RaisesGroup(
-        *subexceptions, match="all attempts to connect to test.example.com:80 failed"
+        *subexceptions,
+        match="all attempts to connect to test.example.com:80 failed",
     ).matches(exc.__cause__)
 
     assert trio.current_time() == (0.1 + 0.2 + 10)

--- a/src/trio/_tests/test_highlevel_open_unix_stream.py
+++ b/src/trio/_tests/test_highlevel_open_unix_stream.py
@@ -12,7 +12,8 @@ from trio._highlevel_open_unix_stream import close_on_error
 assert not TYPE_CHECKING or sys.platform != "win32"
 
 skip_if_not_unix = pytest.mark.skipif(
-    not hasattr(socket, "AF_UNIX"), reason="Needs unix socket support"
+    not hasattr(socket, "AF_UNIX"),
+    reason="Needs unix socket support",
 )
 
 
@@ -79,6 +80,7 @@ async def test_open_unix_socket() -> None:
 @pytest.mark.skipif(hasattr(socket, "AF_UNIX"), reason="Test for non-unix platforms")
 async def test_error_on_no_unix() -> None:
     with pytest.raises(
-        RuntimeError, match="^Unix sockets are not supported on this platform$"
+        RuntimeError,
+        match="^Unix sockets are not supported on this platform$",
     ):
         await open_unix_socket("")

--- a/src/trio/_tests/test_highlevel_serve_listeners.py
+++ b/src/trio/_tests/test_highlevel_serve_listeners.py
@@ -95,7 +95,9 @@ async def test_serve_listeners_basic() -> None:
 
     async with trio.open_nursery() as nursery:
         l2: list[MemoryListener] = await nursery.start(
-            trio.serve_listeners, handler, listeners
+            trio.serve_listeners,
+            handler,
+            listeners,
         )
         assert l2 == listeners
         # This is just split into another function because gh-136 isn't
@@ -123,7 +125,8 @@ async def test_serve_listeners_accept_unrecognized_error() -> None:
 
 
 async def test_serve_listeners_accept_capacity_error(
-    autojump_clock: MockClock, caplog: pytest.LogCaptureFixture
+    autojump_clock: MockClock,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     listener = MemoryListener()
 
@@ -155,7 +158,8 @@ async def test_serve_listeners_connection_nursery(autojump_clock: MockClock) -> 
         pass
 
     async def connection_watcher(
-        *, task_status: TaskStatus[Nursery] = trio.TASK_STATUS_IGNORED
+        *,
+        task_status: TaskStatus[Nursery] = trio.TASK_STATUS_IGNORED,
     ) -> NoReturn:
         async with trio.open_nursery() as nursery:
             task_status.started(nursery)
@@ -173,7 +177,7 @@ async def test_serve_listeners_connection_nursery(autojump_clock: MockClock) -> 
                     handler,
                     [listener],
                     handler_nursery=handler_nursery,
-                )
+                ),
             )
             for _ in range(10):
                 nursery.start_soon(listener.connect)

--- a/src/trio/_tests/test_highlevel_socket.py
+++ b/src/trio/_tests/test_highlevel_socket.py
@@ -27,7 +27,8 @@ async def test_SocketStream_basics() -> None:
     # DGRAM socket bad
     with tsocket.socket(type=tsocket.SOCK_DGRAM) as sock:
         with pytest.raises(
-            ValueError, match="^SocketStream requires a SOCK_STREAM socket$"
+            ValueError,
+            match="^SocketStream requires a SOCK_STREAM socket$",
         ):
             # TODO: does not raise an error?
             SocketStream(sock)
@@ -155,7 +156,8 @@ async def test_SocketListener() -> None:
     with tsocket.socket(type=tsocket.SOCK_DGRAM) as s:
         await s.bind(("127.0.0.1", 0))
         with pytest.raises(
-            ValueError, match="^SocketListener requires a SOCK_STREAM socket$"
+            ValueError,
+            match="^SocketListener requires a SOCK_STREAM socket$",
         ) as excinfo:
             SocketListener(s)
         excinfo.match(r".*SOCK_STREAM")
@@ -166,7 +168,8 @@ async def test_SocketListener() -> None:
         with tsocket.socket() as s:
             await s.bind(("127.0.0.1", 0))
             with pytest.raises(
-                ValueError, match="^SocketListener requires a listening socket$"
+                ValueError,
+                match="^SocketListener requires a listening socket$",
             ) as excinfo:
                 SocketListener(s)
             excinfo.match(r".*listen")
@@ -228,22 +231,39 @@ async def test_SocketListener_accept_errors() -> None:
 
         @overload
         def getsockopt(  # noqa: F811
-            self, /, level: int, optname: int, buflen: int
+            self,
+            /,
+            level: int,
+            optname: int,
+            buflen: int,
         ) -> bytes: ...
 
         def getsockopt(  # noqa: F811
-            self, /, level: int, optname: int, buflen: int | None = None
+            self,
+            /,
+            level: int,
+            optname: int,
+            buflen: int | None = None,
         ) -> int | bytes:
             return True
 
         @overload
         def setsockopt(
-            self, /, level: int, optname: int, value: int | Buffer
+            self,
+            /,
+            level: int,
+            optname: int,
+            value: int | Buffer,
         ) -> None: ...
 
         @overload
         def setsockopt(  # noqa: F811
-            self, /, level: int, optname: int, value: None, optlen: int
+            self,
+            /,
+            level: int,
+            optname: int,
+            value: None,
+            optlen: int,
         ) -> None: ...
 
         def setsockopt(  # noqa: F811
@@ -276,7 +296,7 @@ async def test_SocketListener_accept_errors() -> None:
             OSError(errno.EFAULT, "attempt to write to read-only memory"),
             OSError(errno.ENOBUFS, "out of buffers"),
             fake_server_sock,
-        ]
+        ],
     )
 
     listener = SocketListener(fake_listen_sock)

--- a/src/trio/_tests/test_highlevel_ssl_helpers.py
+++ b/src/trio/_tests/test_highlevel_ssl_helpers.py
@@ -82,8 +82,12 @@ async def test_open_ssl_over_tcp_stream_and_everything_else(
         res: list[SSLListener[SocketListener]] = (  # type: ignore[type-var]
             await nursery.start(
                 partial(
-                    serve_ssl_over_tcp, echo_handler, 0, SERVER_CTX, host="127.0.0.1"
-                )
+                    serve_ssl_over_tcp,
+                    echo_handler,
+                    0,
+                    SERVER_CTX,
+                    host="127.0.0.1",
+                ),
             )
         )
         (listener,) = res
@@ -105,7 +109,9 @@ async def test_open_ssl_over_tcp_stream_and_everything_else(
             # We have the trust but not the hostname
             # (checks custom ssl_context + hostname checking)
             stream = await open_ssl_over_tcp_stream(
-                "xyzzy.example.org", 80, ssl_context=client_ctx
+                "xyzzy.example.org",
+                80,
+                ssl_context=client_ctx,
             )
             async with stream:
                 with pytest.raises(trio.BrokenResourceError):
@@ -113,7 +119,9 @@ async def test_open_ssl_over_tcp_stream_and_everything_else(
 
             # This one should work!
             stream = await open_ssl_over_tcp_stream(
-                "trio-test-1.example.org", 80, ssl_context=client_ctx
+                "trio-test-1.example.org",
+                80,
+                ssl_context=client_ctx,
             )
             async with stream:
                 assert isinstance(stream, trio.SSLStream)
@@ -149,7 +157,10 @@ async def test_open_ssl_over_tcp_listeners() -> None:
         assert not listener._https_compatible
 
     (listener,) = await open_ssl_over_tcp_listeners(
-        0, SERVER_CTX, host="127.0.0.1", https_compatible=True
+        0,
+        SERVER_CTX,
+        host="127.0.0.1",
+        https_compatible=True,
     )
     async with listener:
         assert listener._https_compatible

--- a/src/trio/_tests/test_path.py
+++ b/src/trio/_tests/test_path.py
@@ -98,11 +98,14 @@ async def test_div_magic(cls_a: PathOrStrType, cls_b: PathOrStrType) -> None:
 
 
 @pytest.mark.parametrize(
-    ("cls_a", "cls_b"), [(trio.Path, pathlib.Path), (trio.Path, trio.Path)]
+    ("cls_a", "cls_b"),
+    [(trio.Path, pathlib.Path), (trio.Path, trio.Path)],
 )
 @pytest.mark.parametrize("path", ["foo", "foo/bar/baz", "./foo"])
 async def test_hash_magic(
-    cls_a: EitherPathType, cls_b: EitherPathType, path: str
+    cls_a: EitherPathType,
+    cls_b: EitherPathType,
+    path: str,
 ) -> None:
     a, b = cls_a(path), cls_b(path)
     assert hash(a) == hash(b)
@@ -264,7 +267,7 @@ async def test_classmethods() -> None:
     ],
 )
 def test_wrapping_without_docstrings(
-    wrapper: Callable[[Callable[[], None]], Callable[[], None]]
+    wrapper: Callable[[Callable[[], None]], Callable[[], None]],
 ) -> None:
     @wrapper
     def func_without_docstring() -> None: ...  # pragma: no cover

--- a/src/trio/_tests/test_repl.py
+++ b/src/trio/_tests/test_repl.py
@@ -76,7 +76,7 @@ async def test_basic_interaction(
             # import works
             "import sys",
             "sys.stdout.write('hello stdout\\n')",
-        ]
+        ],
     )
     monkeypatch.setattr(console, "raw_input", raw_input)
     await trio._repl.run_repl(console)
@@ -89,7 +89,7 @@ async def test_system_exits_quit_interpreter(monkeypatch: pytest.MonkeyPatch) ->
     raw_input = build_raw_input(
         [
             "raise SystemExit",
-        ]
+        ],
     )
     monkeypatch.setattr(console, "raw_input", raw_input)
     with pytest.raises(SystemExit):
@@ -115,7 +115,7 @@ async def test_KI_interrupts(
             "",
             "await f()",
             "print('AFTER KeyboardInterrupt')",
-        ]
+        ],
     )
     monkeypatch.setattr(console, "raw_input", raw_input)
     await trio._repl.run_repl(console)
@@ -138,7 +138,7 @@ async def test_system_exits_in_exc_group(
             "",
             "raise BaseExceptionGroup('', [RuntimeError(), SystemExit()])",
             "print('AFTER BaseExceptionGroup')",
-        ]
+        ],
     )
     monkeypatch.setattr(console, "raw_input", raw_input)
     await trio._repl.run_repl(console)
@@ -162,7 +162,7 @@ async def test_system_exits_in_nested_exc_group(
             "raise BaseExceptionGroup(",
             "  '', [BaseExceptionGroup('', [RuntimeError(), SystemExit()])])",
             "print('AFTER BaseExceptionGroup')",
-        ]
+        ],
     )
     monkeypatch.setattr(console, "raw_input", raw_input)
     await trio._repl.run_repl(console)
@@ -182,7 +182,7 @@ async def test_base_exception_captured(
             # The statement after raise should still get executed
             "raise BaseException",
             "print('AFTER BaseException')",
-        ]
+        ],
     )
     monkeypatch.setattr(console, "raw_input", raw_input)
     await trio._repl.run_repl(console)
@@ -202,7 +202,7 @@ async def test_exc_group_captured(
             # The statement after raise should still get executed
             "raise ExceptionGroup('', [KeyError()])",
             "print('AFTER ExceptionGroup')",
-        ]
+        ],
     )
     monkeypatch.setattr(console, "raw_input", raw_input)
     await trio._repl.run_repl(console)
@@ -224,7 +224,7 @@ async def test_base_exception_capture_from_coroutine(
             # be executed
             "await async_func_raises_base_exception()",
             "print('AFTER BaseException')",
-        ]
+        ],
     )
     monkeypatch.setattr(console, "raw_input", raw_input)
     await trio._repl.run_repl(console)

--- a/src/trio/_tests/test_signals.py
+++ b/src/trio/_tests/test_signals.py
@@ -43,7 +43,8 @@ async def test_open_signal_receiver() -> None:
 async def test_open_signal_receiver_restore_handler_after_one_bad_signal() -> None:
     orig = signal.getsignal(signal.SIGILL)
     with pytest.raises(
-        ValueError, match="(signal number out of range|invalid signal value)$"
+        ValueError,
+        match="(signal number out of range|invalid signal value)$",
     ):
         with open_signal_receiver(signal.SIGILL, 1234567):
             pass  # pragma: no cover

--- a/src/trio/_tests/test_socket.py
+++ b/src/trio/_tests/test_socket.py
@@ -56,7 +56,10 @@ class MonkeypatchedGAI:
         return frozenbound
 
     def set(
-        self, response: GetAddrInfoResponse | str, *args: Any, **kwargs: Any
+        self,
+        response: GetAddrInfoResponse | str,
+        *args: Any,
+        **kwargs: Any,
     ) -> None:
         self._responses[self._frozenbind(*args, **kwargs)] = response
 
@@ -473,7 +476,8 @@ async def test_SocketType_shutdown() -> None:
     ],
 )
 async def test_SocketType_simple_server(
-    address: str, socket_type: AddressFamily
+    address: str,
+    socket_type: AddressFamily,
 ) -> None:
     # listen, bind, accept, connect, getpeername, getsockname
     listener = tsocket.socket(socket_type)
@@ -557,7 +561,8 @@ async def test_SocketType_resolve(socket_type: AddressFamily, addrs: Addresses) 
         return addr
 
     def assert_eq(
-        actual: tuple[str | int, ...], expected: tuple[str | int, ...]
+        actual: tuple[str | int, ...],
+        expected: tuple[str | int, ...],
     ) -> None:
         assert pad(expected) == pad(actual)
 
@@ -589,7 +594,7 @@ async def test_SocketType_resolve(socket_type: AddressFamily, addrs: Addresses) 
                     | tuple[str, str]
                     | tuple[str, str, int]
                     | tuple[str, str, int, int]
-                )
+                ),
             ) -> Any:
                 return await sock._resolve_address_nocp(
                     args,
@@ -640,7 +645,8 @@ async def test_SocketType_resolve(socket_type: AddressFamily, addrs: Addresses) 
             # smoke test the basic functionality...
             try:
                 netlink_sock = tsocket.socket(
-                    family=tsocket.AF_NETLINK, type=tsocket.SOCK_DGRAM
+                    family=tsocket.AF_NETLINK,
+                    type=tsocket.SOCK_DGRAM,
                 )
             except (AttributeError, OSError):
                 pass
@@ -794,7 +800,9 @@ async def test_SocketType_connect_paths() -> None:
 
                     cancel_scope.cancel()
                     sock._sock = stdlib_socket.fromfd(
-                        self.detach(), self.family, self.type
+                        self.detach(),
+                        self.family,
+                        self.type,
                     )
                     sock._sock.connect(*args, **kwargs)
                     # If connect *doesn't* raise, then pretend it did
@@ -843,7 +851,9 @@ async def test_resolve_address_exception_in_connect_closes_socket() -> None:
         with tsocket.socket() as sock:
 
             async def _resolve_address_nocp(
-                self: Any, *args: Any, **kwargs: Any
+                self: Any,
+                *args: Any,
+                **kwargs: Any,
             ) -> None:
                 cancel_scope.cancel()
                 await _core.checkpoint()
@@ -992,7 +1002,9 @@ async def test_custom_hostname_resolver(monkeygai: MonkeypatchedGAI) -> None:
             return ("custom_gai", host, port, family, type, proto, flags)
 
         async def getnameinfo(
-            self, sockaddr: tuple[str, int] | tuple[str, int, int, int], flags: int
+            self,
+            sockaddr: tuple[str, int] | tuple[str, int, int, int],
+            flags: int,
         ) -> tuple[str, tuple[str, int] | tuple[str, int, int, int], int]:
             return ("custom_gni", sockaddr, flags)
 

--- a/src/trio/_tests/test_subprocess.py
+++ b/src/trio/_tests/test_subprocess.py
@@ -131,7 +131,8 @@ async def test_basic(background_process: BackgroundProcessType) -> None:
         await proc.wait()
     assert proc.returncode == 1
     assert repr(proc) == "<trio.Process {!r}: {}>".format(
-        EXIT_FALSE, "exited with status 1"
+        EXIT_FALSE,
+        "exited with status 1",
     )
 
 
@@ -173,7 +174,7 @@ async def test_multi_wait(background_process: BackgroundProcessType) -> None:
 COPY_STDIN_TO_STDOUT_AND_BACKWARD_TO_STDERR = python(
     "data = sys.stdin.buffer.read(); "
     "sys.stdout.buffer.write(data); "
-    "sys.stderr.buffer.write(data[::-1])"
+    "sys.stderr.buffer.write(data[::-1])",
 )
 
 
@@ -234,7 +235,7 @@ async def test_interactive(background_process: BackgroundProcessType) -> None:
             "    request = int(line.strip())\n"
             "    print(str(idx * 2) * request)\n"
             "    print(str(idx * 2 + 1) * request * 2, file=sys.stderr)\n"
-            "    idx += 1\n"
+            "    idx += 1\n",
         ),
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
@@ -246,7 +247,9 @@ async def test_interactive(background_process: BackgroundProcessType) -> None:
             async with _core.open_nursery() as nursery:
 
                 async def drain_one(
-                    stream: ReceiveStream, count: int, digit: int
+                    stream: ReceiveStream,
+                    count: int,
+                    digit: int,
                 ) -> None:
                     while count > 0:
                         result = await stream.receive_some(count)
@@ -291,7 +294,10 @@ async def test_run() -> None:
     data = bytes(random.randint(0, 255) for _ in range(2**18))
 
     result = await run_process(
-        CAT, stdin=data, capture_stdout=True, capture_stderr=True
+        CAT,
+        stdin=data,
+        capture_stdout=True,
+        capture_stderr=True,
     )
     assert result.args == CAT
     assert result.returncode == 0
@@ -325,7 +331,8 @@ async def test_run() -> None:
     with pytest.raises(ValueError, match=pipe_stdout_error):
         await run_process(CAT, stdout=subprocess.PIPE)
     with pytest.raises(
-        ValueError, match=pipe_stdout_error.replace("stdout", "stderr", 1)
+        ValueError,
+        match=pipe_stdout_error.replace("stdout", "stderr", 1),
     ):
         await run_process(CAT, stderr=subprocess.PIPE)
     with pytest.raises(
@@ -350,7 +357,10 @@ async def test_run_check() -> None:
     assert excinfo.value.stdout is None
 
     result = await run_process(
-        cmd, capture_stdout=True, capture_stderr=True, check=False
+        cmd,
+        capture_stdout=True,
+        capture_stderr=True,
+        check=False,
     )
     assert result.args == cmd
     assert result.stdout == b""
@@ -361,7 +371,8 @@ async def test_run_check() -> None:
 @skip_if_fbsd_pipes_broken
 async def test_run_with_broken_pipe() -> None:
     result = await run_process(
-        [sys.executable, "-c", "import sys; sys.stdin.close()"], stdin=b"x" * 131072
+        [sys.executable, "-c", "import sys; sys.stdin.close()"],
+        stdin=b"x" * 131072,
     )
     assert result.returncode == 0
     assert result.stdout is result.stderr is None
@@ -404,7 +415,9 @@ async def test_stderr_stdout(background_process: BackgroundProcessType) -> None:
     # this one hits the branch where stderr=STDOUT but stdout
     # is not redirected
     async with background_process(
-        CAT, stdin=subprocess.PIPE, stderr=subprocess.STDOUT
+        CAT,
+        stdin=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
     ) as proc:
         assert proc.stdout is None
         assert proc.stderr is None
@@ -452,7 +465,8 @@ async def test_errors() -> None:
 @background_process_param
 async def test_signals(background_process: BackgroundProcessType) -> None:
     async def test_one_signal(
-        send_it: Callable[[Process], None], signum: signal.Signals | None
+        send_it: Callable[[Process], None],
+        signum: signal.Signals | None,
     ) -> None:
         with move_on_after(1.0) as scope:
             async with background_process(SLEEP(3600)) as proc:
@@ -557,7 +571,7 @@ async def test_custom_deliver_cancel() -> None:
 
     async with _core.open_nursery() as nursery:
         nursery.start_soon(
-            partial(run_process, SLEEP(9999), deliver_cancel=custom_deliver_cancel)
+            partial(run_process, SLEEP(9999), deliver_cancel=custom_deliver_cancel),
         )
         await wait_all_tasks_blocked()
         nursery.cancel_scope.cancel()
@@ -573,7 +587,7 @@ def test_bad_deliver_cancel() -> None:
     async def do_stuff() -> None:
         async with _core.open_nursery() as nursery:
             nursery.start_soon(
-                partial(run_process, SLEEP(9999), deliver_cancel=custom_deliver_cancel)
+                partial(run_process, SLEEP(9999), deliver_cancel=custom_deliver_cancel),
             )
             await wait_all_tasks_blocked()
             nursery.cancel_scope.cancel()
@@ -601,7 +615,8 @@ async def test_warn_on_failed_cancel_terminate(monkeypatch: pytest.MonkeyPatch) 
 
 @pytest.mark.skipif(not posix, reason="posix only")
 async def test_warn_on_cancel_SIGKILL_escalation(
-    autojump_clock: MockClock, monkeypatch: pytest.MonkeyPatch
+    autojump_clock: MockClock,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(Process, "terminate", lambda *args: None)
 

--- a/src/trio/_tests/test_sync.py
+++ b/src/trio/_tests/test_sync.py
@@ -494,7 +494,9 @@ lock_factory_names = [
 ]
 
 generic_lock_test = pytest.mark.parametrize(
-    "lock_factory", lock_factories, ids=lock_factory_names
+    "lock_factory",
+    lock_factories,
+    ids=lock_factory_names,
 )
 
 LockLike: TypeAlias = Union[

--- a/src/trio/_tests/test_testing.py
+++ b/src/trio/_tests/test_testing.py
@@ -393,7 +393,9 @@ async def test_MemorySendStream() -> None:
         record.append("close_hook")
 
     mss2 = MemorySendStream(
-        send_all_hook, wait_send_all_might_not_block_hook, close_hook
+        send_all_hook,
+        wait_send_all_might_not_block_hook,
+        close_hook,
     )
 
     assert mss2.send_all_hook is send_all_hook
@@ -670,10 +672,13 @@ async def test_open_stream_to_socket_listener() -> None:
 
 def test_trio_test() -> None:
     async def busy_kitchen(
-        *, mock_clock: object, autojump_clock: object
+        *,
+        mock_clock: object,
+        autojump_clock: object,
     ) -> None: ...  # pragma: no cover
 
     with pytest.raises(ValueError, match="^too many clocks spoil the broth!$"):
         trio_test(busy_kitchen)(
-            mock_clock=MockClock(), autojump_clock=MockClock(autojump_threshold=0)
+            mock_clock=MockClock(),
+            autojump_clock=MockClock(autojump_threshold=0),
         )

--- a/src/trio/_tests/test_testing_raisesgroup.py
+++ b/src/trio/_tests/test_testing_raisesgroup.py
@@ -22,7 +22,7 @@ def test_raises_group() -> None:
     with pytest.raises(
         ValueError,
         match=wrap_escape(
-            f'Invalid argument "{TypeError()!r}" must be exception type, Matcher, or RaisesGroup.'
+            f'Invalid argument "{TypeError()!r}" must be exception type, Matcher, or RaisesGroup.',
         ),
     ):
         RaisesGroup(TypeError())
@@ -94,7 +94,8 @@ def test_flatten_subgroups() -> None:
         raise ExceptionGroup("", (ExceptionGroup("", (ValueError(),)),))
     with RaisesGroup(RaisesGroup(ValueError, flatten_subgroups=True)):
         raise ExceptionGroup(
-            "", (ExceptionGroup("", (ExceptionGroup("", (ValueError(),)),)),)
+            "",
+            (ExceptionGroup("", (ExceptionGroup("", (ValueError(),)),)),),
         )
     with pytest.raises(ExceptionGroup):
         with RaisesGroup(RaisesGroup(ValueError, flatten_subgroups=True)):
@@ -116,7 +117,8 @@ def test_catch_unwrapped_exceptions() -> None:
 
     # expecting multiple unwrapped exceptions is not possible
     with pytest.raises(
-        ValueError, match="^You cannot specify multiple exceptions with"
+        ValueError,
+        match="^You cannot specify multiple exceptions with",
     ):
         RaisesGroup(SyntaxError, ValueError, allow_unwrapped=True)  # type: ignore[call-overload]
     # if users want one of several exception types they need to use a Matcher
@@ -245,7 +247,8 @@ def test_message() -> None:
     check_message("ExceptionGroup(ValueError)", RaisesGroup(ValueError))
     # multiple exceptions
     check_message(
-        "ExceptionGroup(ValueError, ValueError)", RaisesGroup(ValueError, ValueError)
+        "ExceptionGroup(ValueError, ValueError)",
+        RaisesGroup(ValueError, ValueError),
     )
     # nested
     check_message(
@@ -265,7 +268,8 @@ def test_message() -> None:
 
     # BaseExceptionGroup
     check_message(
-        "BaseExceptionGroup(KeyboardInterrupt)", RaisesGroup(KeyboardInterrupt)
+        "BaseExceptionGroup(KeyboardInterrupt)",
+        RaisesGroup(KeyboardInterrupt),
     )
     # BaseExceptionGroup with type inside Matcher
     check_message(
@@ -286,7 +290,8 @@ def test_message() -> None:
 
 def test_matcher() -> None:
     with pytest.raises(
-        ValueError, match="^You must specify at least one parameter to match on.$"
+        ValueError,
+        match="^You must specify at least one parameter to match on.$",
     ):
         Matcher()  # type: ignore[call-overload]
     with pytest.raises(

--- a/src/trio/_tests/test_threads.py
+++ b/src/trio/_tests/test_threads.py
@@ -336,7 +336,8 @@ async def test_run_in_worker_thread() -> None:
         raise ValueError(threading.current_thread())
 
     with pytest.raises(
-        ValueError, match=r"^<Thread\(Trio thread \d+, started daemon \d+\)>$"
+        ValueError,
+        match=r"^<Thread\(Trio thread \d+, started daemon \d+\)>$",
     ) as excinfo:
         await to_thread_run_sync(g)
     print(excinfo.value.args)
@@ -404,7 +405,8 @@ async def test_run_in_worker_thread_cancellation() -> None:
 # handled gracefully. (Requires that the thread result machinery be prepared
 # for call_soon to raise RunFinishedError.)
 def test_run_in_worker_thread_abandoned(
-    capfd: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    capfd: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(_core._thread_cache, "IDLE_TIMEOUT", 0.01)
 
@@ -444,7 +446,9 @@ def test_run_in_worker_thread_abandoned(
 @pytest.mark.parametrize("cancel", [False, True])
 @pytest.mark.parametrize("use_default_limiter", [False, True])
 async def test_run_in_worker_thread_limiter(
-    MAX: int, cancel: bool, use_default_limiter: bool
+    MAX: int,
+    cancel: bool,
+    use_default_limiter: bool,
 ) -> None:
     # This test is a bit tricky. The goal is to make sure that if we set
     # limiter=CapacityLimiter(MAX), then in fact only MAX threads are ever
@@ -647,7 +651,7 @@ async def test_trio_to_thread_run_sync_expected_error() -> None:
 
 
 trio_test_contextvar: contextvars.ContextVar[str] = contextvars.ContextVar(
-    "trio_test_contextvar"
+    "trio_test_contextvar",
 )
 
 
@@ -879,7 +883,7 @@ def test_from_thread_run_during_shutdown() -> None:
             with _core.CancelScope(shield=True):
                 try:
                     await to_thread_run_sync(
-                        partial(from_thread_run, sleep, 0, trio_token=token)
+                        partial(from_thread_run, sleep, 0, trio_token=token),
                     )
                 except _core.RunFinishedError:
                     record.append("finished")

--- a/src/trio/_tests/test_timeouts.py
+++ b/src/trio/_tests/test_timeouts.py
@@ -108,7 +108,8 @@ async def test_move_on_after_moves_on_even_if_shielded() -> None:
 async def test_fail_after_fails_even_if_shielded() -> None:
     async def task() -> None:
         with pytest.raises(TooSlowError), _core.CancelScope() as outer, fail_after(
-            TARGET, shield=True
+            TARGET,
+            shield=True,
         ):
             outer.cancel()
             # The outer scope is cancelled, but this task is protected by the

--- a/src/trio/_tests/test_wait_for_object.py
+++ b/src/trio/_tests/test_wait_for_object.py
@@ -81,7 +81,9 @@ async def test_WaitForMultipleObjects_sync_slow() -> None:
     t0 = _core.current_time()
     async with _core.open_nursery() as nursery:
         nursery.start_soon(
-            trio.to_thread.run_sync, WaitForMultipleObjects_sync, handle1
+            trio.to_thread.run_sync,
+            WaitForMultipleObjects_sync,
+            handle1,
         )
         await _timeouts.sleep(TIMEOUT)
         # If we would comment the line below, the above thread will be stuck,
@@ -98,7 +100,10 @@ async def test_WaitForMultipleObjects_sync_slow() -> None:
     t0 = _core.current_time()
     async with _core.open_nursery() as nursery:
         nursery.start_soon(
-            trio.to_thread.run_sync, WaitForMultipleObjects_sync, handle1, handle2
+            trio.to_thread.run_sync,
+            WaitForMultipleObjects_sync,
+            handle1,
+            handle2,
         )
         await _timeouts.sleep(TIMEOUT)
         kernel32.SetEvent(handle1)
@@ -114,7 +119,10 @@ async def test_WaitForMultipleObjects_sync_slow() -> None:
     t0 = _core.current_time()
     async with _core.open_nursery() as nursery:
         nursery.start_soon(
-            trio.to_thread.run_sync, WaitForMultipleObjects_sync, handle1, handle2
+            trio.to_thread.run_sync,
+            WaitForMultipleObjects_sync,
+            handle1,
+            handle2,
         )
         await _timeouts.sleep(TIMEOUT)
         kernel32.SetEvent(handle2)

--- a/src/trio/_tests/tools/test_gen_exports.py
+++ b/src/trio/_tests/tools/test_gen_exports.py
@@ -92,7 +92,9 @@ skip_lints = pytest.mark.skipif(
 @skip_lints
 @pytest.mark.parametrize("imports", [IMPORT_1, IMPORT_2, IMPORT_3])
 def test_process(
-    tmp_path: Path, imports: str, capsys: pytest.CaptureFixture[str]
+    tmp_path: Path,
+    imports: str,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     try:
         import black  # noqa: F401

--- a/src/trio/_tests/tools/test_mypy_annotate.py
+++ b/src/trio/_tests/tools/test_mypy_annotate.py
@@ -119,7 +119,7 @@ Found 3 errors in 29 files
         monkeypatch.setattr(sys, "stdin", io.StringIO(inp_text))
 
         mypy_annotate.main(
-            ["--dumpfile", str(result_file), "--platform", "SomePlatform"]
+            ["--dumpfile", str(result_file), "--platform", "SomePlatform"],
         )
 
     std = capsys.readouterr()

--- a/src/trio/_tests/type_tests/path.py
+++ b/src/trio/_tests/type_tests/path.py
@@ -113,7 +113,8 @@ async def async_attrs(path: trio.Path) -> None:
     assert_type(await path.unlink(missing_ok=True), None)
     assert_type(await path.write_bytes(b"123"), int)
     assert_type(
-        await path.write_text("hello", encoding="utf32le", errors="ignore"), int
+        await path.write_text("hello", encoding="utf32le", errors="ignore"),
+        int,
     )
 
 

--- a/src/trio/_tests/type_tests/raisesgroup.py
+++ b/src/trio/_tests/type_tests/raisesgroup.py
@@ -64,7 +64,8 @@ def check_matches_with_different_exception_type() -> None:
     # This should probably raise some type error somewhere, since
     # ValueError != KeyboardInterrupt
     e: BaseExceptionGroup[KeyboardInterrupt] = BaseExceptionGroup(
-        "", (KeyboardInterrupt(),)
+        "",
+        (KeyboardInterrupt(),),
     )
     if RaisesGroup(ValueError).matches(e):
         assert_type(e, BaseExceptionGroup[ValueError])
@@ -192,7 +193,8 @@ def check_nested_raisesgroups_contextmanager() -> None:
 def check_nested_raisesgroups_matches() -> None:
     """Check nested RaisesGroups with .matches"""
     exc: ExceptionGroup[ExceptionGroup[ValueError]] = ExceptionGroup(
-        "", (ExceptionGroup("", (ValueError(),)),)
+        "",
+        (ExceptionGroup("", (ValueError(),)),),
     )
     # has the same problems as check_nested_raisesgroups_contextmanager
     if RaisesGroup(RaisesGroup(ValueError)).matches(exc):

--- a/src/trio/_threads.py
+++ b/src/trio/_threads.py
@@ -150,10 +150,12 @@ class Run(Generic[RetT]):
     afn: Callable[..., Awaitable[RetT]]
     args: tuple[object, ...]
     context: contextvars.Context = attrs.field(
-        init=False, factory=contextvars.copy_context
+        init=False,
+        factory=contextvars.copy_context,
     )
     queue: stdlib_queue.SimpleQueue[outcome.Outcome[RetT]] = attrs.field(
-        init=False, factory=stdlib_queue.SimpleQueue
+        init=False,
+        factory=stdlib_queue.SimpleQueue,
     )
 
     @disable_ki_protection
@@ -190,11 +192,13 @@ class Run(Generic[RetT]):
         def in_trio_thread() -> None:
             try:
                 trio.lowlevel.spawn_system_task(
-                    self.run_system, name=self.afn, context=self.context
+                    self.run_system,
+                    name=self.afn,
+                    context=self.context,
                 )
             except RuntimeError:  # system nursery is closed
                 self.queue.put_nowait(
-                    outcome.Error(trio.RunFinishedError("system nursery is closed"))
+                    outcome.Error(trio.RunFinishedError("system nursery is closed")),
                 )
 
         token.run_sync_soon(in_trio_thread)
@@ -205,10 +209,12 @@ class RunSync(Generic[RetT]):
     fn: Callable[..., RetT]
     args: tuple[object, ...]
     context: contextvars.Context = attrs.field(
-        init=False, factory=contextvars.copy_context
+        init=False,
+        factory=contextvars.copy_context,
     )
     queue: stdlib_queue.SimpleQueue[outcome.Outcome[RetT]] = attrs.field(
-        init=False, factory=stdlib_queue.SimpleQueue
+        init=False,
+        factory=stdlib_queue.SimpleQueue,
     )
 
     @disable_ki_protection
@@ -220,7 +226,7 @@ class RunSync(Generic[RetT]):
             ret.close()
             raise TypeError(
                 "Trio expected a synchronous function, but {!r} appears to be "
-                "asynchronous".format(getattr(self.fn, "__qualname__", self.fn))
+                "asynchronous".format(getattr(self.fn, "__qualname__", self.fn)),
             )
 
         return ret
@@ -386,7 +392,7 @@ async def to_thread_run_sync(  # type: ignore[misc]
                 ret.close()
                 raise TypeError(
                     "Trio expected a sync function, but {!r} appears to be "
-                    "asynchronous".format(getattr(sync_fn, "__qualname__", sync_fn))
+                    "asynchronous".format(getattr(sync_fn, "__qualname__", sync_fn)),
                 )
 
             return ret
@@ -441,7 +447,7 @@ async def to_thread_run_sync(  # type: ignore[misc]
                 msg_from_thread.run_sync()
             else:  # pragma: no cover, internal debugging guard TODO: use assert_never
                 raise TypeError(
-                    f"trio.to_thread.run_sync received unrecognized thread message {msg_from_thread!r}."
+                    f"trio.to_thread.run_sync received unrecognized thread message {msg_from_thread!r}.",
                 )
             del msg_from_thread
 
@@ -477,14 +483,15 @@ def from_thread_check_cancelled() -> None:
         raise_cancel = PARENT_TASK_DATA.cancel_register[0]
     except AttributeError:
         raise RuntimeError(
-            "this thread wasn't created by Trio, can't check for cancellation"
+            "this thread wasn't created by Trio, can't check for cancellation",
         ) from None
     if raise_cancel is not None:
         raise_cancel()
 
 
 def _send_message_to_trio(
-    trio_token: TrioToken | None, message_to_trio: Run[RetT] | RunSync[RetT]
+    trio_token: TrioToken | None,
+    message_to_trio: Run[RetT] | RunSync[RetT],
 ) -> RetT:
     """Shared logic of from_thread functions"""
     token_provided = trio_token is not None
@@ -494,7 +501,7 @@ def _send_message_to_trio(
             trio_token = PARENT_TASK_DATA.token
         except AttributeError:
             raise RuntimeError(
-                "this thread wasn't created by Trio, pass kwarg trio_token=..."
+                "this thread wasn't created by Trio, pass kwarg trio_token=...",
             ) from None
     elif not isinstance(trio_token, TrioToken):
         raise RuntimeError("Passed kwarg trio_token is not of type TrioToken")

--- a/src/trio/_timeouts.py
+++ b/src/trio/_timeouts.py
@@ -134,7 +134,9 @@ if not TYPE_CHECKING:
 
 
 def fail_after(
-    seconds: float, *, shield: bool = False
+    seconds: float,
+    *,
+    shield: bool = False,
 ) -> AbstractContextManager[trio.CancelScope]:
     """Creates a cancel scope with the given timeout, and raises an error if
     it is actually cancelled.

--- a/src/trio/_tools/gen_exports.py
+++ b/src/trio/_tools/gen_exports.py
@@ -191,6 +191,11 @@ def run_linters(file: File, source: str) -> str:
         print(response)
         sys.exit(1)
 
+    success, response = run_black(file, response)
+    if not success:
+        print(response)
+        sys.exit(1)
+
     return response
 
 

--- a/src/trio/_tools/gen_exports.py
+++ b/src/trio/_tools/gen_exports.py
@@ -211,7 +211,7 @@ def gen_public_wrappers_source(file: File) -> str:
         if "import sys" not in file.imports:  # pragma: no cover
             header.append("import sys\n")
         header.append(
-            f'\nassert not TYPE_CHECKING or sys.platform=="{file.platform}"\n'
+            f'\nassert not TYPE_CHECKING or sys.platform=="{file.platform}"\n',
         )
 
     generated = ["".join(header)]
@@ -310,10 +310,13 @@ def process(files: Iterable[File], *, do_test: bool) -> None:
 # doesn't collect coverage.
 def main() -> None:  # pragma: no cover
     parser = argparse.ArgumentParser(
-        description="Generate python code for public api wrappers"
+        description="Generate python code for public api wrappers",
     )
     parser.add_argument(
-        "--test", "-t", action="store_true", help="test if code is still up to date"
+        "--test",
+        "-t",
+        action="store_true",
+        help="test if code is still up to date",
     )
     parsed_args = parser.parse_args()
 

--- a/src/trio/_tools/mypy_annotate.py
+++ b/src/trio/_tools/mypy_annotate.py
@@ -86,7 +86,9 @@ def main(argv: list[str]) -> None:
     """Look for error messages, and convert the format."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "--dumpfile", help="File to write pickled messages to.", required=True
+        "--dumpfile",
+        help="File to write pickled messages to.",
+        required=True,
     )
     parser.add_argument(
         "--platform",

--- a/src/trio/_unix_pipes.py
+++ b/src/trio/_unix_pipes.py
@@ -121,10 +121,10 @@ class FdStream(Stream):
     def __init__(self, fd: int) -> None:
         self._fd_holder = _FdHolder(fd)
         self._send_conflict_detector = ConflictDetector(
-            "another task is using this stream for send"
+            "another task is using this stream for send",
         )
         self._receive_conflict_detector = ConflictDetector(
-            "another task is using this stream for receive"
+            "another task is using this stream for receive",
         )
 
     async def send_all(self, data: bytes) -> None:
@@ -147,7 +147,7 @@ class FdStream(Stream):
                         except OSError as e:
                             if e.errno == errno.EBADF:
                                 raise trio.ClosedResourceError(
-                                    "file was already closed"
+                                    "file was already closed",
                                 ) from None
                             else:
                                 raise trio.BrokenResourceError from e
@@ -182,7 +182,7 @@ class FdStream(Stream):
                 except OSError as exc:
                     if exc.errno == errno.EBADF:
                         raise trio.ClosedResourceError(
-                            "file was already closed"
+                            "file was already closed",
                         ) from None
                     else:
                         raise trio.BrokenResourceError from exc

--- a/src/trio/_util.py
+++ b/src/trio/_util.py
@@ -154,7 +154,7 @@ def coroutine_or_error(
                 "Instead, you want (notice the parentheses!):\n"
                 "\n"
                 f"  trio.run({async_fn.__name__}, ...)            # correct!\n"
-                f"  nursery.start_soon({async_fn.__name__}, ...)  # correct!"
+                f"  nursery.start_soon({async_fn.__name__}, ...)  # correct!",
             ) from None
 
         # Give good error for: nursery.start_soon(future)
@@ -163,7 +163,7 @@ def coroutine_or_error(
                 "Trio was expecting an async function, but instead it got "
                 f"{async_fn!r} – are you trying to use a library written for "
                 "asyncio/twisted/tornado or similar? That won't work "
-                "without some sort of compatibility shim."
+                "without some sort of compatibility shim.",
             ) from None
 
         raise
@@ -183,19 +183,19 @@ def coroutine_or_error(
             raise TypeError(
                 f"Trio got unexpected {coro!r} – are you trying to use a "
                 "library written for asyncio/twisted/tornado or similar? "
-                "That won't work without some sort of compatibility shim."
+                "That won't work without some sort of compatibility shim.",
             )
 
         if inspect.isasyncgen(coro):
             raise TypeError(
                 "start_soon expected an async function but got an async "
-                f"generator {coro!r}"
+                f"generator {coro!r}",
             )
 
         # Give good error for: nursery.start_soon(some_sync_fn)
         raise TypeError(
             "Trio expected an async function, but {!r} appears to be "
-            "synchronous".format(getattr(async_fn, "__qualname__", async_fn))
+            "synchronous".format(getattr(async_fn, "__qualname__", async_fn)),
         )
 
     return coro
@@ -253,7 +253,8 @@ def async_wraps(
 
 
 def fixup_module_metadata(
-    module_name: str, namespace: collections.abc.Mapping[str, object]
+    module_name: str,
+    namespace: collections.abc.Mapping[str, object],
 ) -> None:
     seen_ids: set[int] = set()
 
@@ -370,7 +371,7 @@ class NoPublicConstructor(ABCMeta):
 
     def __call__(cls, *args: object, **kwargs: object) -> None:
         raise TypeError(
-            f"{cls.__module__}.{cls.__qualname__} has no public constructor"
+            f"{cls.__module__}.{cls.__qualname__} has no public constructor",
         )
 
     def _create(cls: type[T], *args: object, **kwargs: object) -> T:

--- a/src/trio/_windows_pipes.py
+++ b/src/trio/_windows_pipes.py
@@ -49,7 +49,7 @@ class PipeSendStream(SendStream):
     def __init__(self, handle: int) -> None:
         self._handle_holder = _HandleHolder(handle)
         self._conflict_detector = ConflictDetector(
-            "another task is currently using this pipe"
+            "another task is currently using this pipe",
         )
 
     async def send_all(self, data: bytes) -> None:
@@ -93,7 +93,7 @@ class PipeReceiveStream(ReceiveStream):
     def __init__(self, handle: int) -> None:
         self._handle_holder = _HandleHolder(handle)
         self._conflict_detector = ConflictDetector(
-            "another task is currently using this pipe"
+            "another task is currently using this pipe",
         )
 
     async def receive_some(self, max_bytes: int | None = None) -> bytes:
@@ -112,12 +112,13 @@ class PipeReceiveStream(ReceiveStream):
             buffer = bytearray(max_bytes)
             try:
                 size = await _core.readinto_overlapped(
-                    self._handle_holder.handle, buffer
+                    self._handle_holder.handle,
+                    buffer,
                 )
             except BrokenPipeError:
                 if self._handle_holder.closed:
                     raise _core.ClosedResourceError(
-                        "another task closed this pipe"
+                        "another task closed this pipe",
                     ) from None
 
                 # Windows raises BrokenPipeError on one end of a pipe

--- a/src/trio/socket.py
+++ b/src/trio/socket.py
@@ -29,7 +29,7 @@ globals().update(
         _name: getattr(_stdlib_socket, _name)
         for _name in _stdlib_socket.__all__  # type: ignore
         if _name.isupper() and _name not in _bad_symbols
-    }
+    },
 )
 
 # import the overwrites

--- a/src/trio/testing/_check_streams.py
+++ b/src/trio/testing/_check_streams.py
@@ -57,7 +57,8 @@ class _ForceCloseBoth(Generic[Res1, Res2]):
 # on pytest, as the check_* functions are publicly exported.
 @contextmanager
 def _assert_raises(
-    expected_exc: type[BaseException], wrapped: bool = False
+    expected_exc: type[BaseException],
+    wrapped: bool = False,
 ) -> Generator[None, None, None]:
     __tracebackhide__ = True
     try:
@@ -174,7 +175,8 @@ async def check_one_way_stream(
 
         async with _core.open_nursery() as nursery:
             nursery.start_soon(
-                simple_check_wait_send_all_might_not_block, nursery.cancel_scope
+                simple_check_wait_send_all_might_not_block,
+                nursery.cancel_scope,
             )
             nursery.start_soon(do_receive_some, 1)
 
@@ -467,7 +469,9 @@ async def check_two_way_stream(
         test_data = i.to_bytes(DUPLEX_TEST_SIZE, "little")
 
         async def sender(
-            s: Stream, data: bytes | bytearray | memoryview, seed: int
+            s: Stream,
+            data: bytes | bytearray | memoryview,
+            seed: int,
         ) -> None:
             r = random.Random(seed)
             m = memoryview(data)

--- a/src/trio/testing/_fake_net.py
+++ b/src/trio/testing/_fake_net.py
@@ -99,7 +99,8 @@ class UDPEndpoint:
 
     @classmethod
     def from_python_sockaddr(
-        cls: type[T_UDPEndpoint], sockaddr: tuple[str, int] | tuple[str, int, int, int]
+        cls: type[T_UDPEndpoint],
+        sockaddr: tuple[str, int] | tuple[str, int, int, int],
     ) -> T_UDPEndpoint:
         ip, port = sockaddr[:2]
         return cls(ip=ipaddress.ip_address(ip), port=port)
@@ -120,7 +121,9 @@ class UDPPacket:
     # not used/tested anywhere
     def reply(self, payload: bytes) -> UDPPacket:  # pragma: no cover
         return UDPPacket(
-            source=self.destination, destination=self.source, payload=payload
+            source=self.destination,
+            destination=self.source,
+            payload=payload,
         )
 
 
@@ -156,7 +159,9 @@ class FakeHostnameResolver(trio.abc.HostnameResolver):
         raise NotImplementedError("FakeNet doesn't do fake DNS yet")
 
     async def getnameinfo(
-        self, sockaddr: tuple[str, int] | tuple[str, int, int, int], flags: int
+        self,
+        sockaddr: tuple[str, int] | tuple[str, int, int, int],
+        flags: int,
     ) -> tuple[str, str]:
         raise NotImplementedError("FakeNet doesn't do fake DNS yet")
 
@@ -256,7 +261,10 @@ class FakeSocket(trio.socket.SocketType, metaclass=NoPublicConstructor):
         self._packet_receiver.close()
 
     async def _resolve_address_nocp(
-        self, address: object, *, local: bool
+        self,
+        address: object,
+        *,
+        local: bool,
     ) -> tuple[str, int]:
         return await trio._socket._resolve_address_nocp(  # type: ignore[no-any-return]
             self.type,
@@ -360,7 +368,7 @@ class FakeSocket(trio.socket.SocketType, metaclass=NoPublicConstructor):
             raise NotImplementedError(
                 "The code will most likely hang if you try to receive on a fakesocket "
                 "without a binding. If that is not the case, or you explicitly want to "
-                "test that, remove this warning."
+                "test that, remove this warning.",
             )
 
         self._check_closed()
@@ -399,11 +407,13 @@ class FakeSocket(trio.socket.SocketType, metaclass=NoPublicConstructor):
         self._check_closed()
         if self._binding is not None:
             assert hasattr(
-                self._binding, "remote"
+                self._binding,
+                "remote",
             ), "This method seems to assume that self._binding has a remote UDPEndpoint"
             if self._binding.remote is not None:  # pragma: no cover
                 assert isinstance(
-                    self._binding.remote, UDPEndpoint
+                    self._binding.remote,
+                    UDPEndpoint,
                 ), "Self._binding.remote should be a UDPEndpoint"
                 return self._binding.remote.as_python_sockaddr()
         _fake_err(errno.ENOTCONN)
@@ -415,7 +425,11 @@ class FakeSocket(trio.socket.SocketType, metaclass=NoPublicConstructor):
     def getsockopt(self, /, level: int, optname: int, buflen: int) -> bytes: ...
 
     def getsockopt(
-        self, /, level: int, optname: int, buflen: int | None = None
+        self,
+        /,
+        level: int,
+        optname: int,
+        buflen: int | None = None,
     ) -> int | bytes:
         self._check_closed()
         raise OSError(f"FakeNet doesn't implement getsockopt({level}, {optname})")
@@ -425,7 +439,12 @@ class FakeSocket(trio.socket.SocketType, metaclass=NoPublicConstructor):
 
     @overload
     def setsockopt(
-        self, /, level: int, optname: int, value: None, optlen: int
+        self,
+        /,
+        level: int,
+        optname: int,
+        value: None,
+        optlen: int,
     ) -> None: ...
 
     def setsockopt(
@@ -466,7 +485,9 @@ class FakeSocket(trio.socket.SocketType, metaclass=NoPublicConstructor):
 
     @overload
     async def sendto(
-        self, __data: Buffer, __address: tuple[object, ...] | str | Buffer
+        self,
+        __data: Buffer,
+        __address: tuple[object, ...] | str | Buffer,
     ) -> int: ...
 
     @overload
@@ -503,21 +524,31 @@ class FakeSocket(trio.socket.SocketType, metaclass=NoPublicConstructor):
         return data, address
 
     async def recvfrom_into(
-        self, buf: Buffer, nbytes: int = 0, flags: int = 0
+        self,
+        buf: Buffer,
+        nbytes: int = 0,
+        flags: int = 0,
     ) -> tuple[int, Any]:
         if nbytes != 0 and nbytes != memoryview(buf).nbytes:
             raise NotImplementedError("partial recvfrom_into")
         got_nbytes, ancdata, msg_flags, address = await self._recvmsg_into(
-            [buf], 0, flags
+            [buf],
+            0,
+            flags,
         )
         return got_nbytes, address
 
     async def _recvmsg(
-        self, bufsize: int, ancbufsize: int = 0, flags: int = 0
+        self,
+        bufsize: int,
+        ancbufsize: int = 0,
+        flags: int = 0,
     ) -> tuple[bytes, list[tuple[int, int, bytes]], int, Any]:
         buf = bytearray(bufsize)
         got_nbytes, ancdata, msg_flags, address = await self._recvmsg_into(
-            [buf], ancbufsize, flags
+            [buf],
+            ancbufsize,
+            flags,
         )
         return (bytes(buf[:got_nbytes]), ancdata, msg_flags, address)
 

--- a/src/trio/testing/_memory_streams.py
+++ b/src/trio/testing/_memory_streams.py
@@ -29,7 +29,7 @@ class _UnboundedByteQueue:
         self._closed = False
         self._lot = _core.ParkingLot()
         self._fetch_lock = _util.ConflictDetector(
-            "another task is already fetching data"
+            "another task is already fetching data",
         )
 
     # This object treats "close" as being like closing the send side of a
@@ -115,7 +115,7 @@ class MemorySendStream(SendStream):
         close_hook: SyncHook | None = None,
     ):
         self._conflict_detector = _util.ConflictDetector(
-            "another task is using this stream"
+            "another task is using this stream",
         )
         self._outgoing = _UnboundedByteQueue()
         self.send_all_hook = send_all_hook
@@ -225,7 +225,7 @@ class MemoryReceiveStream(ReceiveStream):
         close_hook: SyncHook | None = None,
     ):
         self._conflict_detector = _util.ConflictDetector(
-            "another task is using this stream"
+            "another task is using this stream",
         )
         self._incoming = _UnboundedByteQueue()
         self._closed = False
@@ -356,7 +356,7 @@ def memory_stream_one_way_pair() -> tuple[MemorySendStream, MemoryReceiveStream]
 
 
 def _make_stapled_pair(
-    one_way_pair: Callable[[], tuple[SendStreamT, ReceiveStreamT]]
+    one_way_pair: Callable[[], tuple[SendStreamT, ReceiveStreamT]],
 ) -> tuple[
     StapledStream[SendStreamT, ReceiveStreamT],
     StapledStream[SendStreamT, ReceiveStreamT],
@@ -461,10 +461,10 @@ class _LockstepByteQueue:
         self._receiver_waiting = False
         self._waiters = _core.ParkingLot()
         self._send_conflict_detector = _util.ConflictDetector(
-            "another task is already sending"
+            "another task is already sending",
         )
         self._receive_conflict_detector = _util.ConflictDetector(
-            "another task is already receiving"
+            "another task is already receiving",
         )
 
     def _something_happened(self) -> None:

--- a/src/trio/testing/_raises_group.py
+++ b/src/trio/testing/_raises_group.py
@@ -28,7 +28,10 @@ if TYPE_CHECKING:
     from typing_extensions import TypeGuard, TypeVar
 
     MatchE = TypeVar(
-        "MatchE", bound=BaseException, default=BaseException, covariant=True
+        "MatchE",
+        bound=BaseException,
+        default=BaseException,
+        covariant=True,
     )
 else:
     from typing import TypeVar
@@ -49,12 +52,14 @@ class _ExceptionInfo(Generic[MatchE]):
     _excinfo: tuple[type[MatchE], MatchE, types.TracebackType] | None
 
     def __init__(
-        self, excinfo: tuple[type[MatchE], MatchE, types.TracebackType] | None
+        self,
+        excinfo: tuple[type[MatchE], MatchE, types.TracebackType] | None,
     ):
         self._excinfo = excinfo
 
     def fill_unfilled(
-        self, exc_info: tuple[type[MatchE], MatchE, types.TracebackType]
+        self,
+        exc_info: tuple[type[MatchE], MatchE, types.TracebackType],
     ) -> None:
         """Fill an unfilled ExceptionInfo created with ``for_later()``."""
         assert self._excinfo is None, "ExceptionInfo was already filled"
@@ -92,7 +97,7 @@ class _ExceptionInfo(Generic[MatchE]):
 
     def exconly(self, tryshort: bool = False) -> str:
         raise NotImplementedError(
-            "This is a helper method only available if you use RaisesGroup with the pytest package installed"
+            "This is a helper method only available if you use RaisesGroup with the pytest package installed",
         )
 
     def errisinstance(
@@ -100,7 +105,7 @@ class _ExceptionInfo(Generic[MatchE]):
         exc: builtins.type[BaseException] | tuple[builtins.type[BaseException], ...],
     ) -> bool:
         raise NotImplementedError(
-            "This is a helper method only available if you use RaisesGroup with the pytest package installed"
+            "This is a helper method only available if you use RaisesGroup with the pytest package installed",
         )
 
     def getrepr(
@@ -114,7 +119,7 @@ class _ExceptionInfo(Generic[MatchE]):
         chain: bool = True,
     ) -> ReprExceptionInfo | ExceptionChainRepr:
         raise NotImplementedError(
-            "This is a helper method only available if you use RaisesGroup with the pytest package installed"
+            "This is a helper method only available if you use RaisesGroup with the pytest package installed",
         )
 
 
@@ -139,7 +144,7 @@ def _stringify_exception(exc: BaseException) -> str:
         [
             getattr(exc, "message", str(exc)),
             *getattr(exc, "__notes__", []),
-        ]
+        ],
     )
 
 
@@ -195,7 +200,7 @@ class Matcher(Generic[MatchE]):
             raise ValueError("You must specify at least one parameter to match on.")
         if exception_type is not None and not issubclass(exception_type, BaseException):
             raise ValueError(
-                f"exception_type {exception_type} must be a subclass of BaseException"
+                f"exception_type {exception_type} must be a subclass of BaseException",
             )
         self.exception_type = exception_type
         self.match: Pattern[str] | None
@@ -224,11 +229,13 @@ class Matcher(Generic[MatchE]):
 
         """
         if self.exception_type is not None and not isinstance(
-            exception, self.exception_type
+            exception,
+            self.exception_type,
         ):
             return False
         if self.match is not None and not re.search(
-            self.match, _stringify_exception(exception)
+            self.match,
+            _stringify_exception(exception),
         ):
             return False
         # If exception_type is None check() accepts BaseException.
@@ -242,7 +249,7 @@ class Matcher(Generic[MatchE]):
         if (match := self.match) is not None:
             # If no flags were specified, discard the redundant re.compile() here.
             reqs.append(
-                f"match={match.pattern if match.flags == _regex_no_flags else match!r}"
+                f"match={match.pattern if match.flags == _regex_no_flags else match!r}",
             )
         if self.check is not None:
             reqs.append(f"check={self.check!r}")
@@ -403,13 +410,13 @@ class RaisesGroup(ContextManager[ExceptionInfo[BaseExceptionGroup[E]]], SuperCla
                 "You cannot specify multiple exceptions with `allow_unwrapped=True.`"
                 " If you want to match one of multiple possible exceptions you should"
                 " use a `Matcher`."
-                " E.g. `Matcher(check=lambda e: isinstance(e, (...)))`"
+                " E.g. `Matcher(check=lambda e: isinstance(e, (...)))`",
             )
         if allow_unwrapped and isinstance(exception, RaisesGroup):
             raise ValueError(
                 "`allow_unwrapped=True` has no effect when expecting a `RaisesGroup`."
                 " You might want it in the expected `RaisesGroup`, or"
-                " `flatten_subgroups=True` if you don't care about the structure."
+                " `flatten_subgroups=True` if you don't care about the structure.",
             )
         if allow_unwrapped and (match is not None or check is not None):
             raise ValueError(
@@ -418,7 +425,7 @@ class RaisesGroup(ContextManager[ExceptionInfo[BaseExceptionGroup[E]]], SuperCla
                 " exception you should use a `Matcher` object. If you want to match/check"
                 " the exceptiongroup when the exception *is* wrapped you need to"
                 " do e.g. `if isinstance(exc.value, ExceptionGroup):"
-                " assert RaisesGroup(...).matches(exc.value)` afterwards."
+                " assert RaisesGroup(...).matches(exc.value)` afterwards.",
             )
 
         # verify `expected_exceptions` and set `self.is_baseexceptiongroup`
@@ -429,7 +436,7 @@ class RaisesGroup(ContextManager[ExceptionInfo[BaseExceptionGroup[E]]], SuperCla
                         "You cannot specify a nested structure inside a RaisesGroup with"
                         " `flatten_subgroups=True`. The parameter will flatten subgroups"
                         " in the raised exceptiongroup before matching, which would never"
-                        " match a nested structure."
+                        " match a nested structure.",
                     )
                 self.is_baseexceptiongroup |= exc.is_baseexceptiongroup
             elif isinstance(exc, Matcher):
@@ -439,14 +446,15 @@ class RaisesGroup(ContextManager[ExceptionInfo[BaseExceptionGroup[E]]], SuperCla
                     continue
                 # Matcher __init__ assures it's a subclass of BaseException
                 self.is_baseexceptiongroup |= not issubclass(
-                    exc.exception_type, Exception
+                    exc.exception_type,
+                    Exception,
                 )
             elif isinstance(exc, type) and issubclass(exc, BaseException):
                 self.is_baseexceptiongroup |= not issubclass(exc, Exception)
             else:
                 raise ValueError(
                     f'Invalid argument "{exc!r}" must be exception type, Matcher, or'
-                    " RaisesGroup."
+                    " RaisesGroup.",
                 )
 
     def __enter__(self) -> ExceptionInfo[BaseExceptionGroup[E]]:
@@ -454,7 +462,8 @@ class RaisesGroup(ContextManager[ExceptionInfo[BaseExceptionGroup[E]]], SuperCla
         return self.excinfo
 
     def _unroll_exceptions(
-        self, exceptions: Sequence[BaseException]
+        self,
+        exceptions: Sequence[BaseException],
     ) -> Sequence[BaseException]:
         """Used if `flatten_subgroups=True`."""
         res: list[BaseException] = []
@@ -498,7 +507,8 @@ class RaisesGroup(ContextManager[ExceptionInfo[BaseExceptionGroup[E]]], SuperCla
             return False
 
         if self.match_expr is not None and not re.search(
-            self.match_expr, _stringify_exception(exc_val)
+            self.match_expr,
+            _stringify_exception(exc_val),
         ):
             return False
         if self.check is not None and not self.check(exc_val):

--- a/src/trio/testing/_sequencer.py
+++ b/src/trio/testing/_sequencer.py
@@ -55,7 +55,8 @@ class Sequencer:
     """
 
     _sequence_points: defaultdict[int, Event] = attrs.field(
-        factory=lambda: defaultdict(Event), init=False
+        factory=lambda: defaultdict(Event),
+        init=False,
     )
     _claimed: set[int] = attrs.field(factory=set, init=False)
     _broken: bool = attrs.field(default=False, init=False)
@@ -75,7 +76,7 @@ class Sequencer:
                 for event in self._sequence_points.values():
                     event.set()
                 raise RuntimeError(
-                    "Sequencer wait cancelled -- sequence broken"
+                    "Sequencer wait cancelled -- sequence broken",
                 ) from None
             else:
                 if self._broken:

--- a/src/trio/testing/_trio_test.py
+++ b/src/trio/testing/_trio_test.py
@@ -42,7 +42,9 @@ def trio_test(fn: Callable[ArgsT, Awaitable[RetT]]) -> Callable[ArgsT, RetT]:
             raise ValueError("too many clocks spoil the broth!")
         instruments = [i for i in kwargs.values() if isinstance(i, Instrument)]
         return _core.run(
-            partial(fn, *args, **kwargs), clock=clock, instruments=instruments
+            partial(fn, *args, **kwargs),
+            clock=clock,
+            instruments=instruments,
         )
 
     return wrapper


### PR DESCRIPTION
In this pull request, we enable ruff's `flake8-commas` rule and handle all the reformatting black does because of this.

~No functional changes~ Had to update `gen_exports` to run black a 2nd time, if/when this is merged it will probably need to be added to the purely formatting commits thing jakkdl was talking about a while ago.