### PR TITLE
Add missing arguments to run_process

### DIFF
--- a/newsfragments/3183.bugfix.rst
+++ b/newsfragments/3183.bugfix.rst
@@ -1,0 +1,1 @@
+Update type hints for `trio.run_process` and `trio.lowlevel.open_process`.

--- a/src/trio/_subprocess.py
+++ b/src/trio/_subprocess.py
@@ -1122,12 +1122,25 @@ if TYPE_CHECKING:
             check: bool
             deliver_cancel: Callable[[Process], Awaitable[None]] | None
 
+        # TODO: once https://github.com/python/mypy/issues/18692 is
+        #       fixed, move the `UnixRunProcessArgs` definition down.
         if sys.version_info >= (3, 11):
             UnixProcessArgs = UnixProcessArgs3_11
+
+            class UnixRunProcessArgs(UnixProcessArgs3_11, UnixRunProcessMixin):
+                """Arguments for run_process on Unix with 3.11+"""
+
         elif sys.version_info >= (3, 10):
             UnixProcessArgs = UnixProcessArgs3_10
+
+            class UnixRunProcessArgs(UnixProcessArgs3_10, UnixRunProcessMixin):
+                """Arguments for run_process on Unix with 3.10+"""
+
         else:
             UnixProcessArgs = UnixProcessArgs3_9
+
+            class UnixRunProcessArgs(UnixProcessArgs3_9, UnixRunProcessMixin):
+                """Arguments for run_process on Unix with 3.9+"""
 
         @overload  # type: ignore[no-overload-impl]
         async def open_process(
@@ -1146,9 +1159,6 @@ if TYPE_CHECKING:
             shell: bool = False,
             **kwargs: Unpack[UnixProcessArgs],
         ) -> trio.Process: ...
-
-        class UnixRunProcessArgs(UnixProcessArgs, UnixRunProcessMixin):
-            pass
 
         @overload  # type: ignore[no-overload-impl]
         async def run_process(

--- a/src/trio/_subprocess.py
+++ b/src/trio/_subprocess.py
@@ -1111,7 +1111,7 @@ if TYPE_CHECKING:
         class UnixProcessArgs3_11(UnixProcessArgs3_10, total=False):
             """Arguments shared between all Unix runs on 3.11+."""
 
-            process_group: int
+            process_group: int | None
 
         class UnixRunProcessMixin(TypedDict, total=False):
             """Arguments unique to run_process on Unix."""

--- a/src/trio/_subprocess.py
+++ b/src/trio/_subprocess.py
@@ -1085,7 +1085,7 @@ if TYPE_CHECKING:
         # overloads. But might still be a problem for other static analyzers / docstring
         # readers (?)
 
-        class UnixProcessArgs(GeneralProcessArgs, total=False):
+        class UnixProcessArgs3_9(GeneralProcessArgs, total=False):
             preexec_fn: Callable[[], object] | None
             restore_signals: bool
             start_new_session: bool
@@ -1097,7 +1097,7 @@ if TYPE_CHECKING:
             user: str | int | None
             umask: int
 
-        class UnixProcessArgs3_10(UnixProcessArgs, total=False):
+        class UnixProcessArgs3_10(UnixProcessArgs3_9, total=False):
             pipesize: int
 
         class UnixProcessArgs3_11(UnixProcessArgs3_10, total=False):
@@ -1111,127 +1111,50 @@ if TYPE_CHECKING:
             deliver_cancel: Callable[[Process], Awaitable[None]] | None
 
         if sys.version_info >= (3, 11):
-
-            @overload  # type: ignore[no-overload-impl]
-            async def open_process(
-                command: StrOrBytesPath,
-                *,
-                stdin: int | HasFileno | None = None,
-                shell: Literal[True],
-                **kwargs: Unpack[UnixProcessArgs3_11],
-            ) -> trio.Process: ...
-
-            @overload
-            async def open_process(
-                command: Sequence[StrOrBytesPath],
-                *,
-                stdin: int | HasFileno | None = None,
-                shell: bool = False,
-                **kwargs: Unpack[UnixProcessArgs3_11],
-            ) -> trio.Process: ...
-
-            class UnixRunProcessArgs(UnixProcessArgs3_11, UnixRunProcessMixin):
-                pass
-
-            @overload  # type: ignore[no-overload-impl]
-            async def run_process(
-                command: StrOrBytesPath,
-                *,
-                stdin: bytes | bytearray | memoryview | int | HasFileno | None = None,
-                shell: Literal[True],
-                **kwargs: Unpack[UnixRunProcessArgs],
-            ) -> subprocess.CompletedProcess[bytes]: ...
-
-            @overload
-            async def run_process(
-                command: Sequence[StrOrBytesPath],
-                *,
-                stdin: bytes | bytearray | memoryview | int | HasFileno | None = None,
-                shell: bool = False,
-                **kwargs: Unpack[UnixRunProcessArgs],
-            ) -> subprocess.CompletedProcess[bytes]: ...
-
+            UnixProcessArgs = UnixProcessArgs3_11
         elif sys.version_info >= (3, 10):
-
-            @overload  # type: ignore[no-overload-impl]
-            async def open_process(
-                command: StrOrBytesPath,
-                *,
-                stdin: int | HasFileno | None = None,
-                shell: Literal[True],
-                **kwargs: Unpack[UnixProcessArgs3_10],
-            ) -> trio.Process: ...
-
-            @overload
-            async def open_process(
-                command: Sequence[StrOrBytesPath],
-                *,
-                stdin: int | HasFileno | None = None,
-                shell: bool = False,
-                **kwargs: Unpack[UnixProcessArgs3_10],
-            ) -> trio.Process: ...
-
-            class UnixRunProcessArgs(UnixProcessArgs3_10, UnixRunProcessMixin):
-                pass
-
-            @overload  # type: ignore[no-overload-impl]
-            async def run_process(
-                command: StrOrBytesPath,
-                *,
-                stdin: bytes | bytearray | memoryview | int | HasFileno | None = None,
-                shell: Literal[True],
-                **kwargs: Unpack[UnixRunProcessArgs],
-            ) -> subprocess.CompletedProcess[bytes]: ...
-
-            @overload
-            async def run_process(
-                command: Sequence[StrOrBytesPath],
-                *,
-                stdin: bytes | bytearray | memoryview | int | HasFileno | None = None,
-                shell: bool = False,
-                **kwargs: Unpack[UnixRunProcessArgs],
-            ) -> subprocess.CompletedProcess[bytes]: ...
-
+            UnixProcessArgs = UnixProcessArgs3_10
         else:
+            UnixProcessArgs = UnixProcessArgs3_9
 
-            @overload  # type: ignore[no-overload-impl]
-            async def open_process(
-                command: StrOrBytesPath,
-                *,
-                stdin: int | HasFileno | None = None,
-                shell: Literal[True],
-                **kwargs: Unpack[UnixProcessArgs],
-            ) -> trio.Process: ...
+        @overload  # type: ignore[no-overload-impl]
+        async def open_process(
+            command: StrOrBytesPath,
+            *,
+            stdin: int | HasFileno | None = None,
+            shell: Literal[True],
+            **kwargs: Unpack[UnixProcessArgs],
+        ) -> trio.Process: ...
 
-            @overload
-            async def open_process(
-                command: Sequence[StrOrBytesPath],
-                *,
-                stdin: int | HasFileno | None = None,
-                shell: bool = False,
-                **kwargs: Unpack[UnixProcessArgs],
-            ) -> trio.Process: ...
+        @overload
+        async def open_process(
+            command: Sequence[StrOrBytesPath],
+            *,
+            stdin: int | HasFileno | None = None,
+            shell: bool = False,
+            **kwargs: Unpack[UnixProcessArgs],
+        ) -> trio.Process: ...
 
-            class UnixRunProcessArgs(UnixProcessArgs, UnixRunProcessMixin):
-                pass
+        class UnixRunProcessArgs(UnixProcessArgs, UnixRunProcessMixin):
+            pass
 
-            @overload  # type: ignore[no-overload-impl]
-            async def run_process(
-                command: StrOrBytesPath,
-                *,
-                stdin: bytes | bytearray | memoryview | int | HasFileno | None = None,
-                shell: Literal[True],
-                **kwargs: Unpack[UnixRunProcessArgs],
-            ) -> subprocess.CompletedProcess[bytes]: ...
+        @overload  # type: ignore[no-overload-impl]
+        async def run_process(
+            command: StrOrBytesPath,
+            *,
+            stdin: bytes | bytearray | memoryview | int | HasFileno | None = None,
+            shell: Literal[True],
+            **kwargs: Unpack[UnixRunProcessArgs],
+        ) -> subprocess.CompletedProcess[bytes]: ...
 
-            @overload
-            async def run_process(
-                command: Sequence[StrOrBytesPath],
-                *,
-                stdin: bytes | bytearray | memoryview | int | HasFileno | None = None,
-                shell: bool = False,
-                **kwargs: Unpack[UnixRunProcessArgs],
-            ) -> subprocess.CompletedProcess[bytes]: ...
+        @overload
+        async def run_process(
+            command: Sequence[StrOrBytesPath],
+            *,
+            stdin: bytes | bytearray | memoryview | int | HasFileno | None = None,
+            shell: bool = False,
+            **kwargs: Unpack[UnixRunProcessArgs],
+        ) -> subprocess.CompletedProcess[bytes]: ...
 
 else:
     # At runtime, use the actual implementations.

--- a/src/trio/_subprocess.py
+++ b/src/trio/_subprocess.py
@@ -802,6 +802,8 @@ async def _run_process(
 
 
 class GeneralProcessArgs(TypedDict, total=False):
+    """Arguments shared between all runs."""
+
     stdout: int | HasFileno | None
     stderr: int | HasFileno | None
     close_fds: bool
@@ -814,6 +816,8 @@ if TYPE_CHECKING:
     if sys.platform == "win32":
 
         class WindowsProcessArgs(GeneralProcessArgs, total=False):
+            """Arguments shared between all Windows runs."""
+
             shell: bool
             startupinfo: subprocess.STARTUPINFO | None
             creationflags: int
@@ -1086,6 +1090,8 @@ if TYPE_CHECKING:
         # readers (?)
 
         class UnixProcessArgs3_9(GeneralProcessArgs, total=False):
+            """Arguments shared between all Unix runs."""
+
             preexec_fn: Callable[[], object] | None
             restore_signals: bool
             start_new_session: bool
@@ -1098,12 +1104,18 @@ if TYPE_CHECKING:
             umask: int
 
         class UnixProcessArgs3_10(UnixProcessArgs3_9, total=False):
+            """Arguments shared between all Unix runs on 3.10+."""
+
             pipesize: int
 
         class UnixProcessArgs3_11(UnixProcessArgs3_10, total=False):
+            """Arguments shared between all Unix runs on 3.11+."""
+
             process_group: int
 
         class UnixRunProcessMixin(TypedDict, total=False):
+            """Arguments unique to run_process on Unix."""
+
             task_status: TaskStatus[Process]
             capture_stdout: bool
             capture_stderr: bool

--- a/src/trio/_tests/type_tests/subprocesses.py
+++ b/src/trio/_tests/type_tests/subprocesses.py
@@ -1,0 +1,21 @@
+import sys
+
+import trio
+
+
+async def test() -> None:
+    # this could test more by using platform checks, but currently this
+    # is just regression tests + sanity checks.
+    await trio.run_process("python", executable="ls")
+    await trio.lowlevel.open_process("python", executable="ls")
+
+    await trio.run_process("python", capture_stdout=True)
+    await trio.lowlevel.open_process("python", capture_stdout=True)  # type: ignore[call-arg]
+
+    if sys.platform != "win32" and sys.version_info >= (3, 9):
+        await trio.run_process("python", extra_groups=[5])
+        await trio.lowlevel.open_process("python", extra_groups=[5])
+
+        # 3.11+:
+        await trio.run_process("python", process_group=5)  # type: ignore[call-arg]
+        await trio.lowlevel.open_process("python", process_group=5)  # type: ignore[call-arg]

--- a/src/trio/_tests/type_tests/subprocesses.py
+++ b/src/trio/_tests/type_tests/subprocesses.py
@@ -9,13 +9,15 @@ async def test() -> None:
     await trio.run_process("python", executable="ls")
     await trio.lowlevel.open_process("python", executable="ls")
 
+    # note: there's no error code on the type ignore as it varies
+    # between platforms.
     await trio.run_process("python", capture_stdout=True)
-    await trio.lowlevel.open_process("python", capture_stdout=True)  # type: ignore[call-arg]
+    await trio.lowlevel.open_process("python", capture_stdout=True)  # type: ignore
 
     if sys.platform != "win32" and sys.version_info >= (3, 9):
         await trio.run_process("python", extra_groups=[5])
         await trio.lowlevel.open_process("python", extra_groups=[5])
 
         # 3.11+:
-        await trio.run_process("python", process_group=5)  # type: ignore[call-arg]
-        await trio.lowlevel.open_process("python", process_group=5)  # type: ignore[call-arg]
+        await trio.run_process("python", process_group=5)  # type: ignore
+        await trio.lowlevel.open_process("python", process_group=5)  # type: ignore


### PR DESCRIPTION
Fixes https://github.com/python-trio/trio/issues/3183

I tried out TypedDict here like @decorator-factory recommended and it's nicer, though it's explicitly trading off user experience:
 - no defaults listed
 - wacky reveal_type at least under mypy

I *think* it's worth it? I doubt people are looking at overloads for the defaults to things.

I still need to add type tests.