### PR TITLE
Update styles for documentation

### DIFF
--- a/docs/source/_static/hackrtd.css
+++ b/docs/source/_static/hackrtd.css
@@ -23,6 +23,10 @@ pre {
  * thingummy also has an <hr> in it, and putting the ornament on that looks
  * *really weird*. (In particular, the background color is wrong.)
  */
+.rst-content hr {
+    overflow: visible;
+}
+
 .rst-content hr:after {
     /* This .svg gets displayed on top of the middle of the hrule. It has a box
      * behind the logo that's colored to match the RTD theme body background

--- a/docs/source/_static/hackrtd.css
+++ b/docs/source/_static/hackrtd.css
@@ -54,30 +54,16 @@ pre {
     color: #306998 !important;
 }
 
-.wy-side-nav-search > a.logo {
-    display: block !important;
-    padding-bottom: 0.809em !important;
+/* vertically center version text */
+.wy-side-nav-search > a {
+    display: flex;
+    align-items: center;
+    justify-self: center;
 }
 
 .wy-side-nav-search > a img.logo {
-    display: inline !important;
-    padding: 0 !important;
-}
-
-.trio-version {
-    display: inline;
-    /* I *cannot* figure out how to get the version text vertically centered
-       on the logo. Oh well...
-    height: 32px;
-    line-height: 32px;
-    */
-}
-
-.wy-side-nav-search > a {
-    /* Mostly this is just to simplify things, so we don't have margin/padding
-     * on both the <a> and the <img> inside it */
-    margin: 0 !important;
-    padding: 0 !important;
+    margin-left: 0;
+    margin-right: 5px;
 }
 
 /* Get rid of the weird super dark "Contents" label that wastes vertical space

--- a/docs/source/_static/hackrtd.css
+++ b/docs/source/_static/hackrtd.css
@@ -58,7 +58,8 @@ pre {
 .wy-side-nav-search > a {
     display: flex;
     align-items: center;
-    justify-self: center;
+    margin: auto;
+    width: max-content;
 }
 
 .wy-side-nav-search > a img.logo {

--- a/docs/source/_static/styles.css
+++ b/docs/source/_static/styles.css
@@ -1,10 +1,3 @@
-/* Temporary hack to work around bug in rtd theme 2.0 through 2.4
-   See https://github.com/rtfd/sphinx_rtd_theme/pull/382
-*/
-pre {
-    line-height: normal !important;
-}
-
 /* Make .. deprecation:: blocks visible
  * (by default they're entirely unstyled)
  */
@@ -44,11 +37,6 @@ pre {
 }
 
 /* Hacks to make the upper-left logo area look nicer */
-
-.wy-side-nav-search {
-    /* Lighter background color to match logo */
-    background-color: #d2e7fa !important;
-}
 
 .wy-side-nav-search > a {
     color: #306998 !important;

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -12,7 +12,7 @@ https://stackoverflow.com/questions/25243482/how-to-add-sphinx-generated-index-t
 <a class="logo" href="{{ pathto(root_doc) }}">
   <img class="logo" src="{{ logo_url }}" />
   {%- set nav_version = version %}
-  {% if READTHEDOCS and current_version %}
+  {% if current_version %}
     {%- set nav_version = current_version %}
   {% endif %}
   {# don't show the version on RTD if it's the default #}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -180,12 +180,7 @@ def setup(app: Sphinx) -> None:
     app.connect("source-read", on_read_source)
 
 
-# Our docs use the READTHEDOCS variable, so copied from:
-# https://about.readthedocs.com/blog/2024/07/addons-by-default/
-if os.environ.get("READTHEDOCS", "") == "True":
-    if "html_context" not in globals():
-        html_context = {}
-    html_context["READTHEDOCS"] = True
+html_context = {"current_version": os.environ.get("READTHEDOCS_VERSION_NAME")}
 
 # -- General configuration ------------------------------------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -167,13 +167,9 @@ def autodoc_process_signature(
     return signature, return_annotation
 
 
-# XX hack the RTD theme until
-#   https://github.com/rtfd/sphinx_rtd_theme/pull/382
-# is shipped (should be in the release after 0.2.4)
-# ...note that this has since grown to contain a bunch of other CSS hacks too
-# though.
 def setup(app: Sphinx) -> None:
-    app.add_css_file("hackrtd.css")
+    # Add our custom styling to make our documentation better!
+    app.add_css_file("styles.css")
     app.connect("autodoc-process-signature", autodoc_process_signature)
     # After Intersphinx runs, add additional mappings.
     app.connect("builder-inited", add_intersphinx, priority=1000)
@@ -370,6 +366,7 @@ html_theme_options = {
     "navigation_depth": 4,
     "logo_only": True,
     "prev_next_buttons_location": "both",
+    "style_nav_header_background": "#d2e7fa",
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION
Did you know that we have been squishing the logo :'(

![image](https://github.com/user-attachments/assets/5c17f37e-8fb7-48b8-99bc-1673721b22d9)

... Well, no longer!

![image](https://github.com/user-attachments/assets/c7a86c20-2f0e-440f-b2af-6e6c180400fa)

---

Also a few other fixes.