### PR TITLE
Bump Ruff to 0.8.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.4
+    rev: v0.8.0
     hooks:
       - id: ruff
         types: [file]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,15 +125,13 @@ select = [
     "Q",     # flake8-quotes
     "RUF",   # Ruff-specific rules
     "SIM",   # flake8-simplify
-    "TCH",   # flake8-type-checking
+    "TC",    # flake8-type-checking
     "UP",    # pyupgrade
     "W",     # Warning
     "YTT",   # flake8-2020
 ]
 extend-ignore = [
     'A002',    # builtin-argument-shadowing
-    'ANN101',  # missing-type-self
-    'ANN102',  # missing-type-cls
     'ANN401',  # any-type (mypy's `disallow_any_explicit` is better)
     'E402',    # module-import-not-at-top-of-file (usually OS-specific)
     'E501',    # line-too-long

--- a/src/trio/_dtls.py
+++ b/src/trio/_dtls.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
     from types import TracebackType
 
     # See DTLSEndpoint.__init__ for why this is imported here
-    from OpenSSL import SSL  # noqa: TCH004
+    from OpenSSL import SSL  # noqa: TC004
     from typing_extensions import Self, TypeAlias, TypeVarTuple, Unpack
 
     from trio._socket import AddressFormat

--- a/src/trio/_socket.py
+++ b/src/trio/_socket.py
@@ -12,7 +12,6 @@ from socket import AddressFamily, SocketKind
 from typing import (
     TYPE_CHECKING,
     Any,
-    Literal,
     SupportsIndex,
     TypeVar,
     Union,
@@ -337,7 +336,7 @@ if sys.platform == "win32":
     TypeT: TypeAlias = int
     FamilyDefault = _stdlib_socket.AF_INET
 else:
-    FamilyDefault: Literal[None] = None
+    FamilyDefault: None = None
     FamilyT: TypeAlias = Union[int, AddressFamily, None]
     TypeT: TypeAlias = Union[_stdlib_socket.socket, int]
 

--- a/src/trio/_subprocess_platform/__init__.py
+++ b/src/trio/_subprocess_platform/__init__.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 import trio
 
 from .. import _core, _subprocess
-from .._abc import ReceiveStream, SendStream  # noqa: TCH001
+from .._abc import ReceiveStream, SendStream  # noqa: TC001
 
 _wait_child_exiting_error: ImportError | None = None
 _create_child_pipe_error: ImportError | None = None

--- a/src/trio/_tests/test_testing_raisesgroup.py
+++ b/src/trio/_tests/test_testing_raisesgroup.py
@@ -353,9 +353,9 @@ def test_Matcher_check() -> None:
 def test_matcher_tostring() -> None:
     assert str(Matcher(ValueError)) == "Matcher(ValueError)"
     assert str(Matcher(match="[a-z]")) == "Matcher(match='[a-z]')"
-    pattern_no_flags = re.compile("noflag", 0)
+    pattern_no_flags = re.compile(r"noflag", 0)
     assert str(Matcher(match=pattern_no_flags)) == "Matcher(match='noflag')"
-    pattern_flags = re.compile("noflag", re.IGNORECASE)
+    pattern_flags = re.compile(r"noflag", re.IGNORECASE)
     assert str(Matcher(match=pattern_flags)) == f"Matcher(match={pattern_flags!r})"
     assert (
         str(Matcher(ValueError, match="re", check=bool))

--- a/src/trio/_tests/test_threads.py
+++ b/src/trio/_tests/test_threads.py
@@ -220,7 +220,7 @@ async def test_named_thread() -> None:
     # test that you can set a custom name, and that it's reset afterwards
     async def test_thread_name(name: str) -> None:
         thread = await to_thread_run_sync(f(name), thread_name=name)
-        assert re.match("Trio thread [0-9]*", thread.name)
+        assert re.match(r"Trio thread [0-9]*", thread.name)
 
     await test_thread_name("")
     await test_thread_name("fobiedoo")
@@ -301,7 +301,7 @@ async def test_named_thread_os() -> None:
 
         os_thread_name = _get_thread_name(thread.ident)
         assert os_thread_name is not None, "should skip earlier if this is the case"
-        assert re.match("Trio thread [0-9]*", os_thread_name)
+        assert re.match(r"Trio thread [0-9]*", os_thread_name)
 
     await test_thread_name("")
     await test_thread_name("fobiedoo")

--- a/src/trio/testing/_raises_group.py
+++ b/src/trio/testing/_raises_group.py
@@ -147,7 +147,7 @@ def _stringify_exception(exc: BaseException) -> str:
 
 
 # String patterns default to including the unicode flag.
-_regex_no_flags = re.compile("").flags
+_regex_no_flags = re.compile(r"").flags
 
 
 @final

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -13,7 +13,7 @@ cryptography>=41.0.0  # cryptography<41 segfaults on pypy3.10
 black; implementation_name == "cpython"
 mypy  # Would use mypy[faster-cache], but orjson has build issues on pypy
 orjson; implementation_name == "cpython"
-ruff >= 0.6.6
+ruff >= 0.8.0
 astor          # code generation
 uv >= 0.2.24
 codespell

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -113,7 +113,7 @@ pytest==8.3.3
     # via -r test-requirements.in
 requests==2.32.3
     # via sphinx
-ruff==0.7.3
+ruff==0.8.0
     # via -r test-requirements.in
 sniffio==1.3.1
     # via -r test-requirements.in


### PR DESCRIPTION
Hi! I just released Ruff 0.8.0. This release removes a few rules that had been deprecated for a few releases, so Ruff 0.8.0 would have started emitting warnings when linting trio due to the fact that you have some of these now-removed rules explicitly ignored in your Ruff config.

This PR gets rid of the removed rules from your Ruff config. There's also some additional changes made here; let me know if any of them are undesirable, and I can revert them:
- Some changes due to the recoding of the `flake8-type-checking` rules from `TCH` to `TC`
- Some changes due to the addition of the preview rule [`unraw-re-pattern`](https://docs.astral.sh/ruff/rules/unraw-re-pattern/)
- Some changes due to the addition of the preview rule [`redundant-none-literal`](https://docs.astral.sh/ruff/rules/redundant-none-literal/)