### PR TITLE
Document that `trio.sleep_forever` will raise `RuntimeError` instead of returning

### DIFF
--- a/newsfragments/3113.doc.rst
+++ b/newsfragments/3113.doc.rst
@@ -1,0 +1,1 @@
+Document that :func:`trio.sleep_forever` is guaranteed to raise an exception now.

--- a/src/trio/_timeouts.py
+++ b/src/trio/_timeouts.py
@@ -61,8 +61,8 @@ def move_on_after(
 async def sleep_forever() -> NoReturn:
     """Pause execution of the current task forever (or until cancelled).
 
-    Equivalent to calling ``await sleep(math.inf)``, except that instead of
-    returning this will raise a `RuntimeError`.
+    Equivalent to calling ``await sleep(math.inf)``, except that if manually
+    rescheduled this will raise a `RuntimeError`.
 
     Raises:
       RuntimeError: if rescheduled

--- a/src/trio/_timeouts.py
+++ b/src/trio/_timeouts.py
@@ -61,7 +61,11 @@ def move_on_after(
 async def sleep_forever() -> NoReturn:
     """Pause execution of the current task forever (or until cancelled).
 
-    Equivalent to calling ``await sleep(math.inf)``.
+    Equivalent to calling ``await sleep(math.inf)``, except that instead of
+    returning this will raise a `RuntimeError`.
+
+    Raises:
+      RuntimeError: if rescheduled
 
     """
     await trio.lowlevel.wait_task_rescheduled(lambda _: trio.lowlevel.Abort.SUCCEEDED)


### PR DESCRIPTION
Fixes #3113.