### PR TITLE
Enable ruff's `flake8-executable` and `flynt` rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,8 +110,10 @@ select = [
     "B",     # flake8-bugbear
     "C4",    # flake8-comprehensions
     "E",     # Error
+    "EXE",   # flake8-executable
     "F",     # pyflakes
     "FA",    # flake8-future-annotations
+    "FLY",   # flynt
     "I",     # isort
     "PERF",  # Perflint
     "PT",    # flake8-pytest-style

--- a/src/trio/_util.py
+++ b/src/trio/_util.py
@@ -243,7 +243,7 @@ def async_wraps(
 
     def decorator(func: CallT) -> CallT:
         func.__name__ = attr_name
-        func.__qualname__ = ".".join((cls.__qualname__, attr_name))
+        func.__qualname__ = f"{cls.__qualname__}.{attr_name}"
 
         func.__doc__ = f"Like :meth:`~{wrapped_cls.__module__}.{wrapped_cls.__qualname__}.{attr_name}`, but async."
 


### PR DESCRIPTION
In this pull request, we enable ruff's `flake8-executable` and `flynt` rules. Only `flynt` suggested making any actual changes, as none of Trio's files have a shebang line.