### PR TITLE
Avoid `pre-commit run` failing in autodeps

### DIFF
--- a/.github/workflows/autodeps.yml
+++ b/.github/workflows/autodeps.yml
@@ -40,7 +40,7 @@ jobs:
         run: python -m pip install -r test-requirements.txt
 
       - name: Pre-commit fixes
-        run: pre-commit run -a
+        run: pre-commit run -a || true
 
       - name: Commit changes and create automerge PR
         env:


### PR DESCRIPTION
Hopefully fix https://github.com/python-trio/trio/actions/runs/19806895827

We don't care if this fails, because we run it as CI later.