### PR TITLE
Switch from installing in `ci.sh` to GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,6 +281,10 @@ jobs:
         run:
           python -m pip install tox &&
           tox -m check
+      - name: Install python3-apport
+        run:
+          sudo apt update
+          sudo apt install -q python3-apport
       - name: Run tests
         if: matrix.check_formatting == '0'
         run: ./ci.sh

--- a/ci.sh
+++ b/ci.sh
@@ -58,11 +58,6 @@ else
     flags=""
 fi
 
-# So we can run the test for our apport/excepthook interaction working
-if [ -e /etc/lsb-release ] && grep -q Ubuntu /etc/lsb-release; then
-    sudo apt install -q python3-apport
-fi
-
 # If we're testing with a LSP installed, then it might break network
 # stuff, so wait until after we've finished setting everything else
 # up.


### PR DESCRIPTION
We're hitting some transient errors due to not having an `apt update`. I figure we might as well take the change to narrow down `ci.sh` as well.