### PR TITLE
Nursery.start() doesn't specifically return None

### DIFF
--- a/newsfragments/3224.bugfix.rst
+++ b/newsfragments/3224.bugfix.rst
@@ -1,0 +1,1 @@
+Fix incorrect return type hint for :meth:`Nursery.start() <trio.Nursery.start>`.

--- a/src/trio/_core/_run.py
+++ b/src/trio/_core/_run.py
@@ -1307,7 +1307,7 @@ class Nursery(metaclass=NoPublicConstructor):
         async_fn: Callable[..., Awaitable[object]],
         *args: object,
         name: object = None,
-    ) -> Any | None:
+    ) -> Any:
         r"""Creates and initializes a child task.
 
         Like :meth:`start_soon`, but blocks until the new task has


### PR DESCRIPTION
Noticed this, `start()` was set to `Any | None`, but it never specifically returns `None`, only if you call `started()` with no parameter on a `TaskStatus[None]`. If you're using a different task status, forcing `None` checks is just wrong.