### PR TITLE
Explain why our MacOS 14 runners failed with CPython 3.13.1

### DIFF
--- a/src/trio/_tests/test_highlevel_socket.py
+++ b/src/trio/_tests/test_highlevel_socket.py
@@ -20,12 +20,6 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
 
-@pytest.mark.xfail(
-    sys.platform == "darwin" and sys.version_info[:3] == (3, 13, 1),
-    reason="TODO: This started failing in CI after 3.13.1",
-    raises=OSError,
-    strict=True,
-)
 async def test_SocketStream_basics() -> None:
     # stdlib socket bad (even if connected)
     stdlib_a, stdlib_b = stdlib_socket.socketpair()


### PR DESCRIPTION
There's two possible solutions that I see:
 - set our `runs-on` to be `macos-15`
 - ignore the error, it's not showing something bad anyways

Since the first one is somewhat annoying (we would change it back to `macos-latest` at some point and local tests would fail for people), the second one is ideal. So I implemented that here.