### PR TITLE
Switch to a `typos` mirror

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
         additional_dependencies:
           # tomli needed on 3.10. tomllib is available in stdlib on 3.11+
           - tomli
-  - repo: https://github.com/crate-ci/typos
+  - repo: https://github.com/adhtruong/mirrors-typos
     rev: v1.31.1
     hooks:
       - id: typos


### PR DESCRIPTION
In this pull request, we change the `crateci/typos` pre-commit hook to use https://github.com/adhtruong/mirrors-typos instead. See https://github.com/crate-ci/typos/issues/390 for full details about why, but basically to support github marketplace the v1 tag is mutable and pre-commit will raise a warning during updates after it changes it to v1. Using a mirror such as this one avoids the problem.