### PR TITLE
Allow documentation builds on Windows

### DIFF
--- a/docs/source/reference-lowlevel.rst
+++ b/docs/source/reference-lowlevel.rst
@@ -274,17 +274,20 @@ TODO: these are implemented, but are currently more of a sketch than
 anything real. See `#26
 <https://github.com/python-trio/trio/issues/26>`__.
 
-.. function:: current_kqueue()
+.. autofunction:: current_kqueue()
 
-.. function:: wait_kevent(ident, filter, abort_func)
+.. autofunction:: wait_kevent(ident, filter, abort_func)
    :async:
 
-.. function:: monitor_kevent(ident, filter)
+.. autofunction:: monitor_kevent(ident, filter)
    :with: queue
 
 
 Windows-specific API
 --------------------
+
+.. note: this is a function and not `autofunction` since it relies on cffi
+   compiling some things.
 
 .. function:: WaitForSingleObject(handle)
     :async:
@@ -304,20 +307,20 @@ anything real. See `#26
 <https://github.com/python-trio/trio/issues/26>`__ and `#52
 <https://github.com/python-trio/trio/issues/52>`__.
 
-.. function:: register_with_iocp(handle)
+.. autofunction:: register_with_iocp(handle)
 
-.. function:: wait_overlapped(handle, lpOverlapped)
+.. autofunction:: wait_overlapped(handle, lpOverlapped)
    :async:
 
-.. function:: write_overlapped(handle, data)
+.. autofunction:: write_overlapped(handle, data)
    :async:
 
-.. function:: readinto_overlapped(handle, data)
+.. autofunction:: readinto_overlapped(handle, data)
    :async:
 
-.. function:: current_iocp()
+.. autofunction:: current_iocp()
 
-.. function:: monitor_completion_key()
+.. autofunction:: monitor_completion_key()
    :with: queue
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -331,7 +331,7 @@ exclude_also = [
    "@overload",
    'class .*\bProtocol\b.*\):',
    "raise NotImplementedError",
-   'if "sphinx.ext.autodoc" in sys.modules:',
+   '.*if "sphinx.ext.autodoc" in sys.modules:',
    'TODO: test this line',
    'if __name__ == "__main__":',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -330,7 +330,8 @@ exclude_also = [
    "@overload",
    'class .*\bProtocol\b.*\):',
    "raise NotImplementedError",
-   'TODO: test this line'
+   'TODO: test this line',
+   'if "sphinx.ext.autodoc" in sys.modules:',
 ]
 partial_branches = [
     "pragma: no branch",

--- a/src/trio/_channel.py
+++ b/src/trio/_channel.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
     from typing_extensions import ParamSpec, Self
 
     P = ParamSpec("P")
-elif "sphinx" in sys.modules:
+elif "sphinx.ext.autodoc" in sys.modules:
     # P needs to exist for Sphinx to parse the type hints successfully.
     try:
         from typing_extensions import ParamSpec

--- a/src/trio/_core/__init__.py
+++ b/src/trio/_core/__init__.py
@@ -5,6 +5,7 @@ are publicly available in either trio, trio.lowlevel, or trio.testing.
 """
 
 import sys
+import typing as _t
 
 from ._entry_queue import TrioToken
 from ._exceptions import (
@@ -73,7 +74,9 @@ from ._traps import (
 from ._unbounded_queue import UnboundedQueue, UnboundedQueueStatistics
 
 # Windows imports
-if sys.platform == "win32" or "sphinx.ext.autodoc" in sys.modules:
+if sys.platform == "win32" or (
+    not _t.TYPE_CHECKING and "sphinx.ext.autodoc" in sys.modules
+):
     from ._run import (
         current_iocp,
         monitor_completion_key,
@@ -83,9 +86,9 @@ if sys.platform == "win32" or "sphinx.ext.autodoc" in sys.modules:
         write_overlapped,
     )
 # Kqueue imports
-if (
-    sys.platform != "linux" and sys.platform != "win32"
-) or "sphinx.ext.autodoc" in sys.modules:
+if (sys.platform != "linux" and sys.platform != "win32") or (
+    not _t.TYPE_CHECKING and "sphinx.ext.autodoc" in sys.modules
+):
     from ._run import current_kqueue, monitor_kevent, wait_kevent
 
 del sys  # It would be better to import sys as _sys, but mypy does not understand it

--- a/src/trio/_core/__init__.py
+++ b/src/trio/_core/__init__.py
@@ -73,7 +73,7 @@ from ._traps import (
 from ._unbounded_queue import UnboundedQueue, UnboundedQueueStatistics
 
 # Windows imports
-if sys.platform == "win32":
+if sys.platform == "win32" or "sphinx.ext.autodoc" in sys.modules:
     from ._run import (
         current_iocp,
         monitor_completion_key,
@@ -83,7 +83,9 @@ if sys.platform == "win32":
         write_overlapped,
     )
 # Kqueue imports
-elif sys.platform != "linux" and sys.platform != "win32":
+if (
+    sys.platform != "linux" and sys.platform != "win32"
+) or "sphinx.ext.autodoc" in sys.modules:
     from ._run import current_kqueue, monitor_kevent, wait_kevent
 
 del sys  # It would be better to import sys as _sys, but mypy does not understand it

--- a/src/trio/_core/_run.py
+++ b/src/trio/_core/_run.py
@@ -2960,6 +2960,12 @@ def in_trio_task() -> bool:
     return hasattr(GLOBAL_RUN_CONTEXT, "task")
 
 
+# export everything for the documentation
+if "sphinx.ext.autodoc" in sys.modules:
+    from ._generated_io_epoll import *
+    from ._generated_io_kqueue import *
+    from ._generated_io_windows import *
+
 if sys.platform == "win32":
     from ._generated_io_windows import *
     from ._io_windows import (
@@ -2985,7 +2991,7 @@ else:  # pragma: no cover
     _patchers = sorted({"eventlet", "gevent"}.intersection(sys.modules))
     if _patchers:
         raise NotImplementedError(
-            "unsupported platform or primitives trio depends on are monkey-patched out by "
+            "unsupported platform or primitives Trio depends on are monkey-patched out by "
             + ", ".join(_patchers),
         )
 

--- a/src/trio/_highlevel_socket.py
+++ b/src/trio/_highlevel_socket.py
@@ -14,9 +14,17 @@ from .abc import HalfCloseableStream, Listener
 if TYPE_CHECKING:
     from collections.abc import Generator
 
-    from typing_extensions import Buffer
-
     from ._socket import SocketType
+
+import sys
+
+if sys.version_info >= (3, 12):
+    # NOTE: this isn't in the `TYPE_CHECKING` since for some reason
+    # sphinx doesn't autoreload this module for SocketStream
+    # (hypothesis: it's our module renaming magic)
+    from collections.abc import Buffer
+elif TYPE_CHECKING:
+    from typing_extensions import Buffer
 
 # XX TODO: this number was picked arbitrarily. We should do experiments to
 # tune it. (Or make it dynamic -- one idea is to start small and increase it
@@ -152,6 +160,7 @@ class SocketStream(HalfCloseableStream):
     @overload
     def setsockopt(self, level: int, option: int, value: None, length: int) -> None: ...
 
+    # TODO: rename `length` to `optlen`
     def setsockopt(
         self,
         level: int,

--- a/src/trio/_path.py
+++ b/src/trio/_path.py
@@ -255,7 +255,8 @@ class Path(pathlib.PurePath):
         full_match = _wrap_method(pathlib.Path.full_match)
 
 
-Path.relative_to.__doc__ = Path.relative_to.__doc__.replace(" `..` ", " ``..`` ")
+if Path.relative_to.__doc__:
+    Path.relative_to.__doc__ = Path.relative_to.__doc__.replace(" `..` ", " ``..`` ")
 
 
 @final

--- a/src/trio/_path.py
+++ b/src/trio/_path.py
@@ -39,8 +39,18 @@ def _wraps_async(  # type: ignore[explicit-any]
 
         update_wrapper(wrapper, wrapped)
         if wrapped.__doc__:
+            module = wrapped.__module__
+            # these are exported specially from CPython's intersphinx inventory
+            module = module.replace("pathlib._local", "pathlib")
+            module = module.replace("pathlib._abc", "pathlib")
+
+            name = wrapped.__qualname__
+            name = name.replace(
+                "PathBase", "Path"
+            )  # I'm not sure why this is necessary
+
             wrapper.__doc__ = (
-                f"Like :meth:`~{wrapped.__module__}.{wrapped.__qualname__}`, but async.\n"
+                f"Like :meth:`~{module}.{name}`, but async.\n"
                 f"\n"
                 f"{cleandoc(wrapped.__doc__)}\n"
             )
@@ -243,6 +253,9 @@ class Path(pathlib.PurePath):
         link_to = _wrap_method(pathlib.Path.link_to)
     if sys.version_info >= (3, 13):
         full_match = _wrap_method(pathlib.Path.full_match)
+
+
+Path.relative_to.__doc__ = Path.relative_to.__doc__.replace(" `..` ", " ``..`` ")
 
 
 @final

--- a/src/trio/_path.py
+++ b/src/trio/_path.py
@@ -255,7 +255,7 @@ class Path(pathlib.PurePath):
         full_match = _wrap_method(pathlib.Path.full_match)
 
 
-if Path.relative_to.__doc__:
+if Path.relative_to.__doc__:  # pragma: no branch
     Path.relative_to.__doc__ = Path.relative_to.__doc__.replace(" `..` ", " ``..`` ")
 
 

--- a/src/trio/_tests/test_unix_pipes.py
+++ b/src/trio/_tests/test_unix_pipes.py
@@ -22,9 +22,6 @@ assert not TYPE_CHECKING or sys.platform == "unix"
 
 if posix:
     from .._unix_pipes import FdStream
-else:
-    with pytest.raises(ImportError):
-        from .._unix_pipes import FdStream
 
 
 async def make_pipe() -> tuple[FdStream, FdStream]:

--- a/src/trio/_timeouts.py
+++ b/src/trio/_timeouts.py
@@ -190,7 +190,7 @@ def fail_after(
 # Users don't need to know that fail_at & fail_after wraps move_on_at and move_on_after
 # and there is no functional difference. So we replace the return value when generating
 # documentation.
-if "sphinx" in sys.modules:  # pragma: no cover
+if "sphinx.ext.autodoc" in sys.modules:
     import inspect
 
     for c in (fail_at, fail_after):

--- a/src/trio/_unix_pipes.py
+++ b/src/trio/_unix_pipes.py
@@ -15,11 +15,6 @@ if TYPE_CHECKING:
 
 assert not TYPE_CHECKING or sys.platform != "win32"
 
-if os.name != "posix":
-    # We raise an error here rather than gating the import in lowlevel.py
-    # in order to keep jedi static analysis happy.
-    raise ImportError
-
 # XX TODO: is this a good number? who knows... it does match the default Linux
 # pipe capacity though.
 DEFAULT_RECEIVE_SIZE: FinalType = 65536

--- a/src/trio/lowlevel.py
+++ b/src/trio/lowlevel.py
@@ -73,7 +73,7 @@ if sys.platform == "win32" or (
     )
 
     # don't let documentation import the actual implementation
-    if sys.platform == "win32":
+    if sys.platform == "win32":  # pragma: no branch
         from ._wait_for_object import WaitForSingleObject as WaitForSingleObject
 
 if sys.platform != "win32" or (

--- a/src/trio/lowlevel.py
+++ b/src/trio/lowlevel.py
@@ -5,6 +5,7 @@ but useful for extending Trio's functionality.
 
 # imports are renamed with leading underscores to indicate they are not part of the public API
 
+import os as _os
 import select as _select
 
 # static checkers don't understand if importing this as _sys, so it's deleted later
@@ -74,7 +75,8 @@ if sys.platform == "win32":
     from ._wait_for_object import WaitForSingleObject as WaitForSingleObject
 else:
     # Unix symbols
-    from ._unix_pipes import FdStream as FdStream
+    if _os.name == "posix":
+        from ._unix_pipes import FdStream as FdStream
 
     # Kqueue-specific symbols
     if sys.platform != "linux" and (_t.TYPE_CHECKING or not hasattr(_select, "epoll")):

--- a/src/trio/lowlevel.py
+++ b/src/trio/lowlevel.py
@@ -72,7 +72,10 @@ if sys.platform == "win32" or "sphinx.ext.autodoc" in sys.modules:
         wait_overlapped as wait_overlapped,
         write_overlapped as write_overlapped,
     )
-    from ._wait_for_object import WaitForSingleObject as WaitForSingleObject
+
+    # don't let documentation import the actual implementation
+    if sys.platform == "win32":
+        from ._wait_for_object import WaitForSingleObject as WaitForSingleObject
 
 if sys.platform != "win32" or "sphinx.ext.autodoc" in sys.modules:
     # Unix symbols

--- a/src/trio/lowlevel.py
+++ b/src/trio/lowlevel.py
@@ -4,8 +4,6 @@ but useful for extending Trio's functionality.
 """
 
 # imports are renamed with leading underscores to indicate they are not part of the public API
-
-import os as _os
 import select as _select
 
 # static checkers don't understand if importing this as _sys, so it's deleted later
@@ -61,8 +59,9 @@ from ._subprocess import open_process as open_process
 
 # Uses `from x import y as y` for compatibility with `pyright --verifytypes` (#2625)
 
-
-if sys.platform == "win32" or "sphinx.ext.autodoc" in sys.modules:
+if sys.platform == "win32" or (
+    not _t.TYPE_CHECKING and "sphinx.ext.autodoc" in sys.modules
+):
     # Windows symbols
     from ._core import (
         current_iocp as current_iocp,
@@ -77,14 +76,16 @@ if sys.platform == "win32" or "sphinx.ext.autodoc" in sys.modules:
     if sys.platform == "win32":
         from ._wait_for_object import WaitForSingleObject as WaitForSingleObject
 
-if sys.platform != "win32" or "sphinx.ext.autodoc" in sys.modules:
+if sys.platform != "win32" or (
+    not _t.TYPE_CHECKING and "sphinx.ext.autodoc" in sys.modules
+):
     # Unix symbols
     from ._unix_pipes import FdStream as FdStream
 
     # Kqueue-specific symbols
     if (
         sys.platform != "linux" and (_t.TYPE_CHECKING or not hasattr(_select, "epoll"))
-    ) or "sphinx.ext.autodoc" in sys.modules:
+    ) or (not _t.TYPE_CHECKING and "sphinx.ext.autodoc" in sys.modules):
         from ._core import (
             current_kqueue as current_kqueue,
             monitor_kevent as monitor_kevent,

--- a/src/trio/lowlevel.py
+++ b/src/trio/lowlevel.py
@@ -62,7 +62,7 @@ from ._subprocess import open_process as open_process
 # Uses `from x import y as y` for compatibility with `pyright --verifytypes` (#2625)
 
 
-if sys.platform == "win32":
+if sys.platform == "win32" or "sphinx.ext.autodoc" in sys.modules:
     # Windows symbols
     from ._core import (
         current_iocp as current_iocp,
@@ -73,13 +73,15 @@ if sys.platform == "win32":
         write_overlapped as write_overlapped,
     )
     from ._wait_for_object import WaitForSingleObject as WaitForSingleObject
-else:
+
+if sys.platform != "win32" or "sphinx.ext.autodoc" in sys.modules:
     # Unix symbols
-    if _os.name == "posix":
-        from ._unix_pipes import FdStream as FdStream
+    from ._unix_pipes import FdStream as FdStream
 
     # Kqueue-specific symbols
-    if sys.platform != "linux" and (_t.TYPE_CHECKING or not hasattr(_select, "epoll")):
+    if (
+        sys.platform != "linux" and (_t.TYPE_CHECKING or not hasattr(_select, "epoll"))
+    ) or "sphinx.ext.autodoc" in sys.modules:
         from ._core import (
             current_kqueue as current_kqueue,
             monitor_kevent as monitor_kevent,


### PR DESCRIPTION
Fixes https://github.com/python-trio/trio/issues/3071

I'm not *totally* sure about all changes here. Some are likely only because my local installation of Python is 3.13.

Also this is definitely not the cleanest method of doing this :P