### PR TITLE
add __copy__ and __deep_copy__ to Cancelled

### DIFF
--- a/newsfragments/3105.feature.rst
+++ b/newsfragments/3105.feature.rst
@@ -1,0 +1,1 @@
+:exc:`trio.Cancelled` now defines `__copy__` and `__deep_copy__` to support :func:`copy.copy` and :func:`copy.deepcopy`.

--- a/newsfragments/3105.feature.rst
+++ b/newsfragments/3105.feature.rst
@@ -1,1 +1,1 @@
-:exc:`trio.Cancelled` now defines `__copy__` and `__deep_copy__` to support :func:`copy.copy` and :func:`copy.deepcopy`.
+:exc:`trio.Cancelled` now defines ``__copy__`` and ``__deep_copy__`` to support :func:`copy.copy` and :func:`copy.deepcopy`.

--- a/src/trio/_core/_exceptions.py
+++ b/src/trio/_core/_exceptions.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+import copy
+
 from trio._util import NoPublicConstructor, final
 
 
@@ -62,6 +66,31 @@ class Cancelled(BaseException, metaclass=NoPublicConstructor):
 
     def __str__(self) -> str:
         return "Cancelled"
+
+    def __copy__(self) -> Cancelled:
+        result = Cancelled.__new__(Cancelled)
+        result.__context__ = self.__context__
+        result.__cause__ = self.__cause__
+        result.__suppress_context__ = self.__suppress_context__
+        result.__traceback__ = self.__traceback__
+        if hasattr(self, "__notes__"):
+            result.__notes__ = self.__notes__  # type: ignore[attr-defined]
+        return result
+
+    def __deepcopy__(self, memo: dict[int, object]) -> Cancelled:
+        result = Cancelled.__new__(Cancelled)
+        memo[id(self)] = result
+        keys = (
+            "__context__",
+            "__cause__",
+            "__suppress_context__",
+            "__traceback__",
+            "__notes__",
+        )
+        for key in keys:
+            if hasattr(self, key):
+                setattr(result, key, copy.deepcopy(getattr(self, key), memo))
+        return result
 
 
 class BusyResourceError(Exception):

--- a/src/trio/_core/_exceptions.py
+++ b/src/trio/_core/_exceptions.py
@@ -68,28 +68,25 @@ class Cancelled(BaseException, metaclass=NoPublicConstructor):
         return "Cancelled"
 
     def __copy__(self) -> Cancelled:
+        """Enables creating new instances through `copy.copy`.
+
+        This does not copy exception metadata like __cause__, __traceback__, etc
+        in line with the effect of copying built-in exceptions.
+        """
         result = Cancelled.__new__(Cancelled)
-        result.__context__ = self.__context__
-        result.__cause__ = self.__cause__
-        result.__suppress_context__ = self.__suppress_context__
-        result.__traceback__ = self.__traceback__
-        if hasattr(self, "__notes__"):
-            result.__notes__ = self.__notes__  # type: ignore[attr-defined]
+        result.__dict__ = copy.copy(self.__dict__)
         return result
 
     def __deepcopy__(self, memo: dict[int, object]) -> Cancelled:
+        """Enables creating new instances through `copy.deepcopy`.
+
+        This does not copy exception metadata like __cause__, __traceback__, etc
+        in line with the effect of copying built-in exceptions.
+        """
         result = Cancelled.__new__(Cancelled)
+        # copy.deepcopy handles memo logic
         memo[id(self)] = result
-        keys = (
-            "__context__",
-            "__cause__",
-            "__suppress_context__",
-            "__traceback__",
-            "__notes__",
-        )
-        for key in keys:
-            if hasattr(self, key):
-                setattr(result, key, copy.deepcopy(getattr(self, key), memo))
+        result.__dict__ = copy.deepcopy(self.__dict__, memo)
         return result
 
 

--- a/src/trio/_core/_tests/test_run.py
+++ b/src/trio/_core/_tests/test_run.py
@@ -2222,10 +2222,14 @@ def test_Cancelled_copy() -> None:
     cancelled = _core.Cancelled._create()
     cancelled.__context__ = cancelled
     cancelled.__cause__ = BaseException()
+    if sys.version_info > (3, 11):
+        cancelled.add_note("hello")
     my_copy = copy.copy(cancelled)
     assert my_copy is not cancelled
     assert my_copy.__context__ is cancelled.__context__
     assert my_copy.__cause__ is cancelled.__cause__
+    if sys.version_info > (3, 11):
+        assert my_copy.__notes__ == ["hello"]
 
     my_copy = copy.deepcopy(cancelled)
     assert my_copy is not cancelled

--- a/src/trio/_core/_tests/test_run.py
+++ b/src/trio/_core/_tests/test_run.py
@@ -2219,22 +2219,22 @@ def test_Cancelled_subclass() -> None:
 
 
 def test_Cancelled_copy() -> None:
+    # the only notable thing in __dict__ is __notes__
+    # on py<3.11 we only check for ability to create new instances
     cancelled = _core.Cancelled._create()
-    cancelled.__context__ = cancelled
-    cancelled.__cause__ = BaseException()
     if sys.version_info > (3, 11):
         cancelled.add_note("hello")
+
     my_copy = copy.copy(cancelled)
     assert my_copy is not cancelled
-    assert my_copy.__context__ is cancelled.__context__
-    assert my_copy.__cause__ is cancelled.__cause__
     if sys.version_info > (3, 11):
-        assert my_copy.__notes__ == ["hello"]
+        assert my_copy.__notes__ is cancelled.__notes__
 
-    my_copy = copy.deepcopy(cancelled)
-    assert my_copy is not cancelled
-    assert my_copy.__context__ is not cancelled.__context__
-    assert my_copy.__cause__ is not cancelled.__cause__
+    deep_copy = copy.deepcopy(cancelled)
+    assert deep_copy is not cancelled
+    if sys.version_info > (3, 11):
+        assert deep_copy.__notes__ == ["hello"]
+        assert deep_copy.__notes__ is not cancelled.__notes__
 
 
 def test_CancelScope_subclass() -> None:

--- a/src/trio/_core/_tests/test_run.py
+++ b/src/trio/_core/_tests/test_run.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextvars
+import copy
 import functools
 import gc
 import sys
@@ -2215,6 +2216,21 @@ def test_Cancelled_str() -> None:
 def test_Cancelled_subclass() -> None:
     with pytest.raises(TypeError):
         type("Subclass", (_core.Cancelled,), {})
+
+
+def test_Cancelled_copy() -> None:
+    cancelled = _core.Cancelled._create()
+    cancelled.__context__ = cancelled
+    cancelled.__cause__ = BaseException()
+    my_copy = copy.copy(cancelled)
+    assert my_copy is not cancelled
+    assert my_copy.__context__ is cancelled.__context__
+    assert my_copy.__cause__ is cancelled.__cause__
+
+    my_copy = copy.deepcopy(cancelled)
+    assert my_copy is not cancelled
+    assert my_copy.__context__ is not cancelled.__context__
+    assert my_copy.__cause__ is not cancelled.__cause__
 
 
 def test_CancelScope_subclass() -> None:


### PR DESCRIPTION
See https://github.com/python-trio/flake8-async/issues/298 for why I want to be able to copy `Cancelled`.

I suppose there's a minor footgun added if people start copying `Cancelled`, `NoPublicConstructor` was added for a reason, but I think the gain outweighs it. Though of course another option is to simply get rid of `NoPublicConstructor`

I initially tried to write cleaner methods, where I was using `__dict__` and the like, but they do not appear to pick up the relevant dunders so I simply listed everything relevant from https://docs.python.org/3/library/exceptions.html#exception-context