### PR TITLE
Add a sanity check for a missing `derive` for exception groups

### DIFF
--- a/newsfragments/3175.doc.rst
+++ b/newsfragments/3175.doc.rst
@@ -1,0 +1,1 @@
+Warn if a user forgot to implement ``.derive`` for an ExceptionGroup subclass.

--- a/src/trio/_core/_run.py
+++ b/src/trio/_core/_run.py
@@ -639,6 +639,31 @@ class CancelScope:
                 self.cancelled_caught = True
                 exc = None
             elif isinstance(exc, BaseExceptionGroup):
+                # sanity check users
+                egs = [exc]
+                visited = set()
+                while egs:
+                    next_eg = egs.pop()
+                    if next_eg in visited:
+                        continue
+                    visited.add(next_eg)
+                    if (
+                        "derive" not in type(next_eg).__dict__
+                        and type(next_eg) is not ExceptionGroup
+                    ):
+                        warnings.warn(
+                            f"derive not implemented for {type(next_eg).__name__}, results may be unexpected",
+                            stacklevel=1,
+                        )
+
+                    egs.extend(
+                        [
+                            e
+                            for e in next_eg.exceptions
+                            if isinstance(e, BaseExceptionGroup)
+                        ]
+                    )
+
                 matched, exc = exc.split(Cancelled)
                 if matched:
                     self.cancelled_caught = True

--- a/src/trio/_core/_run.py
+++ b/src/trio/_core/_run.py
@@ -52,7 +52,7 @@ from ._traps import (
 )
 
 if sys.version_info < (3, 11):
-    from exceptiongroup import BaseExceptionGroup
+    from exceptiongroup import BaseExceptionGroup, ExceptionGroup
 
 
 if TYPE_CHECKING:

--- a/src/trio/_core/_tests/test_run.py
+++ b/src/trio/_core/_tests/test_run.py
@@ -10,7 +10,7 @@ import types
 import weakref
 from contextlib import ExitStack, contextmanager, suppress
 from math import inf, nan
-from typing import TYPE_CHECKING, NoReturn, Self, TypeVar
+from typing import TYPE_CHECKING, NoReturn, TypeVar
 from unittest import mock
 
 import outcome
@@ -46,6 +46,8 @@ if TYPE_CHECKING:
         Generator,
         Sequence,
     )
+
+    from typing_extensions import Self
 
 if sys.version_info < (3, 11):
     from exceptiongroup import BaseExceptionGroup, ExceptionGroup
@@ -2859,7 +2861,7 @@ def test_context_run_tb_frames() -> None:
 
 
 def test_run_with_custom_exception_group() -> None:
-    class ExceptionGroupForTest(ExceptionGroup):
+    class ExceptionGroupForTest(ExceptionGroup[Exception]):
         @staticmethod
         def for_test(message: str, excs: list[Exception]) -> ExceptionGroupForTest:
             raise NotImplementedError()
@@ -2876,7 +2878,7 @@ def test_run_with_custom_exception_group() -> None:
             raise exception_group_type.for_test("test message", [ValueError("uh oh")])
 
     class HasDerive(ExceptionGroupForTest):
-        def derive(self, excs: Sequence[BaseException]) -> HasDerive:
+        def derive(self, excs: Sequence[Exception]) -> HasDerive:
             return HasDerive(self.message, excs)
 
         @staticmethod
@@ -2897,7 +2899,7 @@ def test_run_with_custom_exception_group() -> None:
             return AbnormalNew(excs)
 
     for check in (check1, check2, check3):
-        for error in (HasDerive, NormalNew, AbnormalNew):
+        for error in [HasDerive, NormalNew, AbnormalNew]:
             if check is check3:
                 if error in (NormalNew, AbnormalNew):
                     with (


### PR DESCRIPTION
Fixes https://github.com/python-trio/trio/issues/3175, probably.

Just adds a sanity check. I started thinking about doing our own `.split()` but then I decided that's a lot. I also looked at just using `.derive` at the end but the exception groups without `.derive()` can be anywhere in the exception group contents.

I made https://github.com/python-trio/flake8-async/issues/334 for the linter rule side of this, but I think this is probably easy enough to forget especially if trying out this feature (and easy to overlook).