### PR TITLE
Add sphinx-lint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,10 @@ repos:
     rev: v2.3.0
     hooks:
       - id: codespell
+  - repo: https://github.com/sphinx-contrib/sphinx-lint
+    rev: v0.9.1
+    hooks:
+      - id: sphinx-lint
   - repo: local
     hooks:
       - id: regenerate-files


### PR DESCRIPTION
Mentioned in and closes https://github.com/python-trio/trio/issues/3082, this pull request adds the sphinx-lint pre-commit hook