### PR TITLE
Publically re-export `__version__`

### DIFF
--- a/newsfragments/3186.misc.rst
+++ b/newsfragments/3186.misc.rst
@@ -1,0 +1,1 @@
+Publicly re-export ``__version__`` for type checking purposes.

--- a/src/trio/__init__.py
+++ b/src/trio/__init__.py
@@ -104,9 +104,6 @@ from ._timeouts import (
     sleep_forever as sleep_forever,
     sleep_until as sleep_until,
 )
-
-# pyright explicitly does not care about `__version__`
-# see https://github.com/microsoft/pyright/blob/main/docs/typed-libraries.md#type-completeness
 from ._version import __version__ as __version__
 
 # Not imported by default, but mentioned here so static analysis tools like

--- a/src/trio/__init__.py
+++ b/src/trio/__init__.py
@@ -107,7 +107,7 @@ from ._timeouts import (
 
 # pyright explicitly does not care about `__version__`
 # see https://github.com/microsoft/pyright/blob/main/docs/typed-libraries.md#type-completeness
-from ._version import __version__
+from ._version import __version__ as __version__
 
 # Not imported by default, but mentioned here so static analysis tools like
 # pylint will know that it exists.


### PR DESCRIPTION
In this pull request, we publicly re-export `__version__`. This came up when working on https://github.com/python-trio/trio-websocket/pull/193, where some of the unit test code looks at Trio's version for version-dependent things and mypy is not happy about accessing `__version__`.