### PR TITLE
Sprinkle `@slow` on slow tests

### DIFF
--- a/src/trio/_tests/test_highlevel_open_tcp_listeners.py
+++ b/src/trio/_tests/test_highlevel_open_tcp_listeners.py
@@ -74,7 +74,7 @@ async def test_open_tcp_listeners_specific_port_specific_host() -> None:
 
 
 @binds_ipv6
-@slow  # turns out failing to connect to a port takes 2 seconds on Windows
+@slow
 async def test_open_tcp_listeners_ipv6_v6only() -> None:
     # Check IPV6_V6ONLY is working properly
     (ipv6_listener,) = await open_tcp_listeners(0, host="::1")
@@ -85,6 +85,8 @@ async def test_open_tcp_listeners_ipv6_v6only() -> None:
             OSError,
             match=r"(Error|all attempts to) connect(ing)* to (\(')*127\.0\.0\.1(', |:)\d+(\): Connection refused| failed)$",
         ):
+            # Windows retries failed connections so this takes seconds
+            # (and that's why this is marked @slow)
             await open_tcp_stream("127.0.0.1", port)
 
 

--- a/src/trio/_tests/test_highlevel_open_tcp_listeners.py
+++ b/src/trio/_tests/test_highlevel_open_tcp_listeners.py
@@ -20,7 +20,7 @@ from trio.abc import HostnameResolver, SendStream, SocketFactory
 from trio.testing import open_stream_to_socket_listener
 
 from .. import socket as tsocket
-from .._core._tests.tutil import binds_ipv6
+from .._core._tests.tutil import binds_ipv6, slow
 
 if sys.version_info < (3, 11):
     from exceptiongroup import BaseExceptionGroup
@@ -74,6 +74,7 @@ async def test_open_tcp_listeners_specific_port_specific_host() -> None:
 
 
 @binds_ipv6
+@slow  # turns out failing to connect to a port takes 2 seconds on Windows
 async def test_open_tcp_listeners_ipv6_v6only() -> None:
     # Check IPV6_V6ONLY is working properly
     (ipv6_listener,) = await open_tcp_listeners(0, host="::1")

--- a/src/trio/_tests/test_socket.py
+++ b/src/trio/_tests/test_socket.py
@@ -14,7 +14,7 @@ import attrs
 import pytest
 
 from .. import _core, socket as tsocket
-from .._core._tests.tutil import binds_ipv6, can_create_ipv6, creates_ipv6
+from .._core._tests.tutil import binds_ipv6, can_create_ipv6, creates_ipv6, slow
 from .._socket import _NUMERIC_ONLY, AddressFormat, SocketType, _SocketType, _try_sync
 from ..testing import assert_checkpoints, wait_all_tasks_blocked
 
@@ -829,6 +829,7 @@ async def test_SocketType_non_blocking_paths() -> None:
 
 
 # This tests the complicated paths through connect
+@slow  # turns out failing to connect to port 2 takes 2 seconds on Windows
 async def test_SocketType_connect_paths() -> None:
     with tsocket.socket() as sock:
         with pytest.raises(
@@ -899,6 +900,7 @@ async def test_SocketType_connect_paths() -> None:
 
 
 # Fix issue #1810
+@slow  # turns out failing to connect to port 2 takes 2 seconds on Windows
 async def test_address_in_socket_error() -> None:
     address = "127.0.0.1"
     with tsocket.socket() as sock:
@@ -1215,7 +1217,7 @@ async def test_interrupted_by_close() -> None:
 
 
 async def test_many_sockets() -> None:
-    total = 5000  # Must be more than MAX_AFD_GROUP_SIZE
+    total = 1000  # Must be more than MAX_AFD_GROUP_SIZE
     sockets = []
     # Open at most <total> socket pairs
     for opened in range(0, total, 2):

--- a/src/trio/_tests/test_socket.py
+++ b/src/trio/_tests/test_socket.py
@@ -829,7 +829,7 @@ async def test_SocketType_non_blocking_paths() -> None:
 
 
 # This tests the complicated paths through connect
-@slow  # turns out failing to connect to port 2 takes 2 seconds on Windows
+@slow
 async def test_SocketType_connect_paths() -> None:
     with tsocket.socket() as sock:
         with pytest.raises(
@@ -896,11 +896,14 @@ async def test_SocketType_connect_paths() -> None:
             # connect to fail. Really. Also if you use a non-routable
             # address. This way fails instantly though. As long as nothing
             # is listening on port 2.)
+
+            # Windows retries failed connections so this takes seconds
+            # (and that's why this is marked @slow)
             await sock.connect(("127.0.0.1", 2))
 
 
 # Fix issue #1810
-@slow  # turns out failing to connect to port 2 takes 2 seconds on Windows
+@slow
 async def test_address_in_socket_error() -> None:
     address = "127.0.0.1"
     with tsocket.socket() as sock:
@@ -908,6 +911,8 @@ async def test_address_in_socket_error() -> None:
             OSError,
             match=rf"^\[\w+ \d+\] Error connecting to \({address!r}, 2\): (Connection refused|Unknown error)$",
         ):
+            # Windows retries failed connections so this takes seconds
+            # (and that's why this is marked @slow)
             await sock.connect((address, 2))
 
 

--- a/src/trio/_tests/tools/test_gen_exports.py
+++ b/src/trio/_tests/tools/test_gen_exports.py
@@ -23,6 +23,8 @@ from trio._tools.gen_exports import (
     run_ruff,
 )
 
+from ..._core._tests.tutil import slow
+
 SOURCE = '''from _run import _public
 from collections import Counter
 
@@ -89,6 +91,7 @@ skip_lints = pytest.mark.skipif(
 )
 
 
+@slow
 @skip_lints
 @pytest.mark.parametrize("imports", [IMPORT_1, IMPORT_2, IMPORT_3])
 def test_process(


### PR DESCRIPTION
Fixes #3206.

The main thing is that it turns out that waiting for a socket to fail to connect takes up to 2 seconds on Windows -- so tests that rely on that should be marked `@slow`.

---

This approximately halves local test time on Windows.

```
================================================ slowest 10 durations =================================================
0.75s call     src/trio/_tests/test_exports.py::test_static_tool_sees_all_symbols[jedi-trio]
0.72s call     src/trio/_tests/tools/test_gen_exports.py::test_lint_failure
0.70s call     src/trio/_tests/test_repl.py::test_main_entrypoint
0.52s call     src/trio/_tests/test_util.py::test_coroutine_or_error
0.39s call     src/trio/_tests/test_exports.py::test_static_tool_sees_all_symbols[pylint-trio]
0.33s call     src/trio/_tests/test_subprocess.py::test_run
0.32s call     src/trio/_tests/test_subprocess.py::test_interactive[run_process in nursery]
0.32s call     src/trio/_tests/test_socket.py::test_many_sockets
0.26s call     src/trio/_tests/test_subprocess.py::test_interactive[open_process]
0.26s call     src/trio/_core/_tests/test_asyncgen.py::test_fallback_when_no_hook_claims_it
===================================== 762 passed, 83 skipped, 2 xfailed in 17.93s =====================================
```