### PR TITLE
_socket.py: fix for systems where AI_NUMERICSERV is not defined

### DIFF
--- a/newsfragments/3133.bugfix.rst
+++ b/newsfragments/3133.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed socket module for some older systems which lack ``socket.AI_NUMERICSERV``.
+Now trio works on legacy (pre-Lion) macOS.

--- a/src/trio/_socket.py
+++ b/src/trio/_socket.py
@@ -164,7 +164,10 @@ def set_custom_socket_factory(
 # getaddrinfo and friends
 ################################################################
 
-_NUMERIC_ONLY = _stdlib_socket.AI_NUMERICHOST | _stdlib_socket.AI_NUMERICSERV
+# AI_NUMERICSERV may be missing on some older platforms, so use it when available.
+# See: https://github.com/python-trio/trio/issues/3133
+_NUMERIC_ONLY = _stdlib_socket.AI_NUMERICHOST
+_NUMERIC_ONLY |= getattr(_stdlib_socket, "AI_NUMERICSERV", 0)
 
 
 # It would be possible to @overload the return value depending on Literal[AddressFamily.INET/6], but should probably be added in typeshed first


### PR DESCRIPTION
Rationale: on some platforms `AI_NUMERICSERV` may not be defined. In particular, old versions of macOS, possibly some other. While affected users are probably few, it is a trivial fix, which makes `trio` usable (for example, `yewtube` app works then).

Credits to @CoolCat467
Closes: https://github.com/python-trio/trio/issues/3133