### PR TITLE
Update ignored branches for GHA's push trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,9 @@ name: CI
 on:
   push:
     branches-ignore:
-      - "dependabot/**"
+      - gh-readonly-queue/**
+      - autodeps/**
+      - pre-commit-ci-update-config
   pull_request:
   merge_group:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,10 @@ name: CI
 on:
   push:
     branches-ignore:
-      - gh-readonly-queue/**
-      - autodeps/**
-      - pre-commit-ci-update-config
+      # these branches always have another event associated
+      - gh-readonly-queue/**        # GitHub's merge queue uses `merge_group`
+      - autodeps/**                 # autodeps always makes a PR
+      - pre-commit-ci-update-config # pre-commit.ci's updates always have a PR
   pull_request:
   merge_group:
 


### PR DESCRIPTION
Based on conversation with @webknjaz on Gitter. This ignores pushes on:
 - autodeps
 - gh's merge queue
 - pre-commit.ci's update branch

This trigger is here so people can test their changes against CI without making a PR. The above types of PRs do not need this extra testing, as they will always have a PR (or more generally another event, for gh's merge queue) associated.