### PR TITLE
install uv with uv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,11 +184,9 @@ jobs:
         # can't use setup-python because that python doesn't seem to work;
         # `python3-dev` (rather than `python:alpine`) for some ctypes reason,
         # `nodejs` for pyright (`node-env` pulls in nodejs but that takes a while and can time out the test).
-        run: apk update && apk add python3-dev bash nodejs
-      - name: Enter virtual environment
-        run: python -m venv .venv
+        run: apk update && apk add python3-dev bash nodejs curl
       - name: Run tests
-        run: source .venv/bin/activate && ./ci.sh
+        run: ./ci.sh
       - if: always()
         uses: codecov/codecov-action@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,5 @@ doc/_build/
 
 # PyCharm
 .idea/
+
+uv-install.sh

--- a/.uv-bin/.gitignore
+++ b/.uv-bin/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/ci.sh
+++ b/ci.sh
@@ -37,13 +37,14 @@ python -c "import sys, struct, ssl; print('python:', sys.version); print('versio
 echo "::endgroup::"
 
 echo "::group::Install dependencies"
-python -m pip install -U pip uv -c test-requirements.txt
-python -m pip --version
+curl-harder https://astral.sh/uv/0.4.30/install.sh -o uv-install.sh
+UV_UNMANAGED_INSTALL="./.uv-bin" sh uv-install.sh
+./.uv-bin/uv pip install uv -c test-requirements.txt
+python -m uv pip uninstall pip
+python -m uv pip install 'build[uv]' -c test-requirements.txt
 python -m uv --version
 
-python -m uv pip install build
-
-python -m build
+python -m build --installer=uv
 wheel_package=$(ls dist/*.whl)
 python -m uv pip install "trio @ $wheel_package" -c test-requirements.txt
 

--- a/ci.sh
+++ b/ci.sh
@@ -37,7 +37,7 @@ python -c "import sys, struct, ssl; print('python:', sys.version); print('versio
 echo "::endgroup::"
 
 echo "::group::Install dependencies"
-curl-harder https://astral.sh/uv/0.4.30/install.sh -o uv-install.sh
+curl-harder $(python ./src/trio/_tools/find_uv_script_url.py test-requirements.txt) -o uv-install.sh
 UV_UNMANAGED_INSTALL="./.uv-bin" sh uv-install.sh
 ./.uv-bin/uv venv .venv
 source $(python ./src/trio/_tools/find_activate_script.py .venv)

--- a/ci.sh
+++ b/ci.sh
@@ -40,7 +40,7 @@ echo "::group::Install dependencies"
 curl-harder https://astral.sh/uv/0.4.30/install.sh -o uv-install.sh
 UV_UNMANAGED_INSTALL="./.uv-bin" sh uv-install.sh
 ./.uv-bin/uv venv .venv
-source .venv/bin/activate
+source $(python ./src/trio/_tools/find_activate_script.py .venv)
 ./.uv-bin/uv pip install uv -c test-requirements.txt
 python -m uv pip install 'build[uv]' -c test-requirements.txt
 python -m uv --version

--- a/ci.sh
+++ b/ci.sh
@@ -39,8 +39,9 @@ echo "::endgroup::"
 echo "::group::Install dependencies"
 curl-harder https://astral.sh/uv/0.4.30/install.sh -o uv-install.sh
 UV_UNMANAGED_INSTALL="./.uv-bin" sh uv-install.sh
+./.uv-bin/uv venv .venv
+source .venv/bin/activate
 ./.uv-bin/uv pip install uv -c test-requirements.txt
-python -m uv pip uninstall pip
 python -m uv pip install 'build[uv]' -c test-requirements.txt
 python -m uv --version
 

--- a/newsfragments/3131.misc.rst
+++ b/newsfragments/3131.misc.rst
@@ -1,1 +1,1 @@
-Bootstrap uv using uv install script instead of pip
+Bootstrap uv using uv install script instead of pip, this works around an issue where pip refused to install uv on PyPy on windows

--- a/newsfragments/3131.misc.rst
+++ b/newsfragments/3131.misc.rst
@@ -1,0 +1,1 @@
+Bootstrap uv using uv install script instead of pip

--- a/src/trio/_tests/tools/test_find_activate_script.py
+++ b/src/trio/_tests/tools/test_find_activate_script.py
@@ -1,0 +1,21 @@
+import os
+import pathlib
+import venv
+
+import pytest
+
+from trio._tools import find_activate_script
+
+
+def test_find_activate_script(
+    tmp_path: pathlib.Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    env_dir = tmp_path / "venv"
+    venv.create(env_dir)
+    find_activate_script.main([os.fsdecode(env_dir)])
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    activate = pathlib.Path(captured.out.removesuffix("\n"))
+    assert activate.exists()
+    assert activate.name == "activate"

--- a/src/trio/_tests/tools/test_find_uv_script_url.py
+++ b/src/trio/_tests/tools/test_find_uv_script_url.py
@@ -11,7 +11,7 @@ def test_find_uv_script_url(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     requirements = tmp_path / "requirements.txt"
-    requirements.write_bytes(b"# uv==2.0\nuv==1.0\n")
+    requirements.write_bytes(b"# uv==2.0\nuv==1.0\r\n")
     find_uv_script_url.main([os.fsdecode(requirements)])
     captured = capsys.readouterr()
     assert captured.err == ""

--- a/src/trio/_tests/tools/test_find_uv_script_url.py
+++ b/src/trio/_tests/tools/test_find_uv_script_url.py
@@ -1,0 +1,25 @@
+import os
+import pathlib
+
+import pytest
+
+from trio._tools import find_uv_script_url
+
+
+def test_find_uv_script_url(
+    tmp_path: pathlib.Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_bytes(b"# uv==2.0\nuv==1.0\n")
+    find_uv_script_url.main([os.fsdecode(requirements)])
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert captured.out == "https://astral.sh/uv/1.0/install.sh\n"
+
+
+def test_cannot_find_uv_version(tmp_path: pathlib.Path) -> None:
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_bytes(b"# uv==2\npip==1\n")
+    with pytest.raises(RuntimeError, match=r"no version found"):
+        find_uv_script_url.main([os.fsdecode(requirements)])

--- a/src/trio/_tools/find_activate_script.py
+++ b/src/trio/_tools/find_activate_script.py
@@ -1,0 +1,58 @@
+"""
+Script to find the activate script in a virtual environment.
+
+Has only stdlib dependencies because it runs before any package is installed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import pathlib
+import sys
+import sysconfig
+
+
+def _venv_path(env_dir: str, name: str) -> str:
+    vars_ = {
+        "base": env_dir,
+        "platbase": env_dir,
+        "installed_base": env_dir,
+        "installed_platbase": env_dir,
+    }
+    return sysconfig.get_path(name, scheme="venv", vars=vars_)
+
+
+if sys.version_info >= (3, 11):
+
+    def _get_binpath(v: pathlib.Path) -> pathlib.Path:
+        return pathlib.Path(_venv_path(env_dir=os.fsdecode(v), name="scripts"))
+
+elif sys.platform == "win32":
+
+    def _get_binpath(v: pathlib.Path) -> pathlib.Path:
+        return v / "Scripts"
+
+else:
+
+    def _get_binpath(v: pathlib.Path) -> pathlib.Path:
+        return v / "bin"
+
+
+def _get_activate_script(v: pathlib.Path) -> pathlib.Path:
+    return _get_binpath(v) / "activate"
+
+
+def main(args: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Find the activate script for a given virtual environment",
+    )
+    parser.add_argument("filename", type=pathlib.Path)
+    parsed_args = parser.parse_args(args=args)
+    activate = _get_activate_script(parsed_args.filename)
+    print(activate)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/trio/_tools/find_activate_script.py
+++ b/src/trio/_tools/find_activate_script.py
@@ -54,5 +54,5 @@ def main(args: list[str] | None = None) -> int:
     return 0
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     sys.exit(main())

--- a/src/trio/_tools/find_uv_script_url.py
+++ b/src/trio/_tools/find_uv_script_url.py
@@ -1,0 +1,39 @@
+"""
+Script to find the uv script url from a constraints file.
+
+Has only stdlib dependencies because it runs before any package is installed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+
+
+def _url(v: str) -> str:
+    return f"https://astral.sh/uv/{v}/install.sh"
+
+
+def _parse(v: pathlib.Path) -> str:
+    with v.open("rb") as f:
+        for line in f:
+            before, found, version = line.partition(b"uv==")
+            if not before and found:
+                return _url(version.removesuffix(b"\n").decode("ascii"))
+    raise RuntimeError("no version found")
+
+
+def main(args: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Find the uv version in a requirements.txt",
+    )
+    parser.add_argument("filename", type=pathlib.Path)
+    parsed_args = parser.parse_args(args=args)
+    version = _parse(parsed_args.filename)
+    print(version)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/src/trio/_tools/find_uv_script_url.py
+++ b/src/trio/_tools/find_uv_script_url.py
@@ -20,7 +20,7 @@ def _parse(v: pathlib.Path) -> str:
         for line in f:
             before, found, version = line.partition(b"uv==")
             if not before and found:
-                return _url(version.removesuffix(b"\n").decode("ascii"))
+                return _url(version.rstrip().decode("ascii"))
     raise RuntimeError("no version found")
 
 

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -16,7 +16,7 @@ mypy  # Would use mypy[faster-cache], but orjson has build issues on pypy
 orjson; implementation_name == "cpython"
 ruff >= 0.6.6
 astor          # code generation
-uv >= 0.2.24
+uv >= 0.5.0
 codespell
 
 # https://github.com/python-trio/trio/pull/654#issuecomment-420518745

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -10,6 +10,7 @@ jedi; implementation_name == "cpython"                  # for jedi code completi
 cryptography>=41.0.0  # cryptography<41 segfaults on pypy3.10
 
 # Tools
+build[uv]
 black; implementation_name == "cpython"
 mypy  # Would use mypy[faster-cache], but orjson has build issues on pypy
 orjson; implementation_name == "cpython"

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -16,6 +16,8 @@ babel==2.16.0
     # via sphinx
 black==24.10.0 ; implementation_name == 'cpython'
     # via -r test-requirements.in
+build==1.2.2.post1
+    # via -r test-requirements.in
 certifi==2024.8.30
     # via requests
 cffi==1.17.1 ; platform_python_implementation != 'PyPy' or os_name == 'nt'
@@ -28,8 +30,9 @@ click==8.1.7 ; implementation_name == 'cpython'
     # via black
 codespell==2.3.0
     # via -r test-requirements.in
-colorama==0.4.6 ; (implementation_name != 'cpython' and sys_platform == 'win32') or (platform_system != 'Windows' and sys_platform == 'win32') or (implementation_name == 'cpython' and platform_system == 'Windows')
+colorama==0.4.6 ; (implementation_name != 'cpython' and sys_platform == 'win32') or (platform_system != 'Windows' and sys_platform == 'win32') or (implementation_name == 'cpython' and platform_system == 'Windows') or os_name == 'nt'
     # via
+    #   build
     #   click
     #   pylint
     #   pytest
@@ -57,8 +60,10 @@ idna==3.10
     #   trustme
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.5.0 ; python_full_version < '3.10'
-    # via sphinx
+importlib-metadata==8.5.0 ; python_full_version < '3.10.2'
+    # via
+    #   build
+    #   sphinx
 iniconfig==2.0.0
     # via pytest
 isort==5.13.2
@@ -87,6 +92,7 @@ outcome==1.3.0.post0
 packaging==24.1
     # via
     #   black
+    #   build
     #   pytest
     #   sphinx
 parso==0.8.4 ; implementation_name == 'cpython'
@@ -107,6 +113,8 @@ pylint==3.3.1
     # via -r test-requirements.in
 pyopenssl==24.2.1
     # via -r test-requirements.in
+pyproject-hooks==1.2.0
+    # via build
 pyright==1.1.387
     # via -r test-requirements.in
 pytest==8.3.3
@@ -138,6 +146,7 @@ sphinxcontrib-serializinghtml==2.0.0
 tomli==2.0.2 ; python_full_version < '3.11'
     # via
     #   black
+    #   build
     #   mypy
     #   pylint
     #   pytest
@@ -166,7 +175,9 @@ typing-extensions==4.12.2
     #   pyright
 urllib3==2.2.3
     # via requests
-uv==0.4.29
-    # via -r test-requirements.in
-zipp==3.20.2 ; python_full_version < '3.10'
+uv==0.4.30
+    # via
+    #   -r test-requirements.in
+    #   build
+zipp==3.20.2 ; python_full_version < '3.10.2'
     # via importlib-metadata

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -175,7 +175,7 @@ typing-extensions==4.12.2
     #   pyright
 urllib3==2.2.3
     # via requests
-uv==0.4.30
+uv==0.5.0
     # via
     #   -r test-requirements.in
     #   build


### PR DESCRIPTION
also avoid pip entirely in ci

this works around the issue where pip could not install uv on pypy on windows with a broken cache