### PR TITLE
Enable pre-commit.ci pull-request autofixing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,5 @@
 ci:
-  autofix_commit_msg: "[pre-commit.ci] auto fixes from pre-commit.com hooks"
-  autofix_prs: false
-  autoupdate_commit_msg: "[pre-commit.ci] pre-commit autoupdate"
+  autofix_prs: true
   autoupdate_schedule: weekly
   submodules: false
   skip: [regenerate-files]


### PR DESCRIPTION
In this pull request, we allow pre-commit.ci to autofix pull requests. The specific pre-commit hooks we use are all designed well and will avoid making changes that might cause issues, and people usually end up saying the trigger message to fix their pull requests anyways.