### PR TITLE
attempt to add typing to _create

### DIFF
--- a/src/trio/_util.py
+++ b/src/trio/_util.py
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
         from exceptiongroup import BaseExceptionGroup
 
     ArgsT = ParamSpec("ArgsT")
+    P = ParamSpec("P")
     PosArgsT = TypeVarTuple("PosArgsT")
 
 
@@ -324,8 +325,9 @@ class NoPublicConstructor(ABCMeta):
             f"{cls.__module__}.{cls.__qualname__} has no public constructor",
         )
 
-    def _create(cls: type[T], *args: object, **kwargs: object) -> T:
-        return super().__call__(*args, **kwargs)  # type: ignore
+    def _create(cls: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
+        # misc = unsupported argument 2 for "super" (??)
+        return super().__call__(*args, **kwargs)  # type: ignore[misc,no-any-return]
 
 
 def name_asyncgen(agen: AsyncGeneratorType[object, NoReturn]) -> str:

--- a/src/trio/testing/_fake_net.py
+++ b/src/trio/testing/_fake_net.py
@@ -129,7 +129,7 @@ class UDPPacket:
 class FakeSocketFactory(trio.abc.SocketFactory):
     fake_net: FakeNet
 
-    def socket(self, family: int, type_: int, proto: int) -> FakeSocket:  # type: ignore[override]
+    def socket(self, family: AddressFamily, type_: SocketKind, proto: int) -> FakeSocket:  # type: ignore[override]
         return FakeSocket._create(self.fake_net, family, type_, proto)
 
 


### PR DESCRIPTION
@A5rocks 

remaining errors:

```
src/trio/_core/_local.py:27: error: Argument 1 to "_create" of "NoPublicConstructor" has incompatible type "RunVar[T]"; expected "Never"  [arg-type]
src/trio/_channel.py:265: error: Argument 1 to "_create" of "NoPublicConstructor" has incompatible type "MemoryChannelState[SendType]"; expected "Never"  [arg-type]
src/trio/_channel.py:417: error: Argument 1 to "_create" of "NoPublicConstructor" has incompatible type "MemoryChannelState[ReceiveType]"; expected "Never"  [arg-type]
```
my hypothesis for these is that they all inherit from some other class which doesn't have this parameter, and `_create` sees the super class.

```
src/trio/_core/_run.py:1907: error: Argument "coro" to "_create" of "NoPublicConstructor" has incompatible type "Coroutine[object, Never, object]"; expected "CoroutineType[Any, Outcome[object], Any]"  [arg-type]
```
idk who's in the wrong here


```
src/trio/_subprocess.py:430: error: Argument 1 to "_create" of "NoPublicConstructor" has incompatible type "Popen[str]"; expected "Popen[bytes]"  [arg-type]
```
this might be an actual bug? https://github.com/python/typeshed/blob/eec809d049d10a5ae9b88780eab15fe36a9768d7/stdlib/subprocess.pyi#L1464 for reference
