### PR TITLE
💄 Refactor the coveragepy config

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,7 +6,7 @@ codecov:
   notify:
     # This number needs to be changed whenever the number of runs in CI is changed.
     # Another option is codecov-cli: https://github.com/codecov/codecov-cli#send-notifications
-    after_n_builds: 27
+    after_n_builds: 31
     wait_for_ci: false
     notify_error: true # if uploads fail, replace cov comment with a comment with errors.
   require_ci_to_pass: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,15 +234,34 @@ jobs:
             cache: pip
         # setuptools is needed to get distutils on 3.12, which cythonize requires
       - name: install trio and setuptools
-        run: python -m pip install --upgrade pip . setuptools
+        run: python -m pip install --upgrade pip . setuptools 'coverage[toml]'
+
+      - name: add cython plugin to the coveragepy config
+        run: >-
+          sed -i 's#plugins\s=\s\[\]#plugins = ["Cython.Coverage"]#'
+          pyproject.toml
 
       - name: install cython & compile pyx file
+        env:
+          CFLAGS: ${{ env.CFLAGS }} -DCYTHON_TRACE_NOGIL=1
         run: |
           python -m pip install "cython${{ matrix.cython }}"
-          cythonize --inplace tests/cython/test_cython.pyx
+          cythonize --inplace -X linetrace=True tests/cython/test_cython.pyx
 
       - name: import & run module
-        run: python -c 'import tests.cython.test_cython'
+        run: coverage run -m tests.cython.run_test_cython
+
+      - name: get Python version for codecov flag
+        id: get-version
+        run: >-
+          echo "version=$(python -V | cut -d' ' -f2 | cut -d'.' -f1,2)"
+          >> "${GITHUB_OUTPUT}"
+      - if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          name: Cython
+          flags: Cython,${{ steps.get-version.outputs.version }}
+          fail_ci_if_error: true
 
   # https://github.com/marketplace/actions/alls-green#why
   check:  # This job does nothing and is only used for the branch protection

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -268,6 +268,10 @@ directory = "misc"
 name = "Miscellaneous internal changes"
 showcontent = true
 
+[tool.coverage.html]
+show_contexts = true
+skip_covered = false
+
 [tool.coverage.run]
 branch = true
 source_pkgs = ["trio"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -291,6 +291,8 @@ relative_files = true
 [tool.coverage.report]
 precision = 1
 skip_covered = true
+skip_empty = true
+show_missing = true
 exclude_lines = [
     "pragma: no cover",
     "abc.abstractmethod",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -272,6 +272,16 @@ showcontent = true
 show_contexts = true
 skip_covered = false
 
+[tool.coverage.paths]
+_site-packages-to-src-mapping = [
+  "src",
+  "*/src",
+  '*\src',
+  "*/lib/pypy*/site-packages",
+  "*/lib/python*/site-packages",
+  '*\Lib\site-packages',
+]
+
 [tool.coverage.run]
 branch = true
 source_pkgs = ["trio"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -296,6 +296,7 @@ omit = [
 # The test suite spawns subprocesses to test some stuff, so make sure
 # this doesn't corrupt the coverage files
 parallel = true
+plugins = []
 relative_files = true
 source = ["."]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -287,6 +287,7 @@ omit = [
 # this doesn't corrupt the coverage files
 parallel = true
 relative_files = true
+source = ["."]
 
 [tool.coverage.report]
 precision = 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -303,6 +303,9 @@ exclude_lines = [
     'class .*\bProtocol\b.*\):',
     "raise NotImplementedError",
 ]
+exclude_also = [
+  '^\s*@pytest\.mark\.xfail',
+]
 partial_branches = [
     "pragma: no branch",
     "if not TYPE_CHECKING:",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -286,6 +286,7 @@ omit = [
 # The test suite spawns subprocesses to test some stuff, so make sure
 # this doesn't corrupt the coverage files
 parallel = true
+relative_files = true
 
 [tool.coverage.report]
 precision = 1

--- a/tests/cython/run_test_cython.py
+++ b/tests/cython/run_test_cython.py
@@ -1,0 +1,3 @@
+from .test_cython import invoke_main_entry_point
+
+invoke_main_entry_point()

--- a/tests/cython/test_cython.pyx
+++ b/tests/cython/test_cython.pyx
@@ -19,4 +19,5 @@ async def trio_main() -> None:
         nursery.start_soon(foo)
         nursery.start_soon(foo)
 
-trio.run(trio_main)
+def invoke_main_entry_point():
+    trio.run(trio_main)


### PR DESCRIPTION
This is a combination of changes that include:
- setting up local coveragepy HTML output to show context
- setting up mapping between site-packages and the repo
- measuring all the Python files in the repo
- including Cython
- making xfails not influence the coverage metric (these test functions may start executing different amounts of lines over time, causing random coverage drops/gains)
- using relative paths for playing nice with Codecov