### PR TITLE
fix broken-channel bug in `@trio.as_safe_channel`

### DIFF
--- a/newsfragments/3331.bugfix.rst
+++ b/newsfragments/3331.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed a bug where iterating over an ``@as_safe_channel``-derived ``ReceiveChannel``
+would raise `~trio.BrokenResourceError` if the channel was closed by another task.
+It now shuts down cleanly.


### PR DESCRIPTION
We dropped this handler from https://github.com/python-trio/trio/pull/3197, presumably because the tests (...or production patterns) which trigger it are fairly esoteric.  The `if not send_chan._state.open_receive_channels: break` clause is actually new, but lets us skip a pointless `__anext__` call in many cases which is a nice perf win.

I just wish I'd noticed this in time for https://github.com/python-trio/trio/pull/3325, rather than when pulling it in the new version 🤦‍♂️ 