### PR TITLE
add now required sphinx.configuration in readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,3 +16,4 @@ python:
 
 sphinx:
   fail_on_warning: true
+  configuration: docs/source/conf.py


### PR DESCRIPTION
see https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/