### PR TITLE
Stop testing PyPy's Python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['pypy-3.9', 'pypy-3.10', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python: ['pypy-3.10', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         check_formatting: ['0']
         no_test_requirements: ['0']
         extra_name: ['']


### PR DESCRIPTION
Latest PyPy release stopped supporting Python 3.9.