### PR TITLE
Make `autojump`/`autojump_threshold` methods of `abc.Clock`

### DIFF
--- a/src/trio/_abc.py
+++ b/src/trio/_abc.py
@@ -43,7 +43,7 @@ class Clock(ABC):
         """
 
     @abstractmethod
-    def deadline_to_sleep_time(self, deadline: float) -> float:
+    def deadline_to_sleep_time(self, timeout: float) -> float:
         """Compute the real time until the given deadline.
 
         This is called before we enter a system-specific wait function like
@@ -66,14 +66,8 @@ class Clock(ABC):
 
         """
 
-    @property
-    def autojump_threshold(self) -> float:
-        return inf
-
-    def autojump(self) -> None:
-        # If `autojump_threshold()` has the default implementation (returning `inf`),
-        # this will never be called.
-        raise NotImplementedError
+    def propagate(self, real_time_passed: float, virtual_timeout: float) -> None:
+        pass
 
 
 class Instrument(ABC):  # noqa: B024  # conceptually is ABC

--- a/src/trio/_abc.py
+++ b/src/trio/_abc.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from math import inf
 import socket
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Generic, TypeVar
@@ -64,6 +65,15 @@ class Clock(ABC):
             deadline. May be :data:`math.inf`.
 
         """
+
+    @property
+    def autojump_threshold(self) -> float:
+        return inf
+
+    def autojump(self) -> None:
+        # If `autojump_threshold()` has the default implementation (returning `inf`),
+        # this will never be called.
+        raise NotImplementedError
 
 
 class Instrument(ABC):  # noqa: B024  # conceptually is ABC

--- a/src/trio/_abc.py
+++ b/src/trio/_abc.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from math import inf
 import socket
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Generic, TypeVar

--- a/src/trio/_core/_mock_clock.py
+++ b/src/trio/_core/_mock_clock.py
@@ -105,12 +105,6 @@ class MockClock(Clock):
         self._autojump_threshold = float(new_autojump_threshold)
         self._try_resync_autojump_threshold()
 
-    # runner.clock_autojump_threshold is an internal API that isn't easily
-    # usable by custom third-party Clock objects. If you need access to this
-    # functionality, let us know, and we'll figure out how to make a public
-    # API. Discussion:
-    #
-    #     https://github.com/python-trio/trio/issues/1587
     def _try_resync_autojump_threshold(self) -> None:
         try:
             runner = GLOBAL_RUN_CONTEXT.runner
@@ -118,13 +112,10 @@ class MockClock(Clock):
                 runner.force_guest_tick_asap()
         except AttributeError:
             pass
-        else:
-            if runner.clock is self:
-                runner.clock_autojump_threshold = self._autojump_threshold
 
     # Invoked by the run loop when runner.clock_autojump_threshold is
     # exceeded.
-    def _autojump(self) -> None:
+    def autojump(self) -> None:
         statistics = _core.current_statistics()
         jump = statistics.seconds_to_next_deadline
         if 0 < jump < inf:
@@ -136,7 +127,7 @@ class MockClock(Clock):
         return self._virtual_base + virtual_offset
 
     def start_clock(self) -> None:
-        self._try_resync_autojump_threshold()
+        pass
 
     def current_time(self) -> float:
         return self._real_to_virtual(self._real_clock())

--- a/src/trio/_core/_mock_clock.py
+++ b/src/trio/_core/_mock_clock.py
@@ -1,7 +1,6 @@
 import time
 from math import inf
 
-from .. import _core
 from .._abc import Clock
 from .._util import final
 from ._run import GLOBAL_RUN_CONTEXT

--- a/src/trio/_core/_tests/test_guest_mode.py
+++ b/src/trio/_core/_tests/test_guest_mode.py
@@ -187,13 +187,6 @@ def test_guest_is_initialized_when_start_returns() -> None:
         def deadline_to_sleep_time(self, deadline: float) -> float:
             raise NotImplementedError()
 
-        @property
-        def autojump_threshold(self) -> float:
-            raise NotImplementedError()
-
-        def autojump(self) -> None:
-            raise NotImplementedError()
-
     def after_start_never_runs() -> None:  # pragma: no cover
         pytest.fail("shouldn't get here")
 

--- a/src/trio/_core/_tests/test_guest_mode.py
+++ b/src/trio/_core/_tests/test_guest_mode.py
@@ -187,6 +187,13 @@ def test_guest_is_initialized_when_start_returns() -> None:
         def deadline_to_sleep_time(self, deadline: float) -> float:
             raise NotImplementedError()
 
+        @property
+        def autojump_threshold(self) -> float:
+            raise NotImplementedError()
+
+        def autojump(self) -> None:
+            raise NotImplementedError()
+
     def after_start_never_runs() -> None:  # pragma: no cover
         pytest.fail("shouldn't get here")
 

--- a/src/trio/_core/_tests/test_mock_clock.py
+++ b/src/trio/_core/_tests/test_mock_clock.py
@@ -24,9 +24,9 @@ def test_mock_clock() -> None:
     with pytest.raises(ValueError, match=r"^time can't go backwards$"):
         c.jump(-1)
     assert c.current_time() == 1.2
-    assert c.deadline_to_sleep_time(1.1) == 0
-    assert c.deadline_to_sleep_time(1.2) == 0
-    assert c.deadline_to_sleep_time(1.3) > 999999
+    assert c.deadline_to_sleep_time(-0.1) == 0
+    assert c.deadline_to_sleep_time(0.0) == 0
+    assert c.deadline_to_sleep_time(0.1) == 999999999
 
     with pytest.raises(ValueError, match=r"^rate must be >= 0$"):
         c.rate = -1
@@ -36,15 +36,15 @@ def test_mock_clock() -> None:
     assert c.current_time() == 1.2
     REAL_NOW += 1
     assert c.current_time() == 3.2
-    assert c.deadline_to_sleep_time(3.1) == 0
-    assert c.deadline_to_sleep_time(3.2) == 0
-    assert c.deadline_to_sleep_time(4.2) == 0.5
+    assert c.deadline_to_sleep_time(-0.1) == 0
+    assert c.deadline_to_sleep_time(0.0) == 0
+    assert c.deadline_to_sleep_time(1.0) == 0.5
 
     c.rate = 0.5
     assert c.current_time() == 3.2
-    assert c.deadline_to_sleep_time(3.1) == 0
-    assert c.deadline_to_sleep_time(3.2) == 0
-    assert c.deadline_to_sleep_time(4.2) == 2.0
+    assert c.deadline_to_sleep_time(-0.1) == 0
+    assert c.deadline_to_sleep_time(0.0) == 0
+    assert c.deadline_to_sleep_time(1.0) == 2.0
 
     c.jump(0.8)
     assert c.current_time() == 4.0
@@ -80,11 +80,12 @@ async def test_mock_clock_autojump(mock_clock: MockClock) -> None:
     t = _core.current_time()
     # this should wake up before the autojump threshold triggers, so time
     # shouldn't change
+    # TODO: technically, this waits for an infinite virtual time - how should `current_time()` change?
     await wait_all_tasks_blocked()
     assert t == _core.current_time()
     # this should too
     await wait_all_tasks_blocked(0.01)
-    assert t == _core.current_time()
+    assert t + 0.01 == _core.current_time()
 
     # set up a situation where the autojump task is blocked for a long long
     # time, to make sure that cancel-and-adjust-threshold logic is working
@@ -179,15 +180,16 @@ async def test_mock_clock_autojump_0_and_wait_all_tasks_blocked_nonzero(
 
 
 async def test_initialization_doesnt_mutate_runner() -> None:
+    # TODO: is this test even necessary now?
     before = (
         GLOBAL_RUN_CONTEXT.runner.clock,
-        GLOBAL_RUN_CONTEXT.runner.clock.autojump_threshold,
+        # GLOBAL_RUN_CONTEXT.runner.clock.autojump_threshold,
     )
 
     MockClock(autojump_threshold=2, rate=3)
 
     after = (
         GLOBAL_RUN_CONTEXT.runner.clock,
-        GLOBAL_RUN_CONTEXT.runner.clock.autojump_threshold,
+        # GLOBAL_RUN_CONTEXT.runner.clock.autojump_threshold,
     )
     assert before == after

--- a/src/trio/_core/_tests/test_mock_clock.py
+++ b/src/trio/_core/_tests/test_mock_clock.py
@@ -181,13 +181,13 @@ async def test_mock_clock_autojump_0_and_wait_all_tasks_blocked_nonzero(
 async def test_initialization_doesnt_mutate_runner() -> None:
     before = (
         GLOBAL_RUN_CONTEXT.runner.clock,
-        GLOBAL_RUN_CONTEXT.runner.clock_autojump_threshold,
+        GLOBAL_RUN_CONTEXT.runner.clock.autojump_threshold,
     )
 
     MockClock(autojump_threshold=2, rate=3)
 
     after = (
         GLOBAL_RUN_CONTEXT.runner.clock,
-        GLOBAL_RUN_CONTEXT.runner.clock_autojump_threshold,
+        GLOBAL_RUN_CONTEXT.runner.clock.autojump_threshold,
     )
     assert before == after


### PR DESCRIPTION
Fixes #3369 by exposing `autojump` and `autojump_threshold` as methods of `abc.Clock`. `runner.clock_autojump_threshold` is removed, and the runner now gets it from `clock`. 

TODO: adjust documentation (`autoump_threshold` description can be moved from `MockClock` to `abc.Clock`)

Note that `MockClock` still has some internal trickery related to guest mode, but it is only necessary if you want to modify `autojump_threshold` while the loop is running. I am not sure how to resolve that at the moment, but I'll think about it.   