### PR TITLE
check for nursery misnesting on task exit

### DIFF
--- a/src/trio/_core/_run.py
+++ b/src/trio/_core/_run.py
@@ -2017,7 +2017,7 @@ class Runner:  # type: ignore[explicit-any]
             task._cancel_status is not None
             and task._cancel_status.abandoned_by_misnesting
             and task._cancel_status.parent is None
-        ):
+        ) or any(not nursery._closed for nursery in task._child_nurseries):
             # The cancel scope surrounding this task's nursery was closed
             # before the task exited. Force the task to exit with an error,
             # since the error might not have been caught elsewhere. See the

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -1,5 +1,5 @@
 # For tests
-pytest >= 5.0         # for faulthandler in core
+pytest >= 8.4         # for pytest.RaisesGroup
 coverage >= 7.2.5
 async_generator >= 1.9
 pyright


### PR DESCRIPTION
fixes #3298 (hopefully, eventually) 

This is working on a minified repro, but not on the full repro posted by @Zac-HD, so something is missing. I had a bunch of false starts of different ways of handling it that left the internal state messed up, but this one seems the most promising so far.