### PR TITLE
Update `uv`'s output when it gets bumped in autodeps

### DIFF
--- a/.github/workflows/autodeps.yml
+++ b/.github/workflows/autodeps.yml
@@ -17,6 +17,7 @@ jobs:
       issues: write
       repository-projects: write
       contents: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -24,6 +25,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.8"
+
       - name: Bump dependencies
         run: |
           python -m pip install -U pip pre-commit
@@ -31,12 +33,19 @@ jobs:
           uv pip compile --universal --python-version=3.8 --upgrade test-requirements.in -o test-requirements.txt
           uv pip compile --universal --python-version=3.8 --upgrade docs-requirements.in -o docs-requirements.txt
           pre-commit autoupdate --jobs 0
+
+      - name: Install new requirements
+        run: python -m pip install -r test-requirements.txt
+
+      # apply newer versions' formatting
       - name: Black
+        run: black src/trio
+
+      - name: uv
         run: |
-          # The new dependencies may contain a new black version.
-          # Commit any changes immediately.
-          python -m pip install -r test-requirements.txt
-          black src/trio
+          uv pip compile --universal --python-version=3.8 test-requirements.in -o test-requirements.txt
+          uv pip compile --universal --python-version=3.8 docs-requirements.in -o docs-requirements.txt
+
       - name: Commit changes and create automerge PR
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
This avoids having to manually update the lockfile and allows for easier regression testing (rather than having to trawl through a failing check.sh run).