### PR TITLE
Remove unnecessary `start_soon` workaround

### DIFF
--- a/src/trio/_highlevel_open_tcp_stream.py
+++ b/src/trio/_highlevel_open_tcp_stream.py
@@ -375,14 +375,6 @@ async def open_tcp_stream(
                 # allowing the next target to be tried early
                 attempt_failed = trio.Event()
 
-                # workaround to check types until typing of nursery.start_soon improved
-                if TYPE_CHECKING:
-                    await attempt_connect(
-                        (address_family, socket_type, proto),
-                        addr,
-                        attempt_failed,
-                    )
-
                 nursery.start_soon(
                     attempt_connect,
                     (address_family, socket_type, proto),


### PR DESCRIPTION
I saw this, not sure when it became unnecessary but I'm pretty sure it's unnecessary now.