### PR TITLE
Documentation search improvements

### DIFF
--- a/docs/source/_templates/genindex.html
+++ b/docs/source/_templates/genindex.html
@@ -19,11 +19,13 @@
   {%- for column in entries|slice_index(2) if column %}
   <td style="width: 33%; vertical-align: top;"><ul>
     {%- for entryname, (links, subitems, _) in column %}
-      <li>{{ indexentries(entryname, links) }}
+      {% set name = links[0][1].rsplit('#', 1)[1] if links else '' %}
+      <li>{{ indexentries(name if name and '-' not in name else entryname, links) }}
       {%- if subitems %}
       <ul>
       {%- for subentryname, subentrylinks in subitems %}
-        <li>{{ indexentries(subentryname, subentrylinks) }}</li>
+        {% set sname = subentrylinks[0][1].rsplit('#', 1)[1] if subentrylinks else '' %}
+        <li>{{ indexentries(sname if sname and '-' not in sname else subentryname, subentrylinks) }}</li>
       {%- endfor %}
       </ul>
       {%- endif -%}</li>

--- a/docs/source/_templates/genindex.html
+++ b/docs/source/_templates/genindex.html
@@ -1,6 +1,6 @@
 {% extends "!genindex.html" %}
 
-{# check sphinx/themes/basic/genindex:sidebartitle if this snippet has become outdated #}
+{# check sphinx/themes/basic/genindex if this snippet has become outdated #}
 
 {% block body %}
 

--- a/docs/source/_templates/genindex.html
+++ b/docs/source/_templates/genindex.html
@@ -1,5 +1,36 @@
 {% extends "!genindex.html" %}
 
+{# check sphinx/themes/basic/genindex:sidebartitle if this snippet has become outdated #}
+
 {% block body %}
-<p>TESTING</p>
+
+<h1 id="index">{{ _('Index') }}</h1>
+
+<div class="genindex-jumpbox">
+ {% for key, dummy in genindexentries -%}
+ <a href="#{{ key }}"><strong>{{ key }}</strong></a>
+ {% if not loop.last %}| {% endif %}
+ {%- endfor %}
+</div>
+
+{%- for key, entries in genindexentries %}
+<h2 id="{{ key }}">{{ key }}</h2>
+<table style="width: 100%" class="indextable genindextable"><tr>
+  {%- for column in entries|slice_index(2) if column %}
+  <td style="width: 33%; vertical-align: top;"><ul>
+    {%- for entryname, (links, subitems, _) in column %}
+      <li>{{ indexentries(entryname, links) }}
+      {%- if subitems %}
+      <ul>
+      {%- for subentryname, subentrylinks in subitems %}
+        <li>{{ indexentries(subentryname, subentrylinks) }}</li>
+      {%- endfor %}
+      </ul>
+      {%- endif -%}</li>
+    {%- endfor %}
+  </ul></td>
+  {%- endfor %}
+</tr></table>
+{% endfor %}
+
 {% endblock %}

--- a/docs/source/_templates/genindex.html
+++ b/docs/source/_templates/genindex.html
@@ -1,0 +1,5 @@
+{% extends "!genindex.html" %}
+
+{% block body %}
+<p>TESTING</p>
+{% endblock %}

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -86,6 +86,7 @@ Vital statistics:
    contributing.rst
    releasing.rst
    code-of-conduct.rst
+   genindex
 
 ====================
  Indices and tables


### PR DESCRIPTION
As discussed in Gitter, the documentation search results that RTD provides kinda suck. I believe it's just a full-text search, so we have to include any fully-qualified names for the search to accept them (try searching `Event.is_set` today!).

This PR is to try that, though I haven't finished yet because I want to see what the documentation preview will look like