### PR TITLE
Remove unnecessary deadsnakes action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,16 +118,10 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup python
         uses: actions/setup-python@v5
-        if: "!endsWith(matrix.python, '-dev')"
         with:
           python-version: ${{ fromJSON(format('["{0}", "{1}"]', format('{0}.0-alpha - {0}.X', matrix.python), matrix.python))[startsWith(matrix.python, 'pypy')] }}
           cache: pip
           cache-dependency-path: test-requirements.txt
-      - name: Setup python (dev)
-        uses: deadsnakes/action@v2.0.2
-        if: endsWith(matrix.python, '-dev')
-        with:
-          python-version: '${{ matrix.python }}'
       - name: Run tests
         run: ./ci.sh
         env:


### PR DESCRIPTION
I was looking at bumping actions versions, but everything is already up to date. The only action that had an older version was this deadsnakes action (and the codecov action we're having trouble with), and we managed to test 3.13 pre-releases without it (by specifying `3.13` on all matrixes).

Therefore I removed it. If that only works after a beta CPython release, then we can readd this.