### PR TITLE
unpin cython

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -390,13 +390,11 @@ jobs:
           - python: '3.9'  # We support running on cython 2 and 3 for 3.9
             cython: '<3'   # cython 2
           - python: '3.9'
-    # cython 3.1.0 broke stuff https://github.com/cython/cython/issues/6865
-            cython: '>=3,<3.1'  # cython 3 (or greater)
+            cython: '>=3'  # cython 3 (or greater)
           - python: '3.11' # 3.11 is the last version Cy2 supports
             cython: '<3'   # cython 2
           - python: '3.13' # We support running cython3 on 3.13
-    # cython 3.1.0 broke stuff https://github.com/cython/cython/issues/6865
-            cython: '>=3,<3.1'  # cython 3 (or greater)
+            cython: '>=3'  # cython 3 (or greater)
     steps:
       - name: Retrieve the project source from an sdist inside the GHA artifact
         uses: re-actors/checkout-python-sdist@release/v2

--- a/tox.ini
+++ b/tox.ini
@@ -63,6 +63,26 @@ commands_pre =
 commands =
     python -m tests.cython.run_test_cython
 
+[testenv:cov-cython]
+deps =
+    setuptools
+    cython
+set_env =
+    CFLAGS= -DCYTHON_TRACE_NOGIL=1A
+allowlist_externals =
+    sed
+    cp
+commands_pre =
+    python --version
+    cython --version
+    cp pyproject.toml {temp_dir}/
+    sed -i "s/plugins\ =\ \\[\\]/plugins = [\"Cython.Coverage\"]/" {temp_dir}/pyproject.toml
+    cythonize --inplace -X linetrace=True tests/cython/test_cython.pyx
+commands =
+    coverage run -m tests.cython.run_test_cython --rcfile={temp_dir}/pyproject.toml
+    coverage combine
+    coverage report
+
 [testenv:gen_exports]
 description = "Run gen_exports.py, regenerating code for public API wrappers."
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,7 @@ commands =
 description = "Run cython tests."
 deps =
     # cython 3.1.0 broke stuff https://github.com/cython/cython/issues/6865
-    cython: cython<3.1.0
+    cython: cython
     cython2: cython<3
     setuptools ; python_version >= '3.12'
 commands_pre =


### PR DESCRIPTION
fixes part of #3267 with the release of https://github.com/cython/cython/releases/tag/3.1.1

I'm getting errors locally when I try to combine it with coverage, so I think there's more to be done, but let's see if CI errors as well


I did look at configuration options for coverage and tox and ultimately couldn't find a better option than `sed`ing `pyproject.toml` (as the CI setup does), though at least did it to a copy in the tox tmp/ directory to not screw with the git working tree.