### PR TITLE
Bump version to 0.26.2

### DIFF
--- a/docs/source/history.rst
+++ b/docs/source/history.rst
@@ -5,6 +5,15 @@ Release history
 
 .. towncrier release notes start
 
+Trio 0.26.2 (2024-08-08)
+------------------------
+
+Bugfixes
+~~~~~~~~
+
+- Remove remaining ``hash`` usage and fix test configuration issue that prevented it from being caught. (`#3053 <https://github.com/python-trio/trio/issues/3053>`__)
+
+
 Trio 0.26.1 (2024-08-05)
 ------------------------
 

--- a/src/trio/_version.py
+++ b/src/trio/_version.py
@@ -1,3 +1,3 @@
 # This file is imported from __init__.py and parsed by setuptools
 
-__version__ = "0.26.1+dev"
+__version__ = "0.26.2"

--- a/src/trio/_version.py
+++ b/src/trio/_version.py
@@ -1,3 +1,3 @@
 # This file is imported from __init__.py and parsed by setuptools
 
-__version__ = "0.26.2"
+__version__ = "0.26.2+dev"


### PR DESCRIPTION
Fixes https://github.com/python-trio/trio/issues/3053 for real this time.