### PR TITLE
Added default value for the "source" parameter in the trio.Cancelled initializer

### DIFF
--- a/src/trio/_core/_exceptions.py
+++ b/src/trio/_core/_exceptions.py
@@ -82,7 +82,7 @@ class Cancelled(BaseException, metaclass=NoPublicConstructor):
 
     """
 
-    source: CancelReasonLiteral
+    source: CancelReasonLiteral = "unknown"
     # repr(Task), so as to avoid gc troubles from holding a reference
     source_task: str | None = None
     reason: str | None = None
@@ -114,7 +114,7 @@ class Cancelled(BaseException, metaclass=NoPublicConstructor):
         def _create(
             cls,
             *,
-            source: CancelReasonLiteral,
+            source: CancelReasonLiteral = "unknown",
             source_task: str | None = None,
             reason: str | None = None,
         ) -> Self: ...

--- a/src/trio/_core/_tests/test_cancelled.py
+++ b/src/trio/_core/_tests/test_cancelled.py
@@ -14,7 +14,7 @@ from .test_ki import ki_self
 
 def test_Cancelled_init() -> None:
     with pytest.raises(TypeError, match=r"^trio.Cancelled has no public constructor$"):
-        raise Cancelled  # type: ignore[call-arg]
+        raise Cancelled
 
     with pytest.raises(TypeError, match=r"^trio.Cancelled has no public constructor$"):
         Cancelled(source="explicit")


### PR DESCRIPTION
This restores backwards compatibility with AnyIO.