### PR TITLE
Deprecate `trio.__version__`

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,6 +13,7 @@ build:
 python:
   install:
     - requirements: docs-requirements.txt
+    - path: .
 
 sphinx:
   fail_on_warning: true

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -315,9 +315,9 @@ author = "Nathaniel J. Smith"
 # built documents.
 #
 # The short X.Y version.
-import trio
+import importlib.metadata
 
-version = trio.__version__
+version = importlib.metadata.version("trio")
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/newsfragments/3190.deprecated.rst
+++ b/newsfragments/3190.deprecated.rst
@@ -1,0 +1,1 @@
+Deprecate ``trio.__version__`` in favor of `importlib.metadata.version`.

--- a/src/trio/__init__.py
+++ b/src/trio/__init__.py
@@ -104,7 +104,7 @@ from ._timeouts import (
     sleep_forever as sleep_forever,
     sleep_until as sleep_until,
 )
-from ._version import __version__ as trio_version
+from ._version import __version__ as __version__
 
 # Not imported by default, but mentioned here so static analysis tools like
 # pylint will know that it exists.
@@ -117,9 +117,12 @@ _deprecate.enable_attribute_deprecations(__name__)
 
 __deprecated_attributes__: dict[str, _deprecate.DeprecatedAttribute] = {
     "__version__": _deprecate.DeprecatedAttribute(
-        trio_version, "0.29.0", issue=None, instead='importlib.metadata.version("trio")'
+        __version__, "0.29.0", issue=None, instead='importlib.metadata.version("trio")'
     )
 }
+
+if not TYPE_CHECKING:
+    del __version__
 
 # Having the public path in .__module__ attributes is important for:
 # - exception names in printed tracebacks

--- a/src/trio/__init__.py
+++ b/src/trio/__init__.py
@@ -115,7 +115,11 @@ from . import _deprecate as _deprecate
 
 _deprecate.enable_attribute_deprecations(__name__)
 
-__deprecated_attributes__: dict[str, _deprecate.DeprecatedAttribute] = {}
+__deprecated_attributes__: dict[str, _deprecate.DeprecatedAttribute] = {
+    "__version__": _deprecate.DeprecatedAttribute(
+        __version__, "0.29.0", issue=None, instead='importlib.metadata.version("trio")'
+    )
+}
 
 # Having the public path in .__module__ attributes is important for:
 # - exception names in printed tracebacks

--- a/src/trio/__init__.py
+++ b/src/trio/__init__.py
@@ -104,7 +104,7 @@ from ._timeouts import (
     sleep_forever as sleep_forever,
     sleep_until as sleep_until,
 )
-from ._version import __version__ as __version__
+from ._version import __version__ as trio_version
 
 # Not imported by default, but mentioned here so static analysis tools like
 # pylint will know that it exists.
@@ -117,7 +117,7 @@ _deprecate.enable_attribute_deprecations(__name__)
 
 __deprecated_attributes__: dict[str, _deprecate.DeprecatedAttribute] = {
     "__version__": _deprecate.DeprecatedAttribute(
-        __version__, "0.29.0", issue=None, instead='importlib.metadata.version("trio")'
+        trio_version, "0.29.0", issue=None, instead='importlib.metadata.version("trio")'
     )
 }
 

--- a/src/trio/_tests/test_trio.py
+++ b/src/trio/_tests/test_trio.py
@@ -6,3 +6,12 @@ def test_trio_import() -> None:
             del sys.modules[module]
 
     import trio  # noqa: F401
+
+
+def test_trio_version_deprecated() -> None:
+    import pytest
+
+    import trio
+
+    with pytest.warns(DeprecationWarning, match="^trio.__version__ is deprecated"):
+        _ = trio.__version__

--- a/src/trio/_tests/type_tests/trio_version.py
+++ b/src/trio/_tests/type_tests/trio_version.py
@@ -1,0 +1,4 @@
+import trio
+from typing_extensions import assert_type
+
+assert_type(trio.__version__, str)


### PR DESCRIPTION
Follow up to https://github.com/python-trio/trio/pull/3186