### PR TITLE
Update to mypy 1.15

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,7 @@ repos:
     hooks:
       - id: codespell
         additional_dependencies:
+          # tomli needed on 3.10. tomllib is available in stdlib on 3.11+
           - tomli
   - repo: https://github.com/crate-ci/typos
     rev: typos-dict-v0.12.4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,8 @@ repos:
     rev: v2.4.1
     hooks:
       - id: codespell
+        additional_dependencies:
+          - tomli
   - repo: https://github.com/crate-ci/typos
     rev: typos-dict-v0.12.4
     hooks:

--- a/newsfragments/3201.misc.rst
+++ b/newsfragments/3201.misc.rst
@@ -3,3 +3,8 @@ match that of the stdlib `socket.getaddrinfo`, which was updated in mypy 1.15 (v
 a typeshed update) to include the possibility of ``tuple[int, bytes]`` for the
 ``sockaddr`` field of the result. This happens in situations where Python was compiled
 with ``--disable-ipv6``.
+
+Additionally, when using mypy 1.15, the static typing of
+:func:`trio.to_thread.run_sync`, :func:`trio.from_thread.run` and
+:func:`trio.from_thread.run_sync` has been improved and should reflect the underlying
+function being run.

--- a/newsfragments/3201.misc.rst
+++ b/newsfragments/3201.misc.rst
@@ -1,0 +1,5 @@
+The typing of :func:`trio.abc.HostnameResolver.getaddrinfo` has been corrected to
+match that of the stdlib `socket.getaddrinfo`, which was updated in mypy 1.15 (via
+a typeshed update) to include the possibility of ``tuple[int, bytes]`` for the
+``sockaddr`` field of the result. This happens in situations where Python was compiled
+with ``--disable-ipv6``.

--- a/newsfragments/3201.misc.rst
+++ b/newsfragments/3201.misc.rst
@@ -4,7 +4,6 @@ a typeshed update) to include the possibility of ``tuple[int, bytes]`` for the
 ``sockaddr`` field of the result. This happens in situations where Python was compiled
 with ``--disable-ipv6``.
 
-Additionally, when using mypy 1.15, the static typing of
-:func:`trio.to_thread.run_sync`, :func:`trio.from_thread.run` and
-:func:`trio.from_thread.run_sync` has been improved and should reflect the underlying
-function being run.
+Additionally, the static typing of :func:`trio.to_thread.run_sync`,
+:func:`trio.from_thread.run` and :func:`trio.from_thread.run_sync` has been
+improved and should reflect the underlying function being run.

--- a/src/trio/_abc.py
+++ b/src/trio/_abc.py
@@ -178,7 +178,7 @@ class HostnameResolver(ABC):
             socket.SocketKind,
             int,
             str,
-            tuple[str, int] | tuple[str, int, int, int],
+            tuple[str, int] | tuple[str, int, int, int] | tuple[int, bytes],
         ]
     ]:
         """A custom implementation of :func:`~trio.socket.getaddrinfo`.

--- a/src/trio/_core/_entry_queue.py
+++ b/src/trio/_core/_entry_queue.py
@@ -16,8 +16,7 @@ if TYPE_CHECKING:
 
     PosArgsT = TypeVarTuple("PosArgsT")
 
-# Explicit "Any" is not allowed
-Function = Callable[..., object]  # type: ignore[misc]
+Function = Callable[..., object]  # type: ignore[explicit-any]
 Job = tuple[Function, tuple[object, ...]]
 
 

--- a/src/trio/_core/_instrumentation.py
+++ b/src/trio/_core/_instrumentation.py
@@ -10,17 +10,14 @@ from .._abc import Instrument
 INSTRUMENT_LOGGER = logging.getLogger("trio.abc.Instrument")
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Sequence
+    from collections.abc import Sequence
 
-    from typing_extensions import ParamSpec
-
-    P = ParamSpec("P")
     T = TypeVar("T")
 
 
 # Decorator to mark methods public. This does nothing by itself, but
 # trio/_tools/gen_exports.py looks for it.
-def _public(fn: Callable[P, T]) -> Callable[P, T]:
+def _public(fn: T) -> T:
     return fn
 
 

--- a/src/trio/_core/_instrumentation.py
+++ b/src/trio/_core/_instrumentation.py
@@ -2,23 +2,25 @@ from __future__ import annotations
 
 import logging
 import types
-from collections.abc import Callable, Sequence
-from typing import TypeVar
+from typing import TYPE_CHECKING, TypeVar
 
 from .._abc import Instrument
 
 # Used to log exceptions in instruments
 INSTRUMENT_LOGGER = logging.getLogger("trio.abc.Instrument")
 
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
 
-# Explicit "Any" is not allowed
-F = TypeVar("F", bound=Callable[..., object])  # type: ignore[misc]
+    from typing_extensions import ParamSpec
+
+    P = ParamSpec("P")
+    T = TypeVar("T")
 
 
 # Decorator to mark methods public. This does nothing by itself, but
 # trio/_tools/gen_exports.py looks for it.
-# Explicit "Any" is not allowed
-def _public(fn: F) -> F:  # type: ignore[misc]
+def _public(fn: Callable[P, T]) -> Callable[P, T]:
     return fn
 
 

--- a/src/trio/_core/_run.py
+++ b/src/trio/_core/_run.py
@@ -7,7 +7,6 @@ import itertools
 import random
 import select
 import sys
-import types
 import warnings
 from collections import deque
 from contextlib import AbstractAsyncContextManager, contextmanager, suppress
@@ -58,6 +57,7 @@ if sys.version_info < (3, 11):
 
 if TYPE_CHECKING:
     import contextvars
+    import types
     from collections.abc import (
         Awaitable,
         Callable,
@@ -1886,8 +1886,7 @@ class Runner:  # type: ignore[explicit-any]
                 return await orig_coro
 
             coro = python_wrapper(coro)
-        assert isinstance(coro, types.CoroutineType)
-        assert coro.cr_frame is not None, "Coroutine frame should exist"
+        assert coro.cr_frame is not None, "Coroutine frame should exist"  # type: ignore[attr-defined]
 
         ######
         # Set up the Task object

--- a/src/trio/_core/_run.py
+++ b/src/trio/_core/_run.py
@@ -7,6 +7,7 @@ import itertools
 import random
 import select
 import sys
+import types
 import warnings
 from collections import deque
 from contextlib import AbstractAsyncContextManager, contextmanager, suppress
@@ -57,7 +58,6 @@ if sys.version_info < (3, 11):
 
 if TYPE_CHECKING:
     import contextvars
-    import types
     from collections.abc import (
         Awaitable,
         Callable,
@@ -1886,7 +1886,8 @@ class Runner:  # type: ignore[explicit-any]
                 return await orig_coro
 
             coro = python_wrapper(coro)
-        assert coro.cr_frame is not None, "Coroutine frame should exist"  # type: ignore[attr-defined]
+        assert isinstance(coro, types.CoroutineType)
+        assert coro.cr_frame is not None, "Coroutine frame should exist"
 
         ######
         # Set up the Task object

--- a/src/trio/_core/_tests/test_ki.py
+++ b/src/trio/_core/_tests/test_ki.py
@@ -165,7 +165,7 @@ async def test_generator_based_context_manager_throw() -> None:
 async def test_async_generator_agen_protection() -> None:
     @_core.enable_ki_protection
     @async_generator  # type: ignore[misc] # untyped generator
-    async def agen_protected1() -> None:
+    async def agen_protected1() -> None:  # type: ignore[misc] # untyped generator
         assert _core.currently_ki_protected()
         try:
             await yield_()
@@ -174,7 +174,7 @@ async def test_async_generator_agen_protection() -> None:
 
     @_core.disable_ki_protection
     @async_generator  # type: ignore[misc] # untyped generator
-    async def agen_unprotected1() -> None:
+    async def agen_unprotected1() -> None:  # type: ignore[misc] # untyped generator
         assert not _core.currently_ki_protected()
         try:
             await yield_()
@@ -184,7 +184,7 @@ async def test_async_generator_agen_protection() -> None:
     # Swap the order of the decorators:
     @async_generator  # type: ignore[misc] # untyped generator
     @_core.enable_ki_protection
-    async def agen_protected2() -> None:
+    async def agen_protected2() -> None:  # type: ignore[misc] # untyped generator
         assert _core.currently_ki_protected()
         try:
             await yield_()
@@ -193,7 +193,7 @@ async def test_async_generator_agen_protection() -> None:
 
     @async_generator  # type: ignore[misc] # untyped generator
     @_core.disable_ki_protection
-    async def agen_unprotected2() -> None:
+    async def agen_unprotected2() -> None:  # type: ignore[misc] # untyped generator
         assert not _core.currently_ki_protected()
         try:
             await yield_()
@@ -677,9 +677,8 @@ async def _consume_async_generator(agen: AsyncGenerator[None, None]) -> None:
         await agen.aclose()
 
 
-# Explicit .../"Any" is not allowed
-def _consume_function_for_coverage(  # type: ignore[misc]
-    fn: Callable[..., object],
+def _consume_function_for_coverage(
+    fn: Callable[[], object],
 ) -> None:
     result = fn()
     if inspect.isasyncgen(result):

--- a/src/trio/_core/_tests/test_run.py
+++ b/src/trio/_core/_tests/test_run.py
@@ -1658,8 +1658,7 @@ async def test_spawn_name() -> None:
     async def func2() -> None:  # pragma: no cover
         pass
 
-    # Explicit .../"Any" is not allowed
-    async def check(  # type: ignore[misc]
+    async def check(  # type: ignore[explicit-any]
         spawn_fn: Callable[..., object],
     ) -> None:
         spawn_fn(func1, "func1")
@@ -1696,14 +1695,13 @@ async def test_current_effective_deadline(mock_clock: _core.MockClock) -> None:
 
 
 def test_nice_error_on_bad_calls_to_run_or_spawn() -> None:
-    # Explicit .../"Any" is not allowed
-    def bad_call_run(  # type: ignore[misc]
+    def bad_call_run(  # type: ignore[explicit-any]
         func: Callable[..., Awaitable[object]],
         *args: tuple[object, ...],
     ) -> None:
         _core.run(func, *args)
 
-    def bad_call_spawn(  # type: ignore[misc]
+    def bad_call_spawn(  # type: ignore[explicit-any]
         func: Callable[..., Awaitable[object]],
         *args: tuple[object, ...],
     ) -> None:

--- a/src/trio/_core/_thread_cache.py
+++ b/src/trio/_core/_thread_cache.py
@@ -215,8 +215,7 @@ class ThreadCache:
     __slots__ = ("_idle_workers",)
 
     def __init__(self) -> None:
-        # Explicit "Any" not allowed
-        self._idle_workers: dict[WorkerThread[Any], None] = {}  # type: ignore[misc]
+        self._idle_workers: dict[WorkerThread[Any], None] = {}  # type: ignore[explicit-any]
 
     def start_thread_soon(
         self,

--- a/src/trio/_core/_traps.py
+++ b/src/trio/_core/_traps.py
@@ -104,8 +104,7 @@ class Abort(enum.Enum):
 
 # Should always return the type a Task "expects", unless you willfully reschedule it
 # with a bad value.
-# Explicit "Any" is not allowed
-async def wait_task_rescheduled(  # type: ignore[misc]
+async def wait_task_rescheduled(  # type: ignore[explicit-any]
     abort_func: Callable[[RaiseCancelT], Abort],
 ) -> Any:
     """Put the current task to sleep, with cancellation support.

--- a/src/trio/_file_io.py
+++ b/src/trio/_file_io.py
@@ -428,7 +428,7 @@ async def open_file(
 
 
 @overload
-async def open_file(  # type: ignore[explicit-any,misc]  # Any usage matches builtins.open().
+async def open_file(  # type: ignore[explicit-any, misc]  # Any usage matches builtins.open().
     file: _OpenFile,
     mode: str,
     buffering: int = -1,

--- a/src/trio/_file_io.py
+++ b/src/trio/_file_io.py
@@ -428,7 +428,7 @@ async def open_file(
 
 
 @overload
-async def open_file(  # type: ignore[misc]  # Any usage matches builtins.open().
+async def open_file(  # type: ignore[explicit-any,misc]  # Any usage matches builtins.open().
     file: _OpenFile,
     mode: str,
     buffering: int = -1,

--- a/src/trio/_highlevel_open_tcp_stream.py
+++ b/src/trio/_highlevel_open_tcp_stream.py
@@ -8,7 +8,7 @@ import trio
 from trio.socket import SOCK_STREAM, SocketType, getaddrinfo, socket
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import Generator, MutableSequence
     from socket import AddressFamily, SocketKind
 
     from trio._socket import AddressFormat
@@ -134,9 +134,8 @@ def close_all() -> Generator[set[SocketType], None, None]:
             raise BaseExceptionGroup("", errs)
 
 
-# Explicit "Any" is not allowed
-def reorder_for_rfc_6555_section_5_4(  # type: ignore[misc]
-    targets: list[tuple[AddressFamily, SocketKind, int, str, Any]],
+def reorder_for_rfc_6555_section_5_4(  # type: ignore[explicit-any]
+    targets: MutableSequence[tuple[AddressFamily, SocketKind, int, str, Any]],
 ) -> None:
     # RFC 6555 section 5.4 says that if getaddrinfo returns multiple address
     # families (e.g. IPv4 and IPv6), then you should make sure that your first

--- a/src/trio/_highlevel_serve_listeners.py
+++ b/src/trio/_highlevel_serve_listeners.py
@@ -25,8 +25,7 @@ LOGGER = logging.getLogger("trio.serve_listeners")
 
 
 StreamT = TypeVar("StreamT", bound=trio.abc.AsyncResource)
-# Explicit "Any" is not allowed
-ListenerT = TypeVar("ListenerT", bound=trio.abc.Listener[Any])  # type: ignore[misc]
+ListenerT = TypeVar("ListenerT", bound=trio.abc.Listener[Any])  # type: ignore[explicit-any]
 Handler = Callable[[StreamT], Awaitable[object]]
 
 
@@ -68,8 +67,7 @@ async def _serve_one_listener(
 # https://github.com/python/typing/issues/548
 
 
-# Explicit "Any" is not allowed
-async def serve_listeners(  # type: ignore[misc]
+async def serve_listeners(  # type: ignore[explicit-any]
     handler: Handler[StreamT],
     listeners: list[ListenerT],
     *,

--- a/src/trio/_path.py
+++ b/src/trio/_path.py
@@ -30,8 +30,7 @@ if TYPE_CHECKING:
     T = TypeVar("T")
 
 
-# Explicit .../"Any" is not allowed
-def _wraps_async(  # type: ignore[misc]
+def _wraps_async(  # type: ignore[explicit-any]
     wrapped: Callable[..., object],
 ) -> Callable[[Callable[P, T]], Callable[P, Awaitable[T]]]:
     def decorator(fn: Callable[P, T]) -> Callable[P, Awaitable[T]]:
@@ -184,7 +183,7 @@ class Path(pathlib.PurePath):
     ) -> AsyncIOWrapper[BinaryIO]: ...
 
     @overload
-    async def open(  # type: ignore[misc]  # Any usage matches builtins.open().
+    async def open(  # type: ignore[misc, explicit-any]  # Any usage matches builtins.open().
         self,
         mode: str,
         buffering: int = -1,
@@ -193,8 +192,8 @@ class Path(pathlib.PurePath):
         newline: str | None = None,
     ) -> AsyncIOWrapper[IO[Any]]: ...
 
-    @_wraps_async(pathlib.Path.open)  # type: ignore[misc]  # Overload return mismatch.
-    def open(self, *args: Any, **kwargs: Any) -> AsyncIOWrapper[IO[Any]]:
+    @_wraps_async(pathlib.Path.open)
+    def open(self, *args: Any, **kwargs: Any) -> AsyncIOWrapper[IO[Any]]:  # type: ignore[misc, explicit-any]  # Overload return mismatch.
         return wrap_file(self._wrapped_cls(self).open(*args, **kwargs))
 
     def __repr__(self) -> str:

--- a/src/trio/_socket.py
+++ b/src/trio/_socket.py
@@ -182,7 +182,7 @@ async def getaddrinfo(
         SocketKind,
         int,
         str,
-        tuple[str, int] | tuple[str, int, int, int],
+        tuple[str, int] | tuple[str, int, int, int] | tuple[int, bytes],
     ]
 ]:
     """Look up a numeric address given a name.

--- a/src/trio/_socket.py
+++ b/src/trio/_socket.py
@@ -46,8 +46,7 @@ T = TypeVar("T")
 # most users, so currently we just specify it as `Any`. Otherwise we would write:
 # `AddressFormat = TypeVar("AddressFormat")`
 # but instead we simply do:
-# Explicit "Any" is not allowed
-AddressFormat: TypeAlias = Any  # type: ignore[misc]
+AddressFormat: TypeAlias = Any  # type: ignore[explicit-any]
 
 
 # Usage:

--- a/src/trio/_ssl.py
+++ b/src/trio/_ssl.py
@@ -423,8 +423,7 @@ class SSLStream(Stream, Generic[T_Stream]):
         "version",
     }
 
-    # Explicit "Any" is not allowed
-    def __getattr__(  # type: ignore[misc]
+    def __getattr__(  # type: ignore[explicit-any]
         self,
         name: str,
     ) -> Any:

--- a/src/trio/_tests/test_highlevel_open_tcp_listeners.py
+++ b/src/trio/_tests/test_highlevel_open_tcp_listeners.py
@@ -255,7 +255,7 @@ class FakeHostnameResolver(HostnameResolver):
             SocketKind,
             int,
             str,
-            tuple[str, int] | tuple[str, int, int, int],
+            tuple[str, int] | tuple[str, int, int, int] | tuple[int, bytes],
         ]
     ]:
         assert isinstance(port, int)

--- a/src/trio/_tests/test_highlevel_open_tcp_stream.py
+++ b/src/trio/_tests/test_highlevel_open_tcp_stream.py
@@ -287,9 +287,9 @@ class Scenario(trio.abc.SocketFactory, trio.abc.HostnameResolver):
         SocketKind,
         int,
         str,
-        tuple[str, int, int, int] | tuple[str, int],
+        tuple[str, int, int, int] | tuple[str, int] | tuple[int, bytes],
     ]:
-        sockaddr: tuple[str, int] | tuple[str, int, int, int]
+        sockaddr: tuple[str, int] | tuple[str, int, int, int] | tuple[int, bytes]
         if ":" in ip:
             family = trio.socket.AF_INET6
             sockaddr = (ip, self.port, 0, 0)
@@ -312,7 +312,7 @@ class Scenario(trio.abc.SocketFactory, trio.abc.HostnameResolver):
             SocketKind,
             int,
             str,
-            tuple[str, int, int, int] | tuple[str, int],
+            tuple[str, int, int, int] | tuple[str, int] | tuple[int, bytes],
         ]
     ]:
         assert host == b"test.example.com"

--- a/src/trio/_tests/test_highlevel_ssl_helpers.py
+++ b/src/trio/_tests/test_highlevel_ssl_helpers.py
@@ -45,7 +45,7 @@ async def echo_handler(stream: Stream) -> None:
 # you ask for.
 @attrs.define(slots=False)
 class FakeHostnameResolver(trio.abc.HostnameResolver):
-    sockaddr: tuple[str, int] | tuple[str, int, int, int]
+    sockaddr: tuple[str, int] | tuple[str, int, int, int] | tuple[int, bytes]
 
     async def getaddrinfo(
         self,
@@ -61,7 +61,7 @@ class FakeHostnameResolver(trio.abc.HostnameResolver):
             SocketKind,
             int,
             str,
-            tuple[str, int] | tuple[str, int, int, int],
+            tuple[str, int] | tuple[str, int, int, int] | tuple[int, bytes],
         ]
     ]:
         return [(AF_INET, SOCK_STREAM, IPPROTO_TCP, "", self.sockaddr)]

--- a/src/trio/_tests/test_socket.py
+++ b/src/trio/_tests/test_socket.py
@@ -186,10 +186,7 @@ async def test_getaddrinfo(monkeygai: MonkeypatchedGAI) -> None:
         ) -> tuple[
             AddressFamily,
             SocketKind,
-            tuple[str, int]
-            | tuple[str, int, int]
-            | tuple[str, int, int, int]
-            | tuple[int, bytes],
+            tuple[str, int] | tuple[str, int, int, int] | tuple[int, bytes],
         ]:
             # (family, type, proto, canonname, sockaddr)
             family, type_, _proto, _canonname, sockaddr = gai_tup
@@ -201,10 +198,7 @@ async def test_getaddrinfo(monkeygai: MonkeypatchedGAI) -> None:
             tuple[
                 AddressFamily,
                 SocketKind,
-                tuple[str, int]
-                | tuple[str, int, int]
-                | tuple[str, int, int, int]
-                | tuple[int, bytes],
+                tuple[str, int] | tuple[str, int, int, int] | tuple[int, bytes],
             ]
         ]:
             return [interesting_fields(gai_tup) for gai_tup in gai_list]

--- a/src/trio/_tests/test_socket.py
+++ b/src/trio/_tests/test_socket.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
         SocketKind,
         int,
         str,
-        Union[tuple[str, int], tuple[str, int, int, int]],
+        Union[tuple[str, int], tuple[str, int, int, int], tuple[int, bytes]],
     ]
     GetAddrInfoResponse: TypeAlias = list[GaiTuple]
     GetAddrInfoArgs: TypeAlias = tuple[
@@ -186,7 +186,10 @@ async def test_getaddrinfo(monkeygai: MonkeypatchedGAI) -> None:
         ) -> tuple[
             AddressFamily,
             SocketKind,
-            tuple[str, int] | tuple[str, int, int] | tuple[str, int, int, int],
+            tuple[str, int]
+            | tuple[str, int, int]
+            | tuple[str, int, int, int]
+            | tuple[int, bytes],
         ]:
             # (family, type, proto, canonname, sockaddr)
             family, type_, _proto, _canonname, sockaddr = gai_tup
@@ -198,7 +201,10 @@ async def test_getaddrinfo(monkeygai: MonkeypatchedGAI) -> None:
             tuple[
                 AddressFamily,
                 SocketKind,
-                tuple[str, int] | tuple[str, int, int] | tuple[str, int, int, int],
+                tuple[str, int]
+                | tuple[str, int, int]
+                | tuple[str, int, int, int]
+                | tuple[int, bytes],
             ]
         ]:
             return [interesting_fields(gai_tup) for gai_tup in gai_list]

--- a/src/trio/_tests/test_ssl.py
+++ b/src/trio/_tests/test_ssl.py
@@ -381,8 +381,7 @@ def virtual_ssl_echo_server(
     yield SSLStream(fakesock, client_ctx, server_hostname="trio-test-1.example.org")
 
 
-# Explicit "Any" is not allowed
-def ssl_wrap_pair(  # type: ignore[misc]
+def ssl_wrap_pair(  # type: ignore[explicit-any]
     client_ctx: SSLContext,
     client_transport: T_Stream,
     server_transport: T_Stream,

--- a/src/trio/_tests/test_subprocess.py
+++ b/src/trio/_tests/test_subprocess.py
@@ -82,8 +82,8 @@ else:
         return python(f"import time; time.sleep({seconds})")
 
 
-@asynccontextmanager  # type: ignore[misc]  # Any in decorated
-async def open_process_then_kill(
+@asynccontextmanager
+async def open_process_then_kill(  # type: ignore[misc, explicit-any]
     *args: Any,
     **kwargs: Any,
 ) -> AsyncIterator[Process]:
@@ -95,8 +95,8 @@ async def open_process_then_kill(
         await proc.wait()
 
 
-@asynccontextmanager  # type: ignore[misc]  # Any in decorated
-async def run_process_in_nursery(
+@asynccontextmanager
+async def run_process_in_nursery(  # type: ignore[misc, explicit-any]
     *args: Any,
     **kwargs: Any,
 ) -> AsyncIterator[Process]:
@@ -115,8 +115,7 @@ background_process_param = pytest.mark.parametrize(
     ids=["open_process", "run_process in nursery"],
 )
 
-# Explicit .../"Any" is not allowed
-BackgroundProcessType: TypeAlias = Callable[  # type: ignore[misc]
+BackgroundProcessType: TypeAlias = Callable[  # type: ignore[explicit-any]
     ...,
     AbstractAsyncContextManager[Process],
 ]

--- a/src/trio/_threads.py
+++ b/src/trio/_threads.py
@@ -29,7 +29,11 @@ from ._util import coroutine_or_error
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Generator
 
+    from typing_extensions import TypeVarTuple, Unpack
+
     from trio._core._traps import RaiseCancelT
+
+    Ts = TypeVarTuple("Ts")
 
 RetT = TypeVar("RetT")
 
@@ -146,9 +150,8 @@ class ThreadPlaceholder:
 
 # Types for the to_thread_run_sync message loop
 @attrs.frozen(eq=False, slots=False)
-# Explicit .../"Any" is not allowed
-class Run(Generic[RetT]):  # type: ignore[misc]
-    afn: Callable[..., Awaitable[RetT]]  # type: ignore[misc]
+class Run(Generic[RetT]):  # type: ignore[explicit-any]
+    afn: Callable[..., Awaitable[RetT]]  # type: ignore[explicit-any]
     args: tuple[object, ...]
     context: contextvars.Context = attrs.field(
         init=False,
@@ -206,9 +209,8 @@ class Run(Generic[RetT]):  # type: ignore[misc]
 
 
 @attrs.frozen(eq=False, slots=False)
-# Explicit .../"Any" is not allowed
-class RunSync(Generic[RetT]):  # type: ignore[misc]
-    fn: Callable[..., RetT]  # type: ignore[misc]
+class RunSync(Generic[RetT]):  # type: ignore[explicit-any]
+    fn: Callable[..., RetT]  # type: ignore[explicit-any]
     args: tuple[object, ...]
     context: contextvars.Context = attrs.field(
         init=False,
@@ -252,9 +254,9 @@ class RunSync(Generic[RetT]):  # type: ignore[misc]
 
 
 @enable_ki_protection  # Decorator used on function with Coroutine[Any, Any, RetT]
-async def to_thread_run_sync(  # type: ignore[misc]
-    sync_fn: Callable[..., RetT],
-    *args: object,
+async def to_thread_run_sync(
+    sync_fn: Callable[[Unpack[Ts]], RetT],
+    *args: Unpack[Ts],
     thread_name: str | None = None,
     abandon_on_cancel: bool = False,
     limiter: CapacityLimiter | None = None,
@@ -524,10 +526,9 @@ def _send_message_to_trio(
     return message_to_trio.queue.get().unwrap()
 
 
-# Explicit "Any" is not allowed
-def from_thread_run(  # type: ignore[misc]
-    afn: Callable[..., Awaitable[RetT]],
-    *args: object,
+def from_thread_run(
+    afn: Callable[[Unpack[Ts]], Awaitable[RetT]],
+    *args: Unpack[Ts],
     trio_token: TrioToken | None = None,
 ) -> RetT:
     """Run the given async function in the parent Trio thread, blocking until it
@@ -569,10 +570,9 @@ def from_thread_run(  # type: ignore[misc]
     return _send_message_to_trio(trio_token, Run(afn, args))
 
 
-# Explicit "Any" is not allowed
-def from_thread_run_sync(  # type: ignore[misc]
-    fn: Callable[..., RetT],
-    *args: object,
+def from_thread_run_sync(
+    fn: Callable[[Unpack[Ts]], RetT],
+    *args: Unpack[Ts],
     trio_token: TrioToken | None = None,
 ) -> RetT:
     """Run the given sync function in the parent Trio thread, blocking until it

--- a/src/trio/_threads.py
+++ b/src/trio/_threads.py
@@ -253,7 +253,7 @@ class RunSync(Generic[RetT]):  # type: ignore[explicit-any]
         token.run_sync_soon(self.run_sync)
 
 
-@enable_ki_protection  # Decorator used on function with Coroutine[Any, Any, RetT]
+@enable_ki_protection
 async def to_thread_run_sync(
     sync_fn: Callable[[Unpack[Ts]], RetT],
     *args: Unpack[Ts],

--- a/src/trio/_util.py
+++ b/src/trio/_util.py
@@ -21,7 +21,7 @@ from sniffio import thread_local as sniffio_loop
 import trio
 
 # Explicit "Any" is not allowed
-CallT = TypeVar("CallT", bound=Callable[..., Any])  # type: ignore[misc]
+CallT = TypeVar("CallT", bound=Callable[..., Any])  # type: ignore[explicit-any]
 T = TypeVar("T")
 RetT = TypeVar("RetT")
 
@@ -177,16 +177,14 @@ class ConflictDetector:
         self._held = False
 
 
-# Explicit "Any" is not allowed
-def async_wraps(  # type: ignore[misc]
+def async_wraps(  # type: ignore[explicit-any]
     cls: type[object],
     wrapped_cls: type[object],
     attr_name: str,
 ) -> Callable[[CallT], CallT]:
     """Similar to wraps, but for async wrappers of non-async functions."""
 
-    # Explicit "Any" is not allowed
-    def decorator(func: CallT) -> CallT:  # type: ignore[misc]
+    def decorator(func: CallT) -> CallT:  # type: ignore[explicit-any]
         func.__name__ = attr_name
         func.__qualname__ = f"{cls.__qualname__}.{attr_name}"
 
@@ -249,8 +247,7 @@ class generic_function(Generic[RetT]):
     but at least it becomes possible to write those.
     """
 
-    # Explicit .../"Any" is not allowed
-    def __init__(  # type: ignore[misc]
+    def __init__(  # type: ignore[explicit-any]
         self,
         fn: Callable[..., RetT],
     ) -> None:
@@ -346,11 +343,9 @@ def name_asyncgen(agen: AsyncGeneratorType[object, NoReturn]) -> str:
 
 # work around a pyright error
 if TYPE_CHECKING:
-    # Explicit .../"Any" is not allowed
-    Fn = TypeVar("Fn", bound=Callable[..., object])  # type: ignore[misc]
+    Fn = TypeVar("Fn", bound=Callable[..., object])  # type: ignore[explicit-any]
 
-    # Explicit .../"Any" is not allowed
-    def wraps(  # type: ignore[misc]
+    def wraps(  # type: ignore[explicit-any]
         wrapped: Callable[..., object],
         assigned: Sequence[str] = ...,
         updated: Sequence[str] = ...,

--- a/src/trio/testing/_fake_net.py
+++ b/src/trio/testing/_fake_net.py
@@ -155,7 +155,7 @@ class FakeHostnameResolver(trio.abc.HostnameResolver):
             SocketKind,
             int,
             str,
-            tuple[str, int] | tuple[str, int, int, int],
+            tuple[str, int] | tuple[str, int, int, int] | tuple[int, bytes],
         ]
     ]:
         raise NotImplementedError("FakeNet doesn't do fake DNS yet")

--- a/src/trio/testing/_fake_net.py
+++ b/src/trio/testing/_fake_net.py
@@ -507,8 +507,7 @@ class FakeSocket(trio.socket.SocketType, metaclass=NoPublicConstructor):
         __address: tuple[object, ...] | str | Buffer | None,
     ) -> int: ...
 
-    # Explicit "Any" is not allowed
-    async def sendto(  # type: ignore[misc]
+    async def sendto(  # type: ignore[explicit-any]
         self,
         *args: Any,
     ) -> int:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -81,7 +81,7 @@ markupsafe==3.0.2
     # via jinja2
 mccabe==0.7.0
     # via pylint
-mypy==1.14.1
+mypy==1.15.0
     # via -r test-requirements.in
 mypy-extensions==1.0.0
     # via


### PR DESCRIPTION
In https://github.com/python/typeshed/pull/13372, the type of the stdlib's `socket.getaddrinfo` was updated to add a union member for cases where Python was compiled with `--disable-ipv6`. This causes custom resolvers that use the stdlib function to fail mypy

This is probably going to (mypy) break everyone's custom `HostnameResolver`, since the parent type is changing