### PR TITLE
Add message with debugging info to Cancelled

### DIFF
--- a/newsfragments/3232.feature.rst
+++ b/newsfragments/3232.feature.rst
@@ -1,0 +1,1 @@
+:exc:`Cancelled` strings can now display the source and reason for a cancellation. Trio-internal sources of cancellation will set this string, and :meth:`CancelScope.cancel` now has a ``reason`` string parameter that can be used to attach info to any :exc:`Cancelled` to help in debugging.

--- a/src/trio/_channel.py
+++ b/src/trio/_channel.py
@@ -17,8 +17,7 @@ from outcome import Error, Value
 import trio
 
 from ._abc import ReceiveChannel, ReceiveType, SendChannel, SendType, T
-from ._core import Abort, RaiseCancelT, Task, current_task, enable_ki_protection
-from ._core._run import CancelReason
+from ._core import Abort, RaiseCancelT, Task, enable_ki_protection
 from ._util import (
     MultipleExceptionError,
     NoPublicConstructor,
@@ -548,12 +547,8 @@ def as_safe_channel(
                     yield wrapped_recv_chan
                 # User has exited context manager, cancel to immediately close the
                 # abandoned generator if it's still alive.
-                nursery.cancel_scope._cancel(
-                    CancelReason(
-                        reason="exited trio.as_safe_channel context manager",
-                        source="shutdown",
-                        source_task=repr(current_task),
-                    )
+                nursery.cancel_scope.cancel(
+                    "exited trio.as_safe_channel context manager"
                 )
         except BaseExceptionGroup as eg:
             try:

--- a/src/trio/_channel.py
+++ b/src/trio/_channel.py
@@ -548,12 +548,13 @@ def as_safe_channel(
                     yield wrapped_recv_chan
                 # User has exited context manager, cancel to immediately close the
                 # abandoned generator if it's still alive.
-                nursery.cancel_scope._cancel_reason = CancelReason(
-                    reason="exited _as_safe_channel context manager",
-                    source="shutdown",
-                    source_task=repr(current_task),
+                nursery.cancel_scope._cancel(
+                    CancelReason(
+                        reason="exited trio.as_safe_channel context manager",
+                        source="shutdown",
+                        source_task=repr(current_task),
+                    )
                 )
-                nursery.cancel_scope.cancel()
         except BaseExceptionGroup as eg:
             try:
                 raise_single_exception_from_group(eg)

--- a/src/trio/_channel.py
+++ b/src/trio/_channel.py
@@ -547,7 +547,7 @@ def as_safe_channel(
                     yield wrapped_recv_chan
                 # User has exited context manager, cancel to immediately close the
                 # abandoned generator if it's still alive.
-                nursery.cancel_scope.cancel()
+                nursery.cancel_scope.cancel(reason="user exited context manager")
         except BaseExceptionGroup as eg:
             try:
                 raise_single_exception_from_group(eg)

--- a/src/trio/_core/_asyncgens.py
+++ b/src/trio/_core/_asyncgens.py
@@ -230,7 +230,9 @@ class AsyncGenerators:
             # with an exception, not even a Cancelled. The inside
             # is cancelled so there's no deadlock risk.
             with _core.CancelScope(shield=True) as cancel_scope:
-                cancel_scope.cancel()
+                cancel_scope.cancel(
+                    reason="internal trio cancellation during finalization"
+                )
                 await agen.aclose()
         except BaseException:
             ASYNCGEN_LOGGER.exception(

--- a/src/trio/_core/_asyncgens.py
+++ b/src/trio/_core/_asyncgens.py
@@ -231,7 +231,7 @@ class AsyncGenerators:
             # is cancelled so there's no deadlock risk.
             with _core.CancelScope(shield=True) as cancel_scope:
                 cancel_scope.cancel(
-                    reason="internal trio cancellation during finalization"
+                    reason="disallow async work when closing async generators during trio shutdown"
                 )
                 await agen.aclose()
         except BaseException:

--- a/src/trio/_core/_exceptions.py
+++ b/src/trio/_core/_exceptions.py
@@ -10,7 +10,16 @@ from trio._util import NoPublicConstructor, final
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from typing_extensions import Self
+    from typing_extensions import Self, TypeAlias
+
+CancelReasonLiteral: TypeAlias = Literal[
+    "KeyboardInterrupt",
+    "deadline",
+    "explicit",
+    "nursery",
+    "shutdown",
+    "unknown",
+]
 
 
 class TrioInternalError(Exception):
@@ -73,9 +82,7 @@ class Cancelled(BaseException, metaclass=NoPublicConstructor):
 
     """
 
-    source: Literal[
-        "KeyboardInterrupt", "deadline", "explicit", "nursery", "shutdown", "unknown"
-    ]
+    source: CancelReasonLiteral
     # repr(Task), so as to avoid gc troubles from holding a reference
     source_task: str | None = None
     reason: str | None = None
@@ -107,14 +114,7 @@ class Cancelled(BaseException, metaclass=NoPublicConstructor):
         def _create(
             cls,
             *,
-            source: Literal[
-                "KeyboardInterrupt",
-                "deadline",
-                "explicit",
-                "nursery",
-                "shutdown",
-                "unknown",
-            ],
+            source: CancelReasonLiteral,
             source_task: str | None = None,
             reason: str | None = None,
         ) -> Self: ...

--- a/src/trio/_core/_exceptions.py
+++ b/src/trio/_core/_exceptions.py
@@ -81,22 +81,16 @@ class Cancelled(BaseException, metaclass=NoPublicConstructor):
     reason: str | None = None
 
     def __str__(self) -> str:
-        def repr_if_not_none(lead: str, s: str | None, do_repr: bool = False) -> str:
-            if s is None:
-                return ""
-            if do_repr:
-                return lead + repr(s)
-            return lead + s
-
         return (
             f"cancelled due to {self.source}"
-            + repr_if_not_none(" with reason ", self.reason, True)
-            + repr_if_not_none(" from task ", self.source_task)
+            + ("" if self.reason is None else f" with reason {self.reason!r}")
+            + ("" if self.source_task is None else f" from task {self.source_task}")
         )
 
     def __reduce__(self) -> tuple[Callable[[], Cancelled], tuple[()]]:
-        # the `__reduce__` tuple does not support kwargs, so we must use partial
-        # for non-default args
+        # The `__reduce__` tuple does not support directly passing kwargs, and the
+        # kwargs are required so we can't use the third item for adding to __dict__,
+        # so we use partial.
         return (
             partial(
                 Cancelled._create,

--- a/src/trio/_core/_run.py
+++ b/src/trio/_core/_run.py
@@ -1648,18 +1648,7 @@ class Task(metaclass=NoPublicConstructor):  # type: ignore[explicit-any]
         if not self._cancel_status.effectively_cancelled:
             return
 
-        def raise_cancel() -> NoReturn:
-            reason = self._cancel_status._scope._cancel_reason
-            if reason is None:
-                raise Cancelled._create(source="unknown", reason="misnesting")
-
-            raise Cancelled._create(
-                source=reason.source,
-                reason=reason.reason,
-                source_task=reason.source_task,
-            )
-
-        self._attempt_abort(raise_cancel)
+        self._attempt_abort(RaiseCancel(self._cancel_status._scope._cancel_reason))
 
     def _attempt_delivery_of_pending_ki(self) -> None:
         assert self._runner.ki_pending
@@ -1671,6 +1660,24 @@ class Task(metaclass=NoPublicConstructor):  # type: ignore[explicit-any]
             raise KeyboardInterrupt
 
         self._attempt_abort(raise_cancel)
+
+
+class RaiseCancel:
+    def __init__(self, reason: CancelReason | None) -> None:
+        if reason is None:
+            self.cancelled = Cancelled._create(source="unknown", reason="misnesting")
+        else:
+            self.cancelled = Cancelled._create(
+                source=reason.source,
+                reason=reason.reason,
+                source_task=reason.source_task,
+            )
+
+    def __call__(self) -> NoReturn:
+        try:
+            raise self.cancelled
+        finally:
+            del self.cancelled
 
 
 ################################################################

--- a/src/trio/_core/_run.py
+++ b/src/trio/_core/_run.py
@@ -911,6 +911,11 @@ class CancelScope:
 
     @enable_ki_protection
     def _cancel(self, cancel_reason: CancelReason | None) -> None:
+        """Internal sources of cancellation should use this instead of :meth:`cancel`
+        in order to set a more detailed :class:`CancelReason`
+        Helper or high-level functions can use `cancel`.
+        """
+
         if self._cancel_called:
             return
 

--- a/src/trio/_core/_run.py
+++ b/src/trio/_core/_run.py
@@ -2180,7 +2180,7 @@ class Runner:  # type: ignore[explicit-any]
             run_sync_soon_nursery.cancel_scope._cancel(
                 CancelReason(
                     source="shutdown",
-                    reason="main task done, shut down run_sync_soon callbacks",
+                    reason="main task done, shutting down run_sync_soon callbacks",
                     source_task=repr(self.init_task),
                 )
             )

--- a/src/trio/_core/_run.py
+++ b/src/trio/_core/_run.py
@@ -18,7 +18,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Final,
-    Literal,
     NoReturn,
     Protocol,
     cast,
@@ -37,7 +36,12 @@ from .._util import NoPublicConstructor, coroutine_or_error, final
 from ._asyncgens import AsyncGenerators
 from ._concat_tb import concat_tb
 from ._entry_queue import EntryQueue, TrioToken
-from ._exceptions import Cancelled, RunFinishedError, TrioInternalError
+from ._exceptions import (
+    Cancelled,
+    CancelReasonLiteral,
+    RunFinishedError,
+    TrioInternalError,
+)
 from ._instrumentation import Instruments
 from ._ki import KIManager, enable_ki_protection
 from ._parking_lot import GLOBAL_PARKING_LOT_BREAKER
@@ -324,9 +328,7 @@ class CancelReason:
     Not publicly exported or documented.
     """
 
-    source: Literal[
-        "KeyboardInterrupt", "deadline", "explicit", "nursery", "shutdown", "unknown"
-    ]
+    source: CancelReasonLiteral
     source_task: str | None = None
     reason: str | None = None
 
@@ -915,7 +917,6 @@ class CancelScope:
         in order to set a more detailed :class:`CancelReason`
         Helper or high-level functions can use `cancel`.
         """
-
         if self._cancel_called:
             return
 

--- a/src/trio/_core/_run.py
+++ b/src/trio/_core/_run.py
@@ -321,6 +321,8 @@ class CancelReason:
     """Attached to a :class:`CancelScope` upon cancellation with details of the source of the
     cancellation, which is then used to construct the string in a :exc:`Cancelled`.
     Users can pass a ``reason`` str to :meth:`CancelScope.cancel` to set it.
+
+    Not publicly exported or documented.
     """
 
     source: Literal[
@@ -916,8 +918,12 @@ class CancelScope:
             self._cancel_status.recalculate()
 
     @enable_ki_protection
-    def cancel(self, *, reason: str | None = None) -> None:
+    def cancel(self, reason: str | None = None) -> None:
         """Cancels this scope immediately.
+
+        The optional ``reason`` argument accepts a string, which will be attached to
+        any resulting :exc:`Cancelled` exception to help you understand where that
+        cancellation is coming from and why it happened.
 
         This method is idempotent, i.e., if the scope was already
         cancelled then this method silently does nothing.

--- a/src/trio/_core/_tests/test_cancel.py
+++ b/src/trio/_core/_tests/test_cancel.py
@@ -1,0 +1,101 @@
+# there's tons of cancellation testing in test_run, but that file is 3k lines long already...
+
+from math import inf
+
+import pytest
+
+import trio
+from trio import Cancelled
+from trio.lowlevel import current_task
+from trio.testing import RaisesGroup
+
+
+async def test_cancel_reason() -> None:
+    with trio.CancelScope() as cs:
+        cs.cancel(reason="hello")
+        with pytest.raises(
+            Cancelled,
+            match=rf"^Cancelled due to explicit with reason 'hello' from task {current_task()!r}$",
+        ):
+            await trio.lowlevel.checkpoint()
+
+    with trio.CancelScope(deadline=-inf) as cs:
+        with pytest.raises(Cancelled, match=r"^Cancelled due to deadline"):
+            await trio.lowlevel.checkpoint()
+
+    with trio.CancelScope() as cs:
+        cs.deadline = -inf
+        with pytest.raises(
+            Cancelled,
+            # FIXME: ??
+            match=r"^Cancelled due to explicit from task None",
+        ):
+            await trio.lowlevel.checkpoint()
+
+
+async def test_cancel_reason_nursery() -> None:
+    async def failing_task(task_status: trio.TaskStatus[trio.lowlevel.Task]) -> None:
+        task_status.started(current_task())
+        raise ValueError
+
+    async def cancelled_task(
+        fail_task: trio.lowlevel.Task, task_status: trio.TaskStatus
+    ) -> None:
+        task_status.started()
+        with pytest.raises(
+            Cancelled, match=rf"^Cancelled due to nursery from task {fail_task!r}$"
+        ):
+            await trio.sleep_forever()
+        raise TypeError
+
+    with RaisesGroup(ValueError, TypeError):
+        async with trio.open_nursery() as nursery:
+            fail_task = await nursery.start(failing_task)
+            await nursery.start(cancelled_task, fail_task)
+
+
+async def test_cancel_reason_nursery2() -> None:
+    async def failing_task(
+        event: trio.Event, task_status: trio.TaskStatus[trio.lowlevel.Task]
+    ) -> None:
+        task_status.started(current_task())
+        await event.wait()
+        raise ValueError
+
+    async def cancelled_task(
+        fail_task: trio.lowlevel.Task, task_status: trio.TaskStatus
+    ) -> None:
+        task_status.started()
+        with pytest.raises(
+            Cancelled, match=rf"^Cancelled due to nursery from task {fail_task!r}$"
+        ):
+            await trio.sleep_forever()
+        raise TypeError
+
+    with RaisesGroup(ValueError, TypeError):
+        async with trio.open_nursery() as nursery:
+            event = trio.Event()
+            fail_task = await nursery.start(failing_task, event)
+            await nursery.start(cancelled_task, fail_task)
+            event.set()
+
+
+async def test_cancel_reason_not_overwritten() -> None:
+    with trio.CancelScope() as cs:
+        cs.cancel()
+        with pytest.raises(Cancelled, match=r"^Cancelled due to explicit"):
+            await trio.lowlevel.checkpoint()
+        cs.deadline = -inf
+        with pytest.raises(Cancelled, match=r"^Cancelled due to explicit"):
+            await trio.lowlevel.checkpoint()
+
+
+async def test_cancel_reason_not_overwritten_2() -> None:
+    # TODO: broken, see earlier test
+    with trio.CancelScope() as cs:
+        cs.deadline = -inf
+        with pytest.raises(Cancelled, match=r"^Cancelled due to explicit"):
+            await trio.lowlevel.checkpoint()
+        cs.cancel()
+        with pytest.raises(Cancelled, match=r"^Cancelled due to explicit"):
+            await trio.lowlevel.checkpoint()

--- a/src/trio/_core/_tests/test_cancelled.py
+++ b/src/trio/_core/_tests/test_cancelled.py
@@ -1,5 +1,5 @@
-# there's tons of cancellation testing in test_run, but that file is 3k lines long already...
-
+import pickle
+import re
 from math import inf
 
 import pytest
@@ -7,9 +7,62 @@ import pytest
 import trio
 from trio import Cancelled
 from trio.lowlevel import current_task
-from trio.testing import RaisesGroup
+from trio.testing import RaisesGroup, wait_all_tasks_blocked
 
 from .test_ki import ki_self
+
+
+def test_Cancelled_init() -> None:
+    with pytest.raises(TypeError, match=r"^trio.Cancelled has no public constructor$"):
+        raise Cancelled  # type: ignore[call-arg]
+
+    with pytest.raises(TypeError, match=r"^trio.Cancelled has no public constructor$"):
+        Cancelled(source="explicit")
+
+    # private constructor should not raise
+    Cancelled._create(source="explicit")
+
+
+async def test_Cancelled_str() -> None:
+    cancelled = Cancelled._create(source="explicit")
+    assert str(cancelled) == "cancelled due to explicit"
+    # note: repr(current_task()) is often fairly verbose
+    assert re.fullmatch(
+        r"cancelled due to deadline from task "
+        r"<Task 'trio._core._tests.test_cancelled.test_Cancelled_str' at 0x\w*>",
+        str(
+            Cancelled._create(
+                source="deadline",
+                source_task=repr(current_task()),
+            )
+        ),
+    )
+
+    assert re.fullmatch(
+        rf"cancelled due to nursery with reason 'pigs flying' from task {current_task()!r}",
+        str(
+            Cancelled._create(
+                source="nursery",
+                source_task=repr(current_task()),
+                reason="pigs flying",
+            )
+        ),
+    )
+
+
+def test_Cancelled_subclass() -> None:
+    with pytest.raises(TypeError):
+        type("Subclass", (Cancelled,), {})
+
+
+# https://github.com/python-trio/trio/issues/3248
+def test_Cancelled_pickle() -> None:
+    cancelled = Cancelled._create(source="KeyboardInterrupt")
+    pickled_cancelled = pickle.loads(pickle.dumps(cancelled))
+    assert isinstance(pickled_cancelled, Cancelled)
+    assert cancelled.source == pickled_cancelled.source
+    assert cancelled.source_task == pickled_cancelled.source_task
+    assert cancelled.reason == pickled_cancelled.reason
 
 
 async def test_cancel_reason() -> None:
@@ -18,8 +71,11 @@ async def test_cancel_reason() -> None:
         with pytest.raises(
             Cancelled,
             match=rf"^cancelled due to explicit with reason 'hello' from task {current_task()!r}$",
-        ):
+        ) as excinfo:
             await trio.lowlevel.checkpoint()
+    assert excinfo.value.source == "explicit"
+    assert excinfo.value.reason == "hello"
+    assert excinfo.value.source_task == repr(current_task())
 
     with trio.CancelScope(deadline=-inf) as cs:
         with pytest.raises(Cancelled, match=r"^cancelled due to deadline"):
@@ -34,21 +90,38 @@ async def test_cancel_reason() -> None:
             await trio.lowlevel.checkpoint()
 
 
+match_str = r"^cancelled due to nursery with reason 'child task raised exception ValueError\(\)' from task {0!r}$"
+
+
+async def cancelled_task(
+    fail_task: trio.lowlevel.Task, task_status: trio.TaskStatus
+) -> None:
+    task_status.started()
+    with pytest.raises(Cancelled, match=match_str.format(fail_task)):
+        await trio.sleep_forever()
+    raise TypeError
+
+
+# failing_task raises before cancelled_task is started
 async def test_cancel_reason_nursery() -> None:
     async def failing_task(task_status: trio.TaskStatus[trio.lowlevel.Task]) -> None:
         task_status.started(current_task())
         raise ValueError
 
-    async def cancelled_task(
-        fail_task: trio.lowlevel.Task, task_status: trio.TaskStatus
-    ) -> None:
-        task_status.started()
-        with pytest.raises(
-            Cancelled,
-            match=rf"^cancelled due to nursery with reason 'child task raised exception ValueError\(\)' from task {fail_task!r}$",
-        ):
-            await trio.sleep_forever()
-        raise TypeError
+    with RaisesGroup(ValueError, TypeError):
+        async with trio.open_nursery() as nursery:
+            fail_task = await nursery.start(failing_task)
+            with pytest.raises(Cancelled, match=match_str.format(fail_task)):
+                await wait_all_tasks_blocked()
+            await nursery.start(cancelled_task, fail_task)
+
+
+# wait until both tasks are running before failing_task raises
+async def test_cancel_reason_nursery2() -> None:
+    async def failing_task(task_status: trio.TaskStatus[trio.lowlevel.Task]) -> None:
+        task_status.started(current_task())
+        await wait_all_tasks_blocked()
+        raise ValueError
 
     with RaisesGroup(ValueError, TypeError):
         async with trio.open_nursery() as nursery:
@@ -56,31 +129,29 @@ async def test_cancel_reason_nursery() -> None:
             await nursery.start(cancelled_task, fail_task)
 
 
-async def test_cancel_reason_nursery2() -> None:
-    async def failing_task(
-        event: trio.Event, task_status: trio.TaskStatus[trio.lowlevel.Task]
-    ) -> None:
-        task_status.started(current_task())
-        await event.wait()
+# failing_task raises before calling task_status.started()
+async def test_cancel_reason_nursery3() -> None:
+    async def failing_task(task_status: trio.TaskStatus[None]) -> None:
         raise ValueError
 
-    async def cancelled_task(
-        fail_task: trio.lowlevel.Task, task_status: trio.TaskStatus
-    ) -> None:
-        task_status.started()
+    parent_task = current_task()
+
+    async def cancelled_task() -> None:
+        # We don't have a way of distinguishing that the nursery code block failed
+        # because it failed to `start()` a task.
         with pytest.raises(
             Cancelled,
-            match=rf"^cancelled due to nursery with reason 'child task raised exception ValueError\(\)' from task {fail_task!r}$",
+            match=re.escape(
+                rf"cancelled due to nursery with reason 'Code block inside nursery contextmanager raised exception ValueError()' from task {parent_task!r}"
+            ),
         ):
             await trio.sleep_forever()
-        raise TypeError
 
-    with RaisesGroup(ValueError, TypeError):
+    with RaisesGroup(ValueError):
         async with trio.open_nursery() as nursery:
-            event = trio.Event()
-            fail_task = await nursery.start(failing_task, event)
-            await nursery.start(cancelled_task, fail_task)
-            event.set()
+            nursery.start_soon(cancelled_task)
+            await wait_all_tasks_blocked()
+            await nursery.start(failing_task)
 
 
 async def test_cancel_reason_not_overwritten() -> None:

--- a/src/trio/_highlevel_generic.py
+++ b/src/trio/_highlevel_generic.py
@@ -43,7 +43,7 @@ async def aclose_forcefully(resource: AsyncResource) -> None:
 
     """
     with trio.CancelScope() as cs:
-        cs.cancel()
+        cs.cancel(reason="cancelled during aclose_forcefully")
         await resource.aclose()
 
 

--- a/src/trio/_highlevel_open_tcp_stream.py
+++ b/src/trio/_highlevel_open_tcp_stream.py
@@ -357,7 +357,7 @@ async def open_tcp_stream(
             # Success! Save the winning socket and cancel all outstanding
             # connection attempts.
             winning_socket = sock
-            nursery.cancel_scope.cancel()
+            nursery.cancel_scope.cancel(reason="successfully found a socket")
         except OSError as exc:
             # This connection attempt failed, but the next one might
             # succeed. Save the error for later so we can report it if

--- a/src/trio/_subprocess.py
+++ b/src/trio/_subprocess.py
@@ -766,6 +766,7 @@ async def _run_process(
 
                 nursery.start_soon(killer)
                 await proc.wait()
+                # TODO: source/reason?
                 killer_cscope.cancel()
                 raise
 

--- a/src/trio/_subprocess.py
+++ b/src/trio/_subprocess.py
@@ -766,8 +766,7 @@ async def _run_process(
 
                 nursery.start_soon(killer)
                 await proc.wait()
-                # TODO: source/reason?
-                killer_cscope.cancel()
+                killer_cscope.cancel(reason="trio internal implementation detail")
                 raise
 
     stdout = b"".join(stdout_chunks) if capture_stdout else None

--- a/src/trio/_tests/test_threads.py
+++ b/src/trio/_tests/test_threads.py
@@ -993,19 +993,26 @@ async def test_from_thread_host_cancelled() -> None:
     assert cancel_scope.cancelled_caught
 
 
-async def test_from_thread_check_cancelled() -> None:
-    q: stdlib_queue.Queue[str | BaseException] = stdlib_queue.Queue()
+async def child(
+    abandon_on_cancel: bool,
+    scope: CancelScope,
+    record: list[str],
+    f: Callable[[], None],
+) -> None:
+    with scope:
+        record.append("start")
+        try:
+            return await to_thread_run_sync(f, abandon_on_cancel=abandon_on_cancel)
+        except _core.Cancelled as e:
+            record.append(str(e))
+            raise
+        finally:
+            record.append("exit")
 
-    async def child(abandon_on_cancel: bool, scope: CancelScope) -> None:
-        with scope:
-            record.append("start")
-            try:
-                return await to_thread_run_sync(f, abandon_on_cancel=abandon_on_cancel)
-            except _core.Cancelled as e:
-                record.append(str(e))
-                raise
-            finally:
-                record.append("exit")
+
+@pytest.mark.parametrize("cancel_the_scope", [False, True])
+async def test_from_thread_check_cancelled_no_abandon(cancel_the_scope: bool) -> None:
+    q: stdlib_queue.Queue[str | BaseException] = stdlib_queue.Queue()
 
     def f() -> None:
         try:
@@ -1017,42 +1024,42 @@ async def test_from_thread_check_cancelled() -> None:
         ev.wait()
         return from_thread_check_cancelled()
 
-    # Base case: nothing cancelled so we shouldn't see cancels anywhere
     record: list[str] = []
     ev = threading.Event()
-    async with _core.open_nursery() as nursery:
-        nursery.start_soon(child, False, _core.CancelScope())
-        await wait_all_tasks_blocked()
-        assert record[0] == "start"
-        assert q.get(timeout=1) == "Not Cancelled"
-        ev.set()
-    # implicit assertion, Cancelled not raised via nursery
-    assert record[1] == "exit"
-
-    # abandon_on_cancel=False case: a cancel will pop out but be handled by
-    # the appropriate cancel scope
-    record = []
-    ev = threading.Event()
     scope = _core.CancelScope()  # Nursery cancel scope gives false positives
+
     async with _core.open_nursery() as nursery:
-        nursery.start_soon(child, False, scope)
+        nursery.start_soon(child, False, scope, record, f)
         await wait_all_tasks_blocked()
         assert record[0] == "start"
         assert q.get(timeout=1) == "Not Cancelled"
-        scope.cancel()
+        if cancel_the_scope:
+            scope.cancel()
         ev.set()
-    assert scope.cancelled_caught
-    assert re.fullmatch(
-        r"cancelled due to explicit from task "
-        r"<Task 'trio._tests.test_threads.test_from_thread_check_cancelled' at 0x\w*>",
-        record[1],
-    ), record[1]
-    assert record[2] == "exit"
-    assert len(record) == 3
+    # Base case: nothing cancelled so we shouldn't see cancels anywhere
+    if not cancel_the_scope:
+        # implicit assertion, Cancelled not raised via nursery
+        assert record[1] == "exit"
+    else:
+        # abandon_on_cancel=False case: a cancel will pop out but be handled by
+        # the appropriate cancel scope
 
+        assert scope.cancelled_caught
+        assert re.fullmatch(
+            r"cancelled due to explicit from task "
+            r"<Task 'trio._tests.test_threads.test_from_thread_check_cancelled_no_abandon' at 0x\w*>",
+            record[1],
+        ), record[1]
+        assert record[2] == "exit"
+        assert len(record) == 3
+
+
+async def test_from_thread_check_cancelled_abandon_on_cancel() -> None:
+    q: stdlib_queue.Queue[str | BaseException] = stdlib_queue.Queue()
     # abandon_on_cancel=True case: slightly different thread behavior needed
     # check thread is cancelled "soon" after abandonment
-    def f() -> None:  # type: ignore[no-redef] # noqa: F811
+
+    def f() -> None:
         ev.wait()
         try:
             from_thread_check_cancelled()
@@ -1065,19 +1072,22 @@ async def test_from_thread_check_cancelled() -> None:
         else:  # pragma: no cover, test failure path
             q.put("Not Cancelled")
 
-    record = []
+    record: list[str] = []
     ev = threading.Event()
     scope = _core.CancelScope()
     async with _core.open_nursery() as nursery:
-        nursery.start_soon(child, True, scope)
+        nursery.start_soon(child, True, scope, record, f)
         await wait_all_tasks_blocked()
         assert record[0] == "start"
         scope.cancel()
-        ev.set()
+    # In the worst case the nursery fully exits before the threaded function
+    # checks for cancellation.
+    ev.set()
+
     assert scope.cancelled_caught
     assert re.fullmatch(
         r"cancelled due to explicit from task "
-        r"<Task 'trio._tests.test_threads.test_from_thread_check_cancelled' at 0x\w*>",
+        r"<Task 'trio._tests.test_threads.test_from_thread_check_cancelled_abandon_on_cancel' at 0x\w*>",
         record[1],
     ), record[1]
     assert record[-1] == "exit"
@@ -1087,7 +1097,7 @@ async def test_from_thread_check_cancelled() -> None:
     else:
         assert re.fullmatch(
             r"cancelled due to explicit from task "
-            r"<Task 'trio._tests.test_threads.test_from_thread_check_cancelled' at 0x\w*>",
+            r"<Task 'trio._tests.test_threads.test_from_thread_check_cancelled_abandon_on_cancel' at 0x\w*>",
             res,
         ), res
 

--- a/src/trio/_tests/test_util.py
+++ b/src/trio/_tests/test_util.py
@@ -282,7 +282,7 @@ async def test_raise_single_exception_from_group() -> None:
     context = TypeError("context")
     exc.__cause__ = cause
     exc.__context__ = context
-    cancelled = trio.Cancelled._create(source="foo")
+    cancelled = trio.Cancelled._create(source="deadline")
 
     with pytest.raises(ValueError, match="foo") as excinfo:
         raise_single_exception_from_group(ExceptionGroup("", [exc]))
@@ -346,11 +346,11 @@ async def test_raise_single_exception_from_group() -> None:
     assert excinfo.value.__context__ is None
 
     # if we only got cancelled, first one is reraised
-    with pytest.raises(
-        trio.Cancelled, match=r"^Cancelled due to foo from task None$"
-    ) as excinfo:
+    with pytest.raises(trio.Cancelled, match=r"^cancelled due to deadline$") as excinfo:
         raise_single_exception_from_group(
-            BaseExceptionGroup("", [cancelled, trio.Cancelled._create(source="bar")])
+            BaseExceptionGroup(
+                "", [cancelled, trio.Cancelled._create(source="explicit")]
+            )
         )
     assert excinfo.value is cancelled
     assert excinfo.value.__cause__ is None

--- a/src/trio/_tests/test_util.py
+++ b/src/trio/_tests/test_util.py
@@ -282,7 +282,7 @@ async def test_raise_single_exception_from_group() -> None:
     context = TypeError("context")
     exc.__cause__ = cause
     exc.__context__ = context
-    cancelled = trio.Cancelled._create()
+    cancelled = trio.Cancelled._create(source="foo")
 
     with pytest.raises(ValueError, match="foo") as excinfo:
         raise_single_exception_from_group(ExceptionGroup("", [exc]))
@@ -346,9 +346,11 @@ async def test_raise_single_exception_from_group() -> None:
     assert excinfo.value.__context__ is None
 
     # if we only got cancelled, first one is reraised
-    with pytest.raises(trio.Cancelled, match=r"^Cancelled$") as excinfo:
+    with pytest.raises(
+        trio.Cancelled, match=r"^Cancelled due to foo from task None$"
+    ) as excinfo:
         raise_single_exception_from_group(
-            BaseExceptionGroup("", [cancelled, trio.Cancelled._create()])
+            BaseExceptionGroup("", [cancelled, trio.Cancelled._create(source="bar")])
         )
     assert excinfo.value is cancelled
     assert excinfo.value.__cause__ is None

--- a/src/trio/_threads.py
+++ b/src/trio/_threads.py
@@ -430,7 +430,9 @@ async def to_thread_run_sync(
 
         def abort(raise_cancel: RaiseCancelT) -> trio.lowlevel.Abort:
             # fill so from_thread_check_cancelled can raise
-            cancel_register[0] = raise_cancel
+            import copy
+
+            cancel_register[0] = copy.copy(raise_cancel)
             if abandon_bool:
                 # empty so report_back_in_trio_thread_fn cannot reschedule
                 task_register[0] = None

--- a/src/trio/_threads.py
+++ b/src/trio/_threads.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import contextvars
+import copy
 import inspect
 import queue as stdlib_queue
 import threading
@@ -432,7 +433,7 @@ async def to_thread_run_sync(
             # fill so from_thread_check_cancelled can raise
             # 'raise_cancel' will immediately delete its reason object, so we make
             # a copy in each thread
-            cancel_register[0] = raise_cancel
+            cancel_register[0] = copy.copy(raise_cancel)
             if abandon_bool:
                 # empty so report_back_in_trio_thread_fn cannot reschedule
                 task_register[0] = None

--- a/src/trio/_threads.py
+++ b/src/trio/_threads.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import contextvars
+import copy
 import inspect
 import queue as stdlib_queue
 import threading
@@ -430,8 +431,8 @@ async def to_thread_run_sync(
 
         def abort(raise_cancel: RaiseCancelT) -> trio.lowlevel.Abort:
             # fill so from_thread_check_cancelled can raise
-            import copy
-
+            # 'raise_cancel' will immediately delete its reason object, so we make
+            # a copy in each thread
             cancel_register[0] = copy.copy(raise_cancel)
             if abandon_bool:
                 # empty so report_back_in_trio_thread_fn cannot reschedule

--- a/src/trio/_threads.py
+++ b/src/trio/_threads.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import contextlib
 import contextvars
-import copy
 import inspect
 import queue as stdlib_queue
 import threading
@@ -433,7 +432,7 @@ async def to_thread_run_sync(
             # fill so from_thread_check_cancelled can raise
             # 'raise_cancel' will immediately delete its reason object, so we make
             # a copy in each thread
-            cancel_register[0] = copy.copy(raise_cancel)
+            cancel_register[0] = raise_cancel
             if abandon_bool:
                 # empty so report_back_in_trio_thread_fn cannot reschedule
                 task_register[0] = None

--- a/src/trio/_util.py
+++ b/src/trio/_util.py
@@ -29,12 +29,11 @@ if TYPE_CHECKING:
     import sys
     from types import AsyncGeneratorType, TracebackType
 
-    from typing_extensions import ParamSpec, Self, TypeVarTuple, Unpack
+    from typing_extensions import Self, TypeVarTuple, Unpack
 
     if sys.version_info < (3, 11):
         from exceptiongroup import BaseExceptionGroup
 
-    ArgsT = ParamSpec("ArgsT")
     PosArgsT = TypeVarTuple("PosArgsT")
 
 


### PR DESCRIPTION
fixes #3232 by adding a `CancelReason` that's tracked by both `CancelScope` and `CancelStatus` and then used when constructing a `Cancelled` to be raised.

Remaining stuff:
- [x] I'm not 100% sure that both `CancelScope` and `CancelStatus` needs to have a `CancelReason` member - initially only `CancelStatus` had it but that wasn't enough, but I haven't tried to see if I can get away with only `CancelScope` having it.
  - It's now only tracked in `CancelScope`
- [x] I also found a bug as I was reviewing and adding a final test, where manually setting `cs.deadline=-inf` and then checkpointing somehow ends up as an `explicit` cancelled.
- [x] `from_thread_check_cancelled` needs some special handling
  - I managed to fix this.. but in a way that created cyclic garbage. So need a better fix