### PR TITLE
Clear worker thread cache after forking

### DIFF
--- a/newsfragments/2764.bugfix.rst
+++ b/newsfragments/2764.bugfix.rst
@@ -1,0 +1,1 @@
+Clear Trio's cache of worker threads upon `os.fork`.

--- a/src/trio/_core/_tests/test_thread_cache.py
+++ b/src/trio/_core/_tests/test_thread_cache.py
@@ -200,6 +200,8 @@ def test_raise_in_deliver(capfd: pytest.CaptureFixture[str]) -> None:
 
 @pytest.mark.skipif(not hasattr(os, "fork"), reason="os.fork isn't supported")
 def test_clear_thread_cache_after_fork() -> None:
+    assert hasattr(os, "fork")
+
     def foo() -> None:
         pass
 
@@ -217,4 +219,4 @@ def test_clear_thread_cache_after_fork() -> None:
 
     if child_pid != 0:
         # if this test fails, this will hang, triggering a timeout.
-        os.wait4(child_pid, 0)
+        os.waitpid(child_pid, 0)

--- a/src/trio/_core/_tests/test_thread_cache.py
+++ b/src/trio/_core/_tests/test_thread_cache.py
@@ -220,3 +220,5 @@ def test_clear_thread_cache_after_fork() -> None:
     if child_pid != 0:
         # if this test fails, this will hang, triggering a timeout.
         os.waitpid(child_pid, 0)
+    else:
+        os._exit(0)

--- a/src/trio/_core/_tests/test_thread_cache.py
+++ b/src/trio/_core/_tests/test_thread_cache.py
@@ -221,14 +221,22 @@ def test_clear_thread_cache_after_fork() -> None:
         # if this test fails, this will hang, triggering a timeout.
         os.waitpid(child_pid, 0)
     else:
+        # this is necessary because os._exit doesn't unwind the stack,
+        # so coverage doesn't get to automatically stop and save
+        # coverage information.
         try:
             import coverage
 
             cov = coverage.Coverage.current()
+            # the following pragmas are necessary because if coverage:
+            #  - isn't running, then it can't record the branch not
+            #    taken
+            #  - isn't installed, then it can't record the ImportError
+
             if cov:  # pragma: no branch
                 cov.stop()
                 cov.save()
         except ImportError:  # pragma: no cover
             pass
 
-        os._exit(0)  # pragma: no cover
+        os._exit(0)  # pragma: no cover  # coverage was stopped above.

--- a/src/trio/_core/_tests/test_thread_cache.py
+++ b/src/trio/_core/_tests/test_thread_cache.py
@@ -221,4 +221,14 @@ def test_clear_thread_cache_after_fork() -> None:
         # if this test fails, this will hang, triggering a timeout.
         os.waitpid(child_pid, 0)
     else:
+        try:
+            import coverage
+
+            cov = coverage.Coverage.current()
+            if cov:
+                cov.stop()
+                cov.save()
+        except ImportError:
+            pass
+
         os._exit(0)

--- a/src/trio/_core/_tests/test_thread_cache.py
+++ b/src/trio/_core/_tests/test_thread_cache.py
@@ -225,10 +225,10 @@ def test_clear_thread_cache_after_fork() -> None:
             import coverage
 
             cov = coverage.Coverage.current()
-            if cov:
+            if cov:  # pragma: no branch
                 cov.stop()
                 cov.save()
-        except ImportError:
+        except ImportError:  # pragma: no cover
             pass
 
-        os._exit(0)
+        os._exit(0)  # pragma: no cover

--- a/src/trio/_core/_thread_cache.py
+++ b/src/trio/_core/_thread_cache.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ctypes
 import ctypes.util
+import os
 import sys
 import traceback
 from functools import partial
@@ -301,3 +302,15 @@ def start_thread_soon(
 
     """
     THREAD_CACHE.start_thread_soon(fn, deliver, name)
+
+
+def clear_worker_threads() -> None:
+    # This is OK because the child process does not actually have any
+    # worker threads. Additionally, while WorkerThread keeps a strong
+    # reference and so would get affected, the only place those are
+    # stored is here.
+    THREAD_CACHE._idle_workers.clear()
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=clear_worker_threads)


### PR DESCRIPTION
Fixes https://github.com/python-trio/trio/issues/2764

While we don't provide any sort of guarantees and I think it's tempting to give up on this:
 - Python (3.12+) will already warn on this, so they have that handled
 - It's friendlier to do the right thing.

As long as people aren't initializing their own thread caches, this should be fine.