### PR TITLE
Add tool to keep test-requirements in sync with pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,6 +58,13 @@ repos:
         pass_filenames: false
         additional_dependencies: ["astor", "attrs", "black", "ruff"]
         files: ^src\/trio\/_core\/(_run|(_i(o_(common|epoll|kqueue|windows)|nstrumentation)))\.py$
+      - id: sync-test-requirements
+        name: synchronize test requirements
+        language: python
+        entry: python src/trio/_tools/sync_requirements.py
+        pass_filenames: false
+        additional_dependencies: ["pyyaml"]
+        files: ^(test-requirements\.txt)|(\.pre-commit-config\.yaml)$
   - repo: https://github.com/astral-sh/uv-pre-commit
     rev: 0.6.6
     hooks:

--- a/src/trio/_tests/tools/test_sync_requirements.py
+++ b/src/trio/_tests/tools/test_sync_requirements.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from trio._tests.pytest_plugin import skip_if_optional_else_raise
+
+# imports in gen_exports that are not in `install_requires` in requirements
+try:
+    import yaml  # noqa: F401
+except ImportError as error:
+    skip_if_optional_else_raise(error)
+
+from trio._tools.sync_requirements import (
+    update_requirements,
+    yield_pre_commit_version_data,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_yield_pre_commit_version_data() -> None:
+    text = """
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.0
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 25.1.0
+"""
+    results = tuple(yield_pre_commit_version_data(text))
+    assert results == (
+        ("ruff-pre-commit", "0.11.0"),
+        ("black-pre-commit-mirror", "25.1.0"),
+    )
+
+
+def test_update_requirements(
+    tmp_path: Path,
+) -> None:
+    requirements_file = tmp_path / "requirements.txt"
+    assert not requirements_file.exists()
+    requirements_file.write_text(
+        """# comment
+  # also comment but spaces line start
+waffles are delicious no equals
+black==3.1.4 ; specific version thingy
+mypy==1.15.0
+ruff==1.2.5
+# required by soupy cat""",
+        encoding="utf-8",
+    )
+    assert update_requirements(requirements_file, {"black": "3.1.5", "ruff": "1.2.7"})
+    assert (
+        requirements_file.read_text(encoding="utf-8")
+        == """# comment
+  # also comment but spaces line start
+waffles are delicious no equals
+black==3.1.5 ; specific version thingy
+mypy==1.15.0
+ruff==1.2.7
+# required by soupy cat"""
+    )
+
+
+def test_update_requirements_no_changes(
+    tmp_path: Path,
+) -> None:
+    requirements_file = tmp_path / "requirements.txt"
+    assert not requirements_file.exists()
+    original = """# comment
+  # also comment but spaces line start
+waffles are delicious no equals
+black==3.1.4 ; specific version thingy
+mypy==1.15.0
+ruff==1.2.5
+# required by soupy cat"""
+    requirements_file.write_text(original, encoding="utf-8")
+    assert not update_requirements(
+        requirements_file, {"black": "3.1.4", "ruff": "1.2.5"}
+    )
+    assert requirements_file.read_text(encoding="utf-8") == original

--- a/src/trio/_tools/sync_requirements.py
+++ b/src/trio/_tools/sync_requirements.py
@@ -25,10 +25,10 @@ except ImportError:
 
 
 def yield_pre_commit_version_data(
-    pre_commit: Path,
+    pre_commit_text: str,
 ) -> Generator[tuple[str, str], None, None]:
     """Yield (name, rev) tuples from pre-commit config file."""
-    pre_commit_config = load_yaml(pre_commit.read_text(encoding="utf-8"), Loader)
+    pre_commit_config = load_yaml(pre_commit_text, Loader)
     for repo in pre_commit_config["repos"]:
         if "repo" not in repo or "rev" not in repo:
             continue
@@ -81,18 +81,19 @@ def main() -> int:
     """Run program."""
 
     source_root = Path.cwd().absolute()
-    while not (source_root / "LICENSE").exists():
-        source_root = source_root.parent
+
     # Double-check we found the right directory
     assert (source_root / "LICENSE").exists()
     pre_commit = source_root / ".pre-commit-config.yaml"
     test_requirements = source_root / "test-requirements.txt"
 
+    pre_commit_text = pre_commit.read_text(encoding="utf-8")
+
     # Get tool versions from pre-commit
     # Get correct names
     pre_commit_versions = {
         name.removesuffix("-mirror").removesuffix("-pre-commit"): version
-        for name, version in yield_pre_commit_version_data(pre_commit)
+        for name, version in yield_pre_commit_version_data(pre_commit_text)
     }
     changed = update_requirements(test_requirements, pre_commit_versions)
     return int(changed)

--- a/src/trio/_tools/sync_requirements.py
+++ b/src/trio/_tools/sync_requirements.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+
+"""Sync Requirements - Automatically upgrade test requirements pinned
+versions from pre-commit config file."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from yaml import load as load_yaml
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from yaml import CLoader as _CLoader, Loader as _Loader
+
+    Loader: type[_CLoader | _Loader]
+
+try:
+    from yaml import CLoader as Loader
+except ImportError:
+    from yaml import Loader
+
+
+def yield_pre_commit_version_data(
+    pre_commit: Path,
+) -> Generator[tuple[str, str], None, None]:
+    """Yield (name, rev) tuples from pre-commit config file."""
+    pre_commit_config = load_yaml(pre_commit.read_text(encoding="utf-8"), Loader)
+    for repo in pre_commit_config["repos"]:
+        if "repo" not in repo or "rev" not in repo:
+            continue
+        url = repo["repo"]
+        name = url.rsplit("/", 1)[-1]
+        rev = repo["rev"].removeprefix("v")
+        yield name, rev
+
+
+def update_requirements(
+    requirements: Path,
+    version_data: dict[str, str],
+) -> bool:
+    """Return if updated requirements file.
+
+    Update requirements file to match versions in version_data."""
+    changed = False
+    old_lines = requirements.read_text(encoding="utf-8").splitlines(True)
+
+    with requirements.open("w", encoding="utf-8") as file:
+        for line in old_lines:
+            # If comment or not version mark line, ignore.
+            if line.startswith("#") or "==" not in line:
+                file.write(line)
+                continue
+            name, rest = line.split("==", 1)
+            # Maintain extra markers if they exist
+            old_version = rest.strip()
+            extra = "\n"
+            if " " in rest:
+                old_version, extra = rest.split(" ", 1)
+                extra = " " + extra
+            version = version_data.get(name)
+            # If does not exist, skip
+            if version is None:
+                file.write(line)
+                continue
+            # Otherwise might have changed
+            new_line = f"{name}=={version}{extra}"
+            if new_line != line:
+                if not changed:
+                    changed = True
+                    print("Changed test requirements version to match pre-commit")
+                print(f"{name}=={old_version} -> {name}=={version}")
+            file.write(new_line)
+    return changed
+
+
+def main() -> int:
+    """Run program."""
+
+    source_root = Path.cwd().absolute()
+    while not (source_root / "LICENSE").exists():
+        source_root = source_root.parent
+    # Double-check we found the right directory
+    assert (source_root / "LICENSE").exists()
+    pre_commit = source_root / ".pre-commit-config.yaml"
+    test_requirements = source_root / "test-requirements.txt"
+
+    # Get tool versions from pre-commit
+    # Get correct names
+    pre_commit_versions = {
+        name.removesuffix("-mirror").removesuffix("-pre-commit"): version
+        for name, version in yield_pre_commit_version_data(pre_commit)
+    }
+    changed = update_requirements(test_requirements, pre_commit_versions)
+    return int(changed)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/trio/_tools/sync_requirements.py
+++ b/src/trio/_tools/sync_requirements.py
@@ -58,9 +58,10 @@ def update_requirements(
             # Maintain extra markers if they exist
             old_version = rest.strip()
             extra = "\n"
-            if " " in rest:
-                old_version, extra = rest.split(" ", 1)
-                extra = " " + extra
+            if ";" in rest:
+                old_version, extra = rest.split(";", 1)
+                old_version = old_version.strip()
+                extra = " ;" + extra
             version = version_data.get(name)
             # If does not exist, skip
             if version is None:

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -27,6 +27,8 @@ types-pyOpenSSL
 # annotations in doc files
 types-docutils
 sphinx
+# sync-requirements
+types-PyYAML
 
 # Trio's own dependencies
 cffi; os_name == "nt"

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -177,6 +177,8 @@ types-docutils==0.21.0.20241128
     # via -r test-requirements.in
 types-pyopenssl==24.1.0.20240722
     # via -r test-requirements.in
+types-pyyaml==6.0.12.20250326
+    # via -r test-requirements.in
 types-setuptools==75.8.0.20250225
     # via types-cffi
 typing-extensions==4.12.2


### PR DESCRIPTION
In this pull request, we add a local pre-commit hook tool to keep the tool versions in `test-requirements.txt` in sync with the equivalent versions in `.pre-commit-config.yaml` automatically, meaning pre-commit.ci automatic updates are more seamless and there can never be cases where the test versions don't match the pre-commit versions.

<!--
I have previously advocated for not disabling the automatic pre-commit updates, because I think it's important to keep the tooling up to date, and in particular for the case of ruff rule changes, version differences can (or at least used to, they are being more stable now) yield wildly different results. My logic was that pre-commit tooling changes should be done as soon as possible and not as a part of other pull requests. I could see a case where once people see this pull request, they argue we should disable the automatic pre-commit updates to avoid the problem this is avoiding.
-->