### PR TITLE
Update type hint for the `CancelStatus.parent` setter

### DIFF
--- a/src/trio/_core/_run.py
+++ b/src/trio/_core/_run.py
@@ -378,7 +378,7 @@ class CancelStatus:
         return self._parent
 
     @parent.setter
-    def parent(self, parent: CancelStatus) -> None:
+    def parent(self, parent: CancelStatus | None) -> None:
         if self._parent is not None:
             self._parent._children.remove(self)
         self._parent = parent


### PR DESCRIPTION
Type hint issue spotted in https://github.com/python/mypy/pull/18510

Maybe we should wait for that to be merged (and maybe released?) to check this works.