### PR TITLE
Fix attrs redone

### DIFF
--- a/src/trio/_tests/test_trio.py
+++ b/src/trio/_tests/test_trio.py
@@ -1,5 +1,8 @@
-import sys
+def test_trio_import():
+    import sys
 
-for module in list(sys.modules.keys()):
-    if module.startswith("trio"):
-        del sys.modules[module]
+    for module in list(sys.modules.keys()):
+        if module.startswith("trio"):
+            del sys.modules[module]
+    
+    import trio

--- a/src/trio/_tests/test_trio.py
+++ b/src/trio/_tests/test_trio.py
@@ -1,8 +1,8 @@
-def test_trio_import():
+def test_trio_import() -> None:
     import sys
 
     for module in list(sys.modules.keys()):
         if module.startswith("trio"):
             del sys.modules[module]
-    
-    import trio
+
+    import trio  # noqa: F401

--- a/src/trio/_tests/test_trio.py
+++ b/src/trio/_tests/test_trio.py
@@ -1,0 +1,5 @@
+import sys
+
+for module in list(sys.modules.keys()):
+    if module.startswith("trio"):
+        del sys.modules[module]

--- a/src/trio/_tests/tools/test_mypy_annotate.py
+++ b/src/trio/_tests/tools/test_mypy_annotate.py
@@ -105,6 +105,8 @@ def test_endtoend(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
+    import trio._tools.mypy_annotate as mypy_annotate
+
     inp_text = """\
 Mypy begun
 trio/core.py:15: error: Bad types here [misc]
@@ -116,7 +118,9 @@ Found 3 errors in 29 files
     with monkeypatch.context():
         monkeypatch.setattr(sys, "stdin", io.StringIO(inp_text))
 
-        main(["--dumpfile", str(result_file), "--platform", "SomePlatform"])
+        mypy_annotate.main(
+            ["--dumpfile", str(result_file), "--platform", "SomePlatform"]
+        )
 
     std = capsys.readouterr()
     assert std.err == ""

--- a/src/trio/_threads.py
+++ b/src/trio/_threads.py
@@ -139,7 +139,7 @@ def current_default_thread_limiter() -> CapacityLimiter:
 # system; see https://github.com/python-trio/trio/issues/182
 # But for now we just need an object to stand in for the thread, so we can
 # keep track of who's holding the CapacityLimiter's token.
-@attrs.frozen(eq=False, hash=False, slots=False)
+@attrs.frozen(eq=False, slots=False)
 class ThreadPlaceholder:
     name: str
 


### PR DESCRIPTION
https://github.com/python-trio/trio/pull/3054 didn't catch everything. However the root cause was that pytest imports trio during plugin phase and doesn't handle deprecation warnings by erroring then.

To fix that, we can just clear the module cache and try importing again. I'm not completely sold on this idea but it's the best one I had and it works.