### PR TITLE
Regenerate generated files automatically if any are changed

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ ci:
   autoupdate_commit_msg: "[pre-commit.ci] pre-commit autoupdate"
   autoupdate_schedule: weekly
   submodules: false
+  skip: [regenerate-files]
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,3 +33,11 @@ repos:
     rev: v2.3.0
     hooks:
       - id: codespell
+  - repo: local
+    hooks:
+      - id: regenerate-files
+        name: regenerate generated files
+        language: system
+        entry: python src/trio/_tools/gen_exports.py
+        pass_filenames: false
+        files: ^src\/trio\/_core\/(_generated)?(_run|(_i(o_(common|epoll|kqueue|windows)|nstrumentation)))\.py$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,4 +41,4 @@ repos:
         language: system
         entry: python src/trio/_tools/gen_exports.py
         pass_filenames: false
-        files: ^src\/trio\/_core\/(_generated)?(_run|(_i(o_(common|epoll|kqueue|windows)|nstrumentation)))\.py$
+        files: ^src\/trio\/_core\/(_run|(_i(o_(common|epoll|kqueue|windows)|nstrumentation)))\.py$

--- a/src/trio/_tests/tools/test_gen_exports.py
+++ b/src/trio/_tests/tools/test_gen_exports.py
@@ -91,7 +91,9 @@ skip_lints = pytest.mark.skipif(
 
 @skip_lints
 @pytest.mark.parametrize("imports", [IMPORT_1, IMPORT_2, IMPORT_3])
-def test_process(tmp_path: Path, imports: str, capsys: pytest.CaptureFixture) -> None:
+def test_process(
+    tmp_path: Path, imports: str, capsys: pytest.CaptureFixture[str]
+) -> None:
     try:
         import black  # noqa: F401
     # there's no dedicated CI run that has astor+isort, but lacks black.

--- a/src/trio/_tests/tools/test_gen_exports.py
+++ b/src/trio/_tests/tools/test_gen_exports.py
@@ -91,7 +91,7 @@ skip_lints = pytest.mark.skipif(
 
 @skip_lints
 @pytest.mark.parametrize("imports", [IMPORT_1, IMPORT_2, IMPORT_3])
-def test_process(tmp_path: Path, imports: str) -> None:
+def test_process(tmp_path: Path, imports: str, capsys: pytest.CaptureFixture) -> None:
     try:
         import black  # noqa: F401
     # there's no dedicated CI run that has astor+isort, but lacks black.
@@ -106,7 +106,13 @@ def test_process(tmp_path: Path, imports: str) -> None:
     with pytest.raises(SystemExit) as excinfo:
         process([file], do_test=True)
     assert excinfo.value.code == 1
-    process([file], do_test=False)
+    captured = capsys.readouterr()
+    assert "Generated sources are outdated. Please regenerate." in captured.out
+    with pytest.raises(SystemExit) as excinfo:
+        process([file], do_test=False)
+    assert excinfo.value.code == 1
+    captured = capsys.readouterr()
+    assert "Regenerated sources successfully." in captured.out
     assert genpath.exists()
     process([file], do_test=True)
     # But if we change the lookup path it notices

--- a/src/trio/_tools/gen_exports.py
+++ b/src/trio/_tools/gen_exports.py
@@ -289,8 +289,9 @@ def process(files: Iterable[File], *, do_test: bool) -> None:
         dirname, basename = os.path.split(file.path)
         new_path = os.path.join(dirname, PREFIX + basename)
         new_files[new_path] = new_source
+    matches_disk = matches_disk_files(new_files)
     if do_test:
-        if not matches_disk_files(new_files):
+        if not matches_disk:
             print("Generated sources are outdated. Please regenerate.")
             sys.exit(1)
         else:
@@ -300,6 +301,9 @@ def process(files: Iterable[File], *, do_test: bool) -> None:
             with open(new_path, "w", encoding="utf-8") as f:
                 f.write(new_source)
         print("Regenerated sources successfully.")
+        if not matches_disk:
+            # With pre-commit integration, show that we edited files.
+            sys.exit(1)
 
 
 # This is in fact run in CI, but only in the formatting check job, which


### PR DESCRIPTION
Making true on https://github.com/python-trio/trio/issues/2835#issuecomment-2266175000, in this pull request I add a local pre-commit hook that automatically regenerates all the generated files if either the generated file itself or the files used to create them are edited. The only one it doesn't match at the moment is `gen_exports.py` itself, and I could add this if needed.