### PR TITLE
Use importlib.metadata in docs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,6 +13,7 @@ build:
 python:
   install:
     - requirements: docs-requirements.txt
+    - path: .
 
 sphinx:
   fail_on_warning: true

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -31,8 +31,6 @@ if TYPE_CHECKING:
 
 # For our local_customization module
 sys.path.insert(0, os.path.abspath("."))
-# For trio itself
-sys.path.insert(0, os.path.abspath("../../src"))
 
 # Enable reloading with `typing.TYPE_CHECKING` being True
 os.environ["SPHINX_AUTODOC_RELOAD_MODULES"] = "1"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -315,9 +315,9 @@ author = "Nathaniel J. Smith"
 # built documents.
 #
 # The short X.Y version.
-import trio
+import importlib.metadata
 
-version = trio.__version__
+version = importlib.metadata.version("trio")
 # The full version, including alpha/beta/rc tags.
 release = version
 


### PR DESCRIPTION
This also makes RTD install trio instead of depending on `import trio` working. IMO this is more correct.

Supersedes https://github.com/python-trio/trio/pull/3190.