### PR TITLE
Remove pip caching for Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,8 +207,6 @@ jobs:
         with:
           python-version: '${{ matrix.python }}'
           architecture: '${{ matrix.arch }}'
-          cache: pip
-          cache-dependency-path: test-requirements.txt
           allow-prereleases: true
       - name: Run tests
         run: ./ci.sh


### PR DESCRIPTION
I've suffered through one too many CI failures due to pip's caching being wrong...

For 3.11, this adds 18 seconds:

```
  Prepared 61 packages in 18.10s
```

