### PR TITLE
Type `RaisesGroup` properly

### DIFF
--- a/newsfragments/3141.bugfix.rst
+++ b/newsfragments/3141.bugfix.rst
@@ -1,0 +1,1 @@
+Fix `trio.testing.RaisesGroup`'s typing.

--- a/src/trio/_tests/test_testing_raisesgroup.py
+++ b/src/trio/_tests/test_testing_raisesgroup.py
@@ -24,7 +24,7 @@ def test_raises_group() -> None:
             f'Invalid argument "{TypeError()!r}" must be exception type, Matcher, or RaisesGroup.',
         ),
     ):
-        RaisesGroup(TypeError())
+        RaisesGroup(TypeError())  # type: ignore
 
     with RaisesGroup(ValueError):
         raise ExceptionGroup("foo", (ValueError(),))

--- a/src/trio/_tests/test_testing_raisesgroup.py
+++ b/src/trio/_tests/test_testing_raisesgroup.py
@@ -24,7 +24,7 @@ def test_raises_group() -> None:
             f'Invalid argument "{TypeError()!r}" must be exception type, Matcher, or RaisesGroup.',
         ),
     ):
-        RaisesGroup(TypeError())  # type: ignore
+        RaisesGroup(TypeError())  # type: ignore[call-overload]
 
     with RaisesGroup(ValueError):
         raise ExceptionGroup("foo", (ValueError(),))

--- a/src/trio/_tests/type_tests/path.py
+++ b/src/trio/_tests/type_tests/path.py
@@ -54,7 +54,7 @@ def sync_attrs(path: trio.Path) -> None:
     assert_type(path.match("*.py"), bool)
     assert_type(path.relative_to("/usr"), trio.Path)
     if sys.version_info >= (3, 12):
-        assert_type(path.relative_to("/", walk_up=True), bool)
+        assert_type(path.relative_to("/", walk_up=True), trio.Path)
     assert_type(path.with_name("filename.txt"), trio.Path)
     assert_type(path.with_stem("readme"), trio.Path)
     assert_type(path.with_suffix(".log"), trio.Path)

--- a/src/trio/_tests/type_tests/raisesgroup.py
+++ b/src/trio/_tests/type_tests/raisesgroup.py
@@ -223,11 +223,15 @@ def check_triple_nested_raisesgroup() -> None:
 
 
 def check_check_typing() -> None:
-    assert_type(  # type: ignore
-        RaisesGroup(ValueError).check,
+    # fmt: off
+    # mypy raises an error on `assert_type`
+    # pyright raises an error on `RaisesGroup(ValueError).check`
+    # to satisfy both, need to disable formatting and put it on one line
+    assert_type(RaisesGroup(ValueError).check,  # type: ignore
         Union[
             Callable[[BaseExceptionGroup[ValueError]], None],
             Callable[[ExceptionGroup[ValueError]], None],
             None,
         ],
     )
+    # fmt: on

--- a/src/trio/_tests/type_tests/raisesgroup.py
+++ b/src/trio/_tests/type_tests/raisesgroup.py
@@ -23,19 +23,6 @@ from typing_extensions import assert_type
 if sys.version_info < (3, 11):
     from exceptiongroup import BaseExceptionGroup, ExceptionGroup
 
-# split into functions to isolate the different scopes
-
-
-def check_inheritance_and_assignments() -> None:
-    # Check inheritance
-    _: BaseExceptionGroup[ValueError] = RaisesGroup(ValueError)
-    _ = RaisesGroup(RaisesGroup(ValueError))  # type: ignore
-
-    a: BaseExceptionGroup[BaseExceptionGroup[ValueError]]
-    a = RaisesGroup(RaisesGroup(ValueError))
-    a = BaseExceptionGroup("", (BaseExceptionGroup("", (ValueError(),)),))
-    assert a
-
 
 def check_matcher_typevar_default(e: Matcher) -> object:
     assert e.exception_type is not None

--- a/src/trio/_tests/type_tests/raisesgroup.py
+++ b/src/trio/_tests/type_tests/raisesgroup.py
@@ -223,6 +223,8 @@ def check_triple_nested_raisesgroup() -> None:
 
 
 def check_check_typing() -> None:
+    # mypy issue is https://github.com/python/mypy/issues/18185
+
     # fmt: off
     # mypy raises an error on `assert_type`
     # pyright raises an error on `RaisesGroup(ValueError).check`

--- a/src/trio/_tests/type_tests/raisesgroup.py
+++ b/src/trio/_tests/type_tests/raisesgroup.py
@@ -19,8 +19,7 @@ def check_matcher_typevar_default(e: Matcher) -> object:
 
 
 def check_basic_contextmanager() -> None:
-    # One level of Group is correctly translated - except it's a BaseExceptionGroup
-    # instead of an ExceptionGroup.
+
     with RaisesGroup(ValueError) as e:
         raise ExceptionGroup("foo", (ValueError(),))
     assert_type(e.value, ExceptionGroup[ValueError])

--- a/src/trio/_tests/type_tests/raisesgroup.py
+++ b/src/trio/_tests/type_tests/raisesgroup.py
@@ -38,12 +38,14 @@ def check_basic_matches() -> None:
 
 
 def check_matches_with_different_exception_type() -> None:
-    # TODO: This should probably raise some type error somewhere, since
-    # ValueError != KeyboardInterrupt
     e: BaseExceptionGroup[KeyboardInterrupt] = BaseExceptionGroup(
         "",
         (KeyboardInterrupt(),),
     )
+
+    # note: it might be tempting to have this warn.
+    # however, note that we should not warn if e: BaseException
+    # .... therefore this needs to pass as there is no distinction
     if RaisesGroup(ValueError).matches(e):
         assert_type(e, ExceptionGroup[ValueError])
 

--- a/src/trio/_tests/type_tests/raisesgroup.py
+++ b/src/trio/_tests/type_tests/raisesgroup.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sys
-from typing import Union
+from typing import Callable, Union
 
 from trio.testing import Matcher, RaisesGroup
 from typing_extensions import assert_type
@@ -44,8 +44,7 @@ def check_matches_with_different_exception_type() -> None:
     )
 
     # note: it might be tempting to have this warn.
-    # however, note that we should not warn if e: BaseException
-    # .... therefore this needs to pass as there is no distinction
+    # however, that isn't possible with current typing
     if RaisesGroup(ValueError).matches(e):
         assert_type(e, ExceptionGroup[ValueError])
 
@@ -221,3 +220,14 @@ def check_raisesgroup_overloads() -> None:
 def check_triple_nested_raisesgroup() -> None:
     with RaisesGroup(RaisesGroup(RaisesGroup(ValueError))) as e:
         assert_type(e.value, ExceptionGroup[ExceptionGroup[ExceptionGroup[ValueError]]])
+
+
+def check_check_typing() -> None:
+    assert_type(  # type: ignore
+        RaisesGroup(ValueError).check,
+        Union[
+            Callable[[BaseExceptionGroup[ValueError]], None],
+            Callable[[ExceptionGroup[ValueError]], None],
+            None,
+        ],
+    )

--- a/src/trio/testing/_raises_group.py
+++ b/src/trio/testing/_raises_group.py
@@ -42,8 +42,6 @@ E3 = TypeVar("E3", bound=BaseException)
 Ec2 = TypeVar("Ec2", bound=Exception)
 Ec3 = TypeVar("Ec3", bound=Exception)
 
-# These typevars are special cased in sphinx config to workaround lookup bugs.
-
 if sys.version_info < (3, 11):
     from exceptiongroup import BaseExceptionGroup, ExceptionGroup
 

--- a/src/trio/testing/_raises_group.py
+++ b/src/trio/testing/_raises_group.py
@@ -151,7 +151,7 @@ def _stringify_exception(exc: BaseException) -> str:
 
 
 # String patterns default to including the unicode flag.
-_REGEX_NO_FLAGS = re.compile("").flags
+_REGEX_NO_FLAGS = re.compile(r"").flags
 
 
 @final

--- a/src/trio/testing/_raises_group.py
+++ b/src/trio/testing/_raises_group.py
@@ -39,7 +39,6 @@ else:
 E = TypeVar("E", bound=BaseException, covariant=True)
 E2 = TypeVar("E2", bound=BaseException)
 E3 = TypeVar("E3", bound=BaseException)
-Ec = TypeVar("Ec", bound=Exception)
 Ec2 = TypeVar("Ec2", bound=Exception)
 Ec3 = TypeVar("Ec3", bound=Exception)
 
@@ -480,7 +479,7 @@ class RaisesGroup(
                 )
 
     @overload
-    def __enter__(self: RaisesGroup[Ec]) -> ExceptionInfo[ExceptionGroup[Ec]]: ...
+    def __enter__(self: RaisesGroup[Ec2]) -> ExceptionInfo[ExceptionGroup[Ec2]]: ...
     @overload
     def __enter__(
         self: RaisesGroup[BaseException],
@@ -506,9 +505,9 @@ class RaisesGroup(
 
     @overload
     def matches(
-        self: RaisesGroup[Ec],
+        self: RaisesGroup[Ec2],
         exc_val: BaseException | None,
-    ) -> TypeGuard[ExceptionGroup[Ec]]: ...
+    ) -> TypeGuard[ExceptionGroup[Ec2]]: ...
     @overload
     def matches(
         self: RaisesGroup[BaseException],

--- a/src/trio/testing/_raises_group.py
+++ b/src/trio/testing/_raises_group.py
@@ -419,7 +419,6 @@ class RaisesGroup(
         allow_unwrapped: bool = False,
         flatten_subgroups: bool = False,
         match: str | Pattern[str] | None = None,
-        # NOTE: I don't think the following argument type *should* work. But it does!
         check: (
             Callable[[BaseExceptionGroup[BaseExcT_1]], bool]
             | Callable[[ExceptionGroup[ExcT_1]], bool]

--- a/src/trio/testing/_raises_group.py
+++ b/src/trio/testing/_raises_group.py
@@ -259,9 +259,7 @@ class Matcher(Generic[MatchE]):
 
 
 @final
-class RaisesGroup(
-    Generic[BaseExcT_co],
-):
+class RaisesGroup(Generic[BaseExcT_co]):
     """Contextmanager for checking for an expected `ExceptionGroup`.
     This works similar to ``pytest.raises``, and a version of it will hopefully be added upstream, after which this can be deprecated and removed. See https://github.com/pytest-dev/pytest/issues/11538
 

--- a/src/trio/testing/_raises_group.py
+++ b/src/trio/testing/_raises_group.py
@@ -412,7 +412,6 @@ class RaisesGroup(
             | None
         ) = None,
     ):
-        check = None
         self.expected_exceptions: tuple[
             type[E] | Matcher[E] | RaisesGroup[BaseException],
             ...,


### PR DESCRIPTION
@jakkdl because you wrote this / these comments

This should fix the typing weirdness around it. I didn't really look too hard at things originally so there might be some outdated comments.

Maybe also @TeamSpen210 because types

... also this might be easier to review commit by commit. I tried my best to keep things separated (eg staging hunks so that only related pieces were in a single commit). However, I did not run mypy / tests after every single commit so things may be broken after a commit.