### PR TITLE
Unbreak CI (3.14 + cython)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
           endsWith(matrix.python, '-dev')
           || endsWith(matrix.python, '-nightly')
           # 3.14+windows has very broken cffi
-          || matrix.python == '3.14'
+          || endsWith(matrix.python, '3.14')
         )
         && true
         || false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,8 @@ jobs:
           #  lsp: 'http://download.pctools.com/mirror/updates/9.0.0.2308-SDavfree-lite_en.exe'
           #  lsp_extract_file: ''
           #  extra_name: ', with non-IFS LSP'
-    # 3.14+windows has very broken cffi
+
+    # ***REMEMBER*** to remove the 3.14 line once windows+cffi works again
     continue-on-error: >-
       ${{
         (

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14-dev']
         arch: ['x86', 'x64']
         lsp: ['']
         lsp_extract_file: ['']
@@ -387,11 +387,13 @@ jobs:
           - python: '3.9'  # We support running on cython 2 and 3 for 3.9
             cython: '<3'   # cython 2
           - python: '3.9'
-            cython: '>=3'  # cython 3 (or greater)
+    # cython 3.1.0 broke stuff https://github.com/cython/cython/issues/6865
+            cython: '>=3,<3.1'  # cython 3 (or greater)
           - python: '3.11' # 3.11 is the last version Cy2 supports
             cython: '<3'   # cython 2
           - python: '3.13' # We support running cython3 on 3.13
-            cython: '>=3'  # cython 3 (or greater)
+    # cython 3.1.0 broke stuff https://github.com/cython/cython/issues/6865
+            cython: '>=3,<3.1'  # cython 3 (or greater)
     steps:
       - name: Retrieve the project source from an sdist inside the GHA artifact
         uses: re-actors/checkout-python-sdist@release/v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14-dev']
+        python: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
         arch: ['x86', 'x64']
         lsp: ['']
         lsp_extract_file: ['']
@@ -186,6 +186,8 @@ jobs:
         (
           endsWith(matrix.python, '-dev')
           || endsWith(matrix.python, '-nightly')
+          # 3.14+windows has very broken cffi
+          || matrix.python == '3.14'
         )
         && true
         || false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,13 +181,13 @@ jobs:
           #  lsp: 'http://download.pctools.com/mirror/updates/9.0.0.2308-SDavfree-lite_en.exe'
           #  lsp_extract_file: ''
           #  extra_name: ', with non-IFS LSP'
+    # 3.14+windows has very broken cffi
     continue-on-error: >-
       ${{
         (
           endsWith(matrix.python, '-dev')
           || endsWith(matrix.python, '-nightly')
-          # 3.14+windows has very broken cffi
-          || endsWith(matrix.python, '3.14')
+          || matrix.python == '3.14'
         )
         && true
         || false

--- a/src/trio/_core/_tests/test_run.py
+++ b/src/trio/_core/_tests/test_run.py
@@ -922,10 +922,11 @@ def test_broken_abort() -> None:
     gc_collect_harder()
 
 
+# This segfaults, so we need to skipif. Remember to remove the skipif once
+# the upstream issue is resolved.
 @restore_unraisablehook()
-@pytest.mark.xfail(
-    sys.version_info == (3, 14, 0, "beta", 1),
-    strict=False,
+@pytest.mark.skipif(
+    sys.version_info[:3] == (3, 14, 0),
     reason="https://github.com/python/cpython/issues/133932",
 )
 def test_error_in_run_loop() -> None:

--- a/src/trio/_core/_tests/test_run.py
+++ b/src/trio/_core/_tests/test_run.py
@@ -923,6 +923,11 @@ def test_broken_abort() -> None:
 
 
 @restore_unraisablehook()
+@pytest.mark.xfail(
+    sys.version_info == (3, 14, 0, "beta", 1),
+    strict=False,
+    reason="https://github.com/python/cpython/issues/133932",
+)
 def test_error_in_run_loop() -> None:
     # Blow stuff up real good to check we at least get a TrioInternalError
     async def main() -> None:

--- a/src/trio/_tests/test_exports.py
+++ b/src/trio/_tests/test_exports.py
@@ -117,6 +117,10 @@ PUBLIC_MODULE_NAMES = [m.__name__ for m in PUBLIC_MODULES]
 # won't be reflected in trio.socket, and this shouldn't cause downstream test
 # runs to start failing.
 @pytest.mark.redistributors_should_skip
+@pytest.mark.skipif(
+    sys.version_info == (3, 14, 0, "beta", 1),
+    reason="several tools don't support 3.14.0b1",
+)
 # Static analysis tools often have trouble with alpha releases, where Python's
 # internals are in flux, grammar may not have settled down, etc.
 @pytest.mark.skipif(

--- a/src/trio/_tests/test_exports.py
+++ b/src/trio/_tests/test_exports.py
@@ -118,9 +118,9 @@ PUBLIC_MODULE_NAMES = [m.__name__ for m in PUBLIC_MODULES]
 # runs to start failing.
 @pytest.mark.redistributors_should_skip
 @pytest.mark.skipif(
-    sys.version_info == (3, 14, 0, "beta", 1),
+    sys.version_info[:4] == (3, 14, 0, "beta"),
     # 12 pass, 16 fail
-    reason="several tools don't support 3.14.0b1",
+    reason="several tools don't support 3.14",
 )
 # Static analysis tools often have trouble with alpha releases, where Python's
 # internals are in flux, grammar may not have settled down, etc.
@@ -249,9 +249,9 @@ def test_static_tool_sees_all_symbols(tool: str, modname: str, tmp_path: Path) -
 # see comment on test_static_tool_sees_all_symbols
 @pytest.mark.redistributors_should_skip
 @pytest.mark.skipif(
-    sys.version_info == (3, 14, 0, "beta", 1),
+    sys.version_info[:4] == (3, 14, 0, "beta"),
     # 2 passes, 12 fails
-    reason="several tools don't support 3.14.0b1",
+    reason="several tools don't support 3.14.0",
 )
 # Static analysis tools often have trouble with alpha releases, where Python's
 # internals are in flux, grammar may not have settled down, etc.

--- a/src/trio/_tests/test_exports.py
+++ b/src/trio/_tests/test_exports.py
@@ -117,9 +117,9 @@ PUBLIC_MODULE_NAMES = [m.__name__ for m in PUBLIC_MODULES]
 # won't be reflected in trio.socket, and this shouldn't cause downstream test
 # runs to start failing.
 @pytest.mark.redistributors_should_skip
-@pytest.mark.xfail(
-    sys.version_info[:2] == (3, 14),
-    strict=True,
+@pytest.mark.skipif(
+    sys.version_info == (3, 14, 0, "beta", 1),
+    # 12 pass, 16 fail
     reason="several tools don't support 3.14.0b1",
 )
 # Static analysis tools often have trouble with alpha releases, where Python's
@@ -248,9 +248,9 @@ def test_static_tool_sees_all_symbols(tool: str, modname: str, tmp_path: Path) -
 @slow
 # see comment on test_static_tool_sees_all_symbols
 @pytest.mark.redistributors_should_skip
-@pytest.mark.xfail(
-    sys.version_info[:2] == (3, 14),
-    strict=True,
+@pytest.mark.skipif(
+    sys.version_info == (3, 14, 0, "beta", 1),
+    # 2 passes, 12 fails
     reason="several tools don't support 3.14.0b1",
 )
 # Static analysis tools often have trouble with alpha releases, where Python's

--- a/src/trio/_tests/test_exports.py
+++ b/src/trio/_tests/test_exports.py
@@ -247,6 +247,10 @@ def test_static_tool_sees_all_symbols(tool: str, modname: str, tmp_path: Path) -
 @slow
 # see comment on test_static_tool_sees_all_symbols
 @pytest.mark.redistributors_should_skip
+@pytest.mark.skipif(
+    sys.version_info == (3, 14, 0, "beta", 1),
+    reason="several tools don't support 3.14.0b1",
+)
 # Static analysis tools often have trouble with alpha releases, where Python's
 # internals are in flux, grammar may not have settled down, etc.
 @pytest.mark.skipif(

--- a/src/trio/_tests/test_exports.py
+++ b/src/trio/_tests/test_exports.py
@@ -117,8 +117,9 @@ PUBLIC_MODULE_NAMES = [m.__name__ for m in PUBLIC_MODULES]
 # won't be reflected in trio.socket, and this shouldn't cause downstream test
 # runs to start failing.
 @pytest.mark.redistributors_should_skip
-@pytest.mark.skipif(
-    sys.version_info == (3, 14, 0, "beta", 1),
+@pytest.mark.xfail(
+    sys.version_info[:2] == (3, 14),
+    strict=True,
     reason="several tools don't support 3.14.0b1",
 )
 # Static analysis tools often have trouble with alpha releases, where Python's
@@ -247,8 +248,9 @@ def test_static_tool_sees_all_symbols(tool: str, modname: str, tmp_path: Path) -
 @slow
 # see comment on test_static_tool_sees_all_symbols
 @pytest.mark.redistributors_should_skip
-@pytest.mark.skipif(
-    sys.version_info == (3, 14, 0, "beta", 1),
+@pytest.mark.xfail(
+    sys.version_info[:2] == (3, 14),
+    strict=True,
     reason="several tools don't support 3.14.0b1",
 )
 # Static analysis tools often have trouble with alpha releases, where Python's

--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,8 @@ commands =
 [testenv:py39-cython2,py39-cython,py311-cython2,py313-cython]
 description = "Run cython tests."
 deps =
-    cython
+    # cython 3.1.0 broke stuff https://github.com/cython/cython/issues/6865
+    cython: cython<3.1.0
     cython2: cython<3
     setuptools ; python_version >= '3.12'
 commands_pre =


### PR DESCRIPTION
I'm for some reason not getting mypy fails locally, but disabling `test_static_tool_sees_all_symbols` entirely for 3.14.0b1 rather than trying to dig into why that might be the case

I'm also getting cffi/OpenSSL segfaults locally on 3.14, but that doesn't seem to impact CI so we can probs ignore that one for now