### PR TITLE
Use PEP 562 instead of _ModuleWithDeprecations

### DIFF
--- a/newsfragments/2135.bugfix.rst
+++ b/newsfragments/2135.bugfix.rst
@@ -1,0 +1,1 @@
+Allow `trio` to be a `types.ModuleType` and still have deprecated attributes.

--- a/src/trio/__init__.py
+++ b/src/trio/__init__.py
@@ -112,8 +112,7 @@ if TYPE_CHECKING:
 
 from . import _deprecate as _deprecate
 
-if not TYPE_CHECKING:
-    __getattr__ = _deprecate.getattr_for_deprecated_attributes(__name__, {})
+_deprecate.deprecate_attributes(__name__, {})
 
 # Having the public path in .__module__ attributes is important for:
 # - exception names in printed tracebacks

--- a/src/trio/__init__.py
+++ b/src/trio/__init__.py
@@ -112,9 +112,8 @@ if TYPE_CHECKING:
 
 from . import _deprecate as _deprecate
 
-_deprecate.enable_attribute_deprecations(__name__)
-
-__deprecated_attributes__: dict[str, _deprecate.DeprecatedAttribute] = {}
+if not TYPE_CHECKING:
+    __getattr__ = _deprecate.getattr_for_deprecated_attributes(__name__, {})
 
 # Having the public path in .__module__ attributes is important for:
 # - exception names in printed tracebacks

--- a/src/trio/_deprecate.py
+++ b/src/trio/_deprecate.py
@@ -151,7 +151,7 @@ class DeprecatedAttribute:
 
 def deprecate_attributes(
     module_name: str, deprecated_attributes: dict[str, DeprecatedAttribute]
-) -> Callable[[str], object]:
+) -> None:
     def __getattr__(name: str) -> object:
         if name in deprecated_attributes:
             info = deprecated_attributes[name]
@@ -165,4 +165,4 @@ def deprecate_attributes(
         msg = "module '{}' has no attribute '{}'"
         raise AttributeError(msg.format(module_name, name))
 
-    sys.modules[module_name].__getattr__ = __getattr__
+    sys.modules[module_name].__getattr__ = __getattr__  # type: ignore[method-assign]

--- a/src/trio/_deprecate.py
+++ b/src/trio/_deprecate.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 import warnings
 from functools import wraps
 from typing import TYPE_CHECKING, ClassVar, TypeVar
@@ -148,7 +149,7 @@ class DeprecatedAttribute:
     instead: object = _not_set
 
 
-def getattr_for_deprecated_attributes(
+def deprecate_attributes(
     module_name: str, deprecated_attributes: dict[str, DeprecatedAttribute]
 ) -> Callable[[str], object]:
     def __getattr__(name: str) -> object:
@@ -164,4 +165,4 @@ def getattr_for_deprecated_attributes(
         msg = "module '{}' has no attribute '{}'"
         raise AttributeError(msg.format(module_name, name))
 
-    return __getattr__
+    sys.modules[module_name].__getattr__ = __getattr__

--- a/src/trio/_deprecate.py
+++ b/src/trio/_deprecate.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
-import sys
 import warnings
 from functools import wraps
-from types import ModuleType
 from typing import TYPE_CHECKING, ClassVar, TypeVar
 
 import attrs
@@ -150,28 +148,20 @@ class DeprecatedAttribute:
     instead: object = _not_set
 
 
-class _ModuleWithDeprecations(ModuleType):
-    __deprecated_attributes__: dict[str, DeprecatedAttribute]
-
-    def __getattr__(self, name: str) -> object:
-        if name in self.__deprecated_attributes__:
-            info = self.__deprecated_attributes__[name]
+def getattr_for_deprecated_attributes(
+    module_name: str, deprecated_attributes: dict[str, DeprecatedAttribute]
+) -> Callable[[str], object]:
+    def __getattr__(name: str) -> object:
+        if name in deprecated_attributes:
+            info = deprecated_attributes[name]
             instead = info.instead
             if instead is DeprecatedAttribute._not_set:
                 instead = info.value
-            thing = f"{self.__name__}.{name}"
+            thing = f"{module_name}.{name}"
             warn_deprecated(thing, info.version, issue=info.issue, instead=instead)
             return info.value
 
         msg = "module '{}' has no attribute '{}'"
-        raise AttributeError(msg.format(self.__name__, name))
+        raise AttributeError(msg.format(module_name, name))
 
-
-def enable_attribute_deprecations(module_name: str) -> None:
-    module = sys.modules[module_name]
-    module.__class__ = _ModuleWithDeprecations
-    assert isinstance(module, _ModuleWithDeprecations)
-    # Make sure that this is always defined so that
-    # _ModuleWithDeprecations.__getattr__ can access it without jumping
-    # through hoops or risking infinite recursion.
-    module.__deprecated_attributes__ = {}
+    return __getattr__

--- a/src/trio/_tests/module_with_deprecations.py
+++ b/src/trio/_tests/module_with_deprecations.py
@@ -1,27 +1,22 @@
 regular = "hi"
 
-# Make sure that we don't trigger infinite recursion when accessing module
-# attributes in between calling enable_attribute_deprecations and defining
-# __deprecated_attributes__:
 import sys
-from typing import TYPE_CHECKING
 
 from .. import _deprecate
 
+_deprecate.deprecate_attributes(
+    __name__,
+    {
+        "dep1": _deprecate.DeprecatedAttribute("value1", "1.1", issue=1),
+        "dep2": _deprecate.DeprecatedAttribute(
+            "value2",
+            "1.2",
+            issue=1,
+            instead="instead-string",
+        ),
+    },
+)
+
 this_mod = sys.modules[__name__]
 assert this_mod.regular == "hi"
-assert not hasattr(this_mod, "dep1")
-
-if not TYPE_CHECKING:
-    __getattr__ = _deprecate.getattr_for_deprecated_attributes(
-        __name__,
-        {
-            "dep1": _deprecate.DeprecatedAttribute("value1", "1.1", issue=1),
-            "dep2": _deprecate.DeprecatedAttribute(
-                "value2",
-                "1.2",
-                issue=1,
-                instead="instead-string",
-            ),
-        },
-    )
+assert "dep1" not in globals()

--- a/src/trio/_tests/module_with_deprecations.py
+++ b/src/trio/_tests/module_with_deprecations.py
@@ -1,24 +1,27 @@
 regular = "hi"
 
-from .. import _deprecate
-
-_deprecate.enable_attribute_deprecations(__name__)
-
 # Make sure that we don't trigger infinite recursion when accessing module
 # attributes in between calling enable_attribute_deprecations and defining
 # __deprecated_attributes__:
 import sys
+import typing
+
+from .. import _deprecate
 
 this_mod = sys.modules[__name__]
 assert this_mod.regular == "hi"
 assert not hasattr(this_mod, "dep1")
 
-__deprecated_attributes__ = {
-    "dep1": _deprecate.DeprecatedAttribute("value1", "1.1", issue=1),
-    "dep2": _deprecate.DeprecatedAttribute(
-        "value2",
-        "1.2",
-        issue=1,
-        instead="instead-string",
-    ),
-}
+if not typing.TYPE_CHECKING:
+    __getattr__ = _deprecate.getattr_for_deprecated_attributes(
+        __name__,
+        {
+            "dep1": _deprecate.DeprecatedAttribute("value1", "1.1", issue=1),
+            "dep2": _deprecate.DeprecatedAttribute(
+                "value2",
+                "1.2",
+                issue=1,
+                instead="instead-string",
+            ),
+        },
+    )

--- a/src/trio/_tests/module_with_deprecations.py
+++ b/src/trio/_tests/module_with_deprecations.py
@@ -4,7 +4,7 @@ regular = "hi"
 # attributes in between calling enable_attribute_deprecations and defining
 # __deprecated_attributes__:
 import sys
-import typing
+from typing import TYPE_CHECKING
 
 from .. import _deprecate
 
@@ -12,7 +12,7 @@ this_mod = sys.modules[__name__]
 assert this_mod.regular == "hi"
 assert not hasattr(this_mod, "dep1")
 
-if not typing.TYPE_CHECKING:
+if not TYPE_CHECKING:
     __getattr__ = _deprecate.getattr_for_deprecated_attributes(
         __name__,
         {

--- a/src/trio/_tests/test_deprecate.py
+++ b/src/trio/_tests/test_deprecate.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import inspect
 import warnings
+from types import ModuleType
 
 import pytest
 
@@ -243,6 +244,8 @@ def test_deprecated_docstring_munging() -> None:
 def test_module_with_deprecations(recwarn_always: pytest.WarningsRecorder) -> None:
     assert module_with_deprecations.regular == "hi"
     assert len(recwarn_always) == 0
+
+    assert type(module_with_deprecations) is ModuleType
 
     filename, lineno = _here()
     assert module_with_deprecations.dep1 == "value1"  # type: ignore[attr-defined]


### PR DESCRIPTION
Presumably fixes https://github.com/python-trio/trio/issues/2135 but I haven't checked this and I'm not sure how to test this (as it relies on `cloudpickle` not `pickle`).