### PR TITLE
Diminish the severity of renaming `ErrorCodes` enum members

### DIFF
--- a/newsfragments/3166.breaking.rst
+++ b/newsfragments/3166.breaking.rst
@@ -1,1 +1,0 @@
-Fixed spelling error in Windows CFFI ErrorCodes Enum ``ERROR_INVALID_PARAMETER``

--- a/newsfragments/3166.misc.rst
+++ b/newsfragments/3166.misc.rst
@@ -1,0 +1,1 @@
+Fixed spelling error in Windows error code enum for ``ERROR_INVALID_PARAMETER``.


### PR DESCRIPTION
Follow up to #3166, I think `breaking` is not accurate because ErrorCode is neither exported nor returned anywhere public.

(this is a kind of unnecessary change but I figure better not make people think the next release has what we would consider a breaking change. I'm fine if we decide to keep it as is.)