### PR TITLE
Switch from `PurePath#as_uri` to `PurePath#joinpath` for our test that PurePath methods get inherited

### DIFF
--- a/src/trio/_path.py
+++ b/src/trio/_path.py
@@ -244,6 +244,9 @@ class Path(pathlib.PurePath):
     if sys.version_info >= (3, 13):
         full_match = _wrap_method(pathlib.Path.full_match)
 
+    def as_uri(self) -> str:
+        return pathlib.Path.as_uri(self)
+
 
 @final
 class PosixPath(Path, pathlib.PurePosixPath):

--- a/src/trio/_tests/test_path.py
+++ b/src/trio/_tests/test_path.py
@@ -168,10 +168,14 @@ def test_forward_properties_rewrap(path: trio.Path) -> None:
     assert isinstance(path.parent, trio.Path)
 
 
-async def test_forward_methods_without_rewrap(path: trio.Path) -> None:
+def test_forward_methods_without_rewrap(path: trio.Path) -> None:
+    assert "totally-unique-path" in str(path.joinpath("totally-unique-path"))
+
+
+async def test_path_methods_on_trio_path(path: trio.Path) -> None:
     path = await path.parent.resolve()
 
-    assert path.as_uri().startswith("file:///")
+    assert pathlib.Path.as_uri(path).startswith("file:///")
 
 
 def test_repr() -> None:

--- a/src/trio/_tests/test_path.py
+++ b/src/trio/_tests/test_path.py
@@ -172,12 +172,6 @@ def test_forward_methods_without_rewrap(path: trio.Path) -> None:
     assert "totally-unique-path" in str(path.joinpath("totally-unique-path"))
 
 
-async def test_path_methods_on_trio_path(path: trio.Path) -> None:
-    path = await path.parent.resolve()
-
-    assert pathlib.Path.as_uri(path).startswith("file:///")
-
-
 def test_repr() -> None:
     path = trio.Path(".")
 
@@ -234,6 +228,12 @@ async def test_globmethods(path: trio.Path) -> None:
         entries.add(entry.name)
 
     assert entries == {"_bar.txt", "bar.txt"}
+
+
+async def test_as_uri(path: trio.Path) -> None:
+    path = await path.parent.resolve()
+
+    assert path.as_uri().startswith("file:///")
 
 
 async def test_iterdir(path: trio.Path) -> None:

--- a/src/trio/_tests/type_tests/path.py
+++ b/src/trio/_tests/type_tests/path.py
@@ -46,6 +46,7 @@ def sync_attrs(path: trio.Path) -> None:
     assert_type(path.suffixes, list[str])
     assert_type(path.stem, str)
     assert_type(path.as_posix(), str)
+    assert_type(path.as_uri(), str)
     assert_type(path.is_absolute(), bool)
     assert_type(path.is_relative_to(path), bool)
     assert_type(path.is_reserved(), bool)

--- a/src/trio/_tests/type_tests/path.py
+++ b/src/trio/_tests/type_tests/path.py
@@ -46,7 +46,6 @@ def sync_attrs(path: trio.Path) -> None:
     assert_type(path.suffixes, list[str])
     assert_type(path.stem, str)
     assert_type(path.as_posix(), str)
-    assert_type(path.as_uri(), str)
     assert_type(path.is_absolute(), bool)
     assert_type(path.is_relative_to(path), bool)
     assert_type(path.is_reserved(), bool)


### PR DESCRIPTION
`as_uri` is deprecated in `PurePath`. This commit also introduces a test to ensure users have a workaround that is not deprecated.

Failing test run: https://github.com/python-trio/trio/actions/runs/14393482504/job/40364976912