### PR TITLE
Warn if there's no docstring for documented things

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,6 +26,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 from sphinx.util.inventory import _InventoryItem
+from sphinx.util.logging import getLogger
 
 if TYPE_CHECKING:
     from sphinx.application import Sphinx
@@ -167,6 +168,21 @@ def autodoc_process_signature(
     return signature, return_annotation
 
 
+logger = getLogger("trio")
+
+
+def autodoc_process_docstring(
+    app: Sphinx,
+    what: str,
+    name: str,
+    obj: object,
+    options: object,
+    lines: list[str],
+) -> None:
+    if not lines:
+        logger.warning(f"{name} has no docstring")
+
+
 # XX hack the RTD theme until
 #   https://github.com/rtfd/sphinx_rtd_theme/pull/382
 # is shipped (should be in the release after 0.2.4)
@@ -175,6 +191,8 @@ def autodoc_process_signature(
 def setup(app: Sphinx) -> None:
     app.add_css_file("hackrtd.css")
     app.connect("autodoc-process-signature", autodoc_process_signature)
+    app.connect("autodoc-process-docstring", autodoc_process_docstring)
+
     # After Intersphinx runs, add additional mappings.
     app.connect("builder-inited", add_intersphinx, priority=1000)
     app.connect("source-read", on_read_source)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -168,7 +168,21 @@ def autodoc_process_signature(
     return signature, return_annotation
 
 
+# currently undocumented things
 logger = getLogger("trio")
+UNDOCUMENTED = {
+    "trio.CancelScope.relative_deadline",
+    "trio.MemorySendChannel",
+    "trio.MemoryReceiveChannel",
+    "trio.MemoryChannelStatistics",
+    "trio.SocketStream.aclose",
+    "trio.SocketStream.receive_some",
+    "trio.SocketStream.send_all",
+    "trio.SocketStream.send_eof",
+    "trio.SocketStream.wait_send_all_might_not_block",
+    "trio._subprocess.HasFileno.fileno",
+    "trio.lowlevel.ParkingLot.broken_by",
+}
 
 
 def autodoc_process_docstring(
@@ -180,7 +194,14 @@ def autodoc_process_docstring(
     lines: list[str],
 ) -> None:
     if not lines:
+        # TODO: document these and remove them from here
+        if name in UNDOCUMENTED:
+            return
+
         logger.warning(f"{name} has no docstring")
+    else:
+        if name in UNDOCUMENTED:
+            logger.warning("outdated list of undocumented things")
 
 
 # XX hack the RTD theme until


### PR DESCRIPTION
References https://github.com/python-trio/trio/issues/3221

An earlier version found these:
```
!!!!!! trio.CancelScope.relative_deadline
!!!!!! trio.MemorySendChannel
!!!!!! trio.MemoryReceiveChannel
!!!!!! trio.MemoryChannelStatistics
!!!!!! trio.SocketStream.aclose
!!!!!! trio.SocketStream.receive_some
!!!!!! trio.SocketStream.send_all
!!!!!! trio.SocketStream.send_eof
!!!!!! trio.SocketStream.wait_send_all_might_not_block
!!!!!! trio._subprocess.HasFileno.fileno
!!!!!! trio.lowlevel.ParkingLot.broken_by
```

Which at least seems right:
 - `relative_deadline` is from the above issue
 - `SocketStream` has `:undoc-members:` ... for no good reason??
 - didn't check the others

Anyways we could probably edit the issue above for a checklist of every one of those so we have easy issues for anyone who wants to contribute!