### PR TITLE
Introducing Trio Guru on Gurubase.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,10 @@
    :target: https://codecov.io/gh/python-trio/trio
    :alt: Test coverage
 
+.. image:: https://img.shields.io/badge/Gurubase-Ask%20Trio%20Guru-006BFF.svg
+   :target: https://gurubase.io/g/trio
+   :alt: Ask Trio Guru
+
 Trio – a friendly Python library for async concurrency and I/O
 ==============================================================
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Trio Guru](https://gurubase.io/g/trio) to Gurubase. Trio Guru uses the data from this repo and data from the [docs](https://trio.readthedocs.io) to answer questions by leveraging the LLM.

In this PR, I showcased the "Trio Guru", which highlights that Trio now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Trio Guru in Gurubase, just let me know that's totally fine.
