### PR TITLE
Enable extra error codes for mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,6 +193,7 @@ files = ["src/trio/", "docs/source/*.py"]
 ignore_missing_imports = true
 
 # Be strict about use of Mypy
+enable_error_code = ["truthy-bool", "mutable-override"]
 local_partial_types = true
 warn_unused_ignores = true
 warn_unused_configs = true

--- a/src/trio/_tests/check_type_completeness.py
+++ b/src/trio/_tests/check_type_completeness.py
@@ -49,7 +49,7 @@ def has_docstring_at_runtime(name: str) -> bool:
     """
     # This assert is solely for stopping isort from removing our imports of trio & trio.testing
     # It could also be done with isort:skip, but that'd also disable import sorting and the like.
-    assert trio.testing
+    assert trio.testing is not None
 
     # figure out what part of the name is the module, so we can "import" it
     name_parts = name.split(".")
@@ -116,7 +116,7 @@ def check_type(
     expected_errors: list[object],
 ) -> list[object]:
     # convince isort we use the trio import
-    assert trio
+    assert trio is not None
 
     # run pyright, load output into json
     res = run_pyright(platform)

--- a/src/trio/_tests/type_tests/raisesgroup.py
+++ b/src/trio/_tests/type_tests/raisesgroup.py
@@ -169,7 +169,7 @@ def check_multiple_exceptions_1() -> None:
     d = a
     d = b
     d = c
-    assert d
+    assert isinstance(d, RaisesGroup)
 
 
 def check_multiple_exceptions_2() -> None:
@@ -182,7 +182,7 @@ def check_multiple_exceptions_2() -> None:
     d = a
     d = b
     d = c
-    assert d
+    assert isinstance(d, RaisesGroup)
 
 
 def check_raisesgroup_overloads() -> None:


### PR DESCRIPTION
In https://github.com/python-trio/trio/issues/3238 I noticed the `truthy-bool` error code seems useful. I combined it with some changes I have locally for another interesting-but-unimpactful error code.

This doesn't catch anything but it's better to lead by example! (all 4 places flagged by `truthy-bool` were us using `assert` to tell various tools that the thing being asserted is used.)