### PR TITLE
avoid error when `coro.cr_frame is None`

### DIFF
--- a/newsfragments/3337.bugfix.rst
+++ b/newsfragments/3337.bugfix.rst
@@ -1,0 +1,3 @@
+`trio.lowlevel.Task.iter_await_frames` now works on completed tasks, by
+returning an empty list of frames if the underlying coroutine has been closed.
+Previously, it raised an internal error.

--- a/src/trio/_core/_run.py
+++ b/src/trio/_core/_run.py
@@ -1588,11 +1588,13 @@ class Task(metaclass=NoPublicConstructor):  # type: ignore[explicit-any]
         while coro is not None:
             if hasattr(coro, "cr_frame"):
                 # A real coroutine
-                yield coro.cr_frame, coro.cr_frame.f_lineno
+                if cr_frame := coro.cr_frame:  # None if the task has finished
+                    yield cr_frame, cr_frame.f_lineno
                 coro = coro.cr_await
             elif hasattr(coro, "gi_frame"):
                 # A generator decorated with @types.coroutine
-                yield coro.gi_frame, coro.gi_frame.f_lineno
+                if gi_frame := coro.gi_frame:  # pragma: no branch
+                    yield gi_frame, gi_frame.f_lineno  # pragma: no cover
                 coro = coro.gi_yieldfrom
             elif coro.__class__.__name__ in [
                 "async_generator_athrow",


### PR DESCRIPTION
`.cr_frame` is set to `None` when a coroutine closes, per https://github.com/python/cpython/pull/112428, and while this rarely comes up in practice you can _probably_ guess why I'm opening a PR.