### PR TITLE
Prevent MockClock from mutating the current runner

### DIFF
--- a/newsfragments/3205.bugfix.rst
+++ b/newsfragments/3205.bugfix.rst
@@ -1,0 +1,1 @@
+Don't mutate the global runner when MockClock is created.

--- a/src/trio/_core/_mock_clock.py
+++ b/src/trio/_core/_mock_clock.py
@@ -70,7 +70,7 @@ class MockClock(Clock):
         self._real_base = 0.0
         self._virtual_base = 0.0
         self._rate = 0.0
-        self._autojump_threshold = 0.0
+
         # kept as an attribute so that our tests can monkeypatch it
         self._real_clock = time.perf_counter
 
@@ -119,7 +119,8 @@ class MockClock(Clock):
         except AttributeError:
             pass
         else:
-            runner.clock_autojump_threshold = self._autojump_threshold
+            if runner.clock is self:
+                runner.clock_autojump_threshold = self._autojump_threshold
 
     # Invoked by the run loop when runner.clock_autojump_threshold is
     # exceeded.

--- a/src/trio/_core/_tests/test_mock_clock.py
+++ b/src/trio/_core/_tests/test_mock_clock.py
@@ -8,6 +8,7 @@ from trio import sleep
 from ... import _core
 from .. import wait_all_tasks_blocked
 from .._mock_clock import MockClock
+from .._run import GLOBAL_RUN_CONTEXT
 from .tutil import slow
 
 
@@ -175,3 +176,18 @@ async def test_mock_clock_autojump_0_and_wait_all_tasks_blocked_nonzero(
         nursery.start_soon(waiter)
 
     assert record == ["waiter done", "yawn"]
+
+
+async def test_initialization_doesnt_mutate_runner() -> None:
+    before = (
+        GLOBAL_RUN_CONTEXT.runner.clock,
+        GLOBAL_RUN_CONTEXT.runner.clock_autojump_threshold,
+    )
+
+    MockClock(autojump_threshold=2, rate=3)
+
+    after = (
+        GLOBAL_RUN_CONTEXT.runner.clock,
+        GLOBAL_RUN_CONTEXT.runner.clock_autojump_threshold,
+    )
+    assert before == after


### PR DESCRIPTION
Based on the issue @jc211 had on Gitter. You probably shouldn't be creating a `MockClock` and not using it, but this is a footgun.