### PR TITLE
Enable more minor ruff rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,10 +112,14 @@ select = [
     "E",     # Error
     "F",     # pyflakes
     "FA",    # flake8-future-annotations
+    "FURB",  # refurb
     "I",     # isort
+    "ICN",   # flake8-import-conventions
     "PERF",  # Perflint
+    "PIE",   # flake8-pie
     "PT",    # flake8-pytest-style
     "PYI",   # flake8-pyi
+    "Q",     # flake8-quotes
     "RUF",   # Ruff-specific rules
     "SIM",   # flake8-simplify
     "TCH",   # flake8-type-checking

--- a/src/trio/_core/_tests/type_tests/nursery_start.py
+++ b/src/trio/_core/_tests/type_tests/nursery_start.py
@@ -47,7 +47,6 @@ async def task_requires_start(*, task_status: TaskStatus[str]) -> None:
 
 async def task_pos_or_kw(value: str, task_status: TaskStatus[int]) -> None:
     """Check a function which doesn't use the *-syntax works."""
-    ...
 
 
 def check_start_soon(nursery: Nursery) -> None:


### PR DESCRIPTION
In this pull request, we enable ruff's `refurb`, `flake8-import-conventions`, `flake8-pie`, and `flake8-quotes` rules, all of which make very minor changes if any.