### PR TITLE
Add missing docstrings for documented public APIs

### DIFF
--- a/docs/source/reference-io.rst
+++ b/docs/source/reference-io.rst
@@ -218,7 +218,6 @@ abstraction.
 
 .. autoclass:: SocketStream
    :members:
-   :undoc-members:
    :show-inheritance:
 
 .. autoclass:: SocketListener

--- a/newsfragments/3221.doc.rst
+++ b/newsfragments/3221.doc.rst
@@ -1,0 +1,3 @@
+Added missing docstrings for `MemorySendChannel`, `MemoryReceiveChannel`,
+`MemoryChannelStatistics`, ``SocketStream`` methods, `~trio.lowlevel.ParkingLot.broken_by`,
+and ``HasFileno.fileno``.

--- a/src/trio/_channel.py
+++ b/src/trio/_channel.py
@@ -118,6 +118,12 @@ class open_memory_channel(tuple["MemorySendChannel[T]", "MemoryReceiveChannel[T]
 
 @attrs.frozen
 class MemoryChannelStatistics:
+    """Object returned by `MemorySendChannel.statistics` and
+    `MemoryReceiveChannel.statistics`.
+
+    See :func:`open_memory_channel` for details on the fields.
+    """
+
     current_buffer_used: int
     max_buffer_size: int | float
     open_send_channels: int
@@ -152,6 +158,15 @@ class MemoryChannelState(Generic[T]):
 @final
 @attrs.define(eq=False, repr=False, slots=False)
 class MemorySendChannel(SendChannel[SendType], metaclass=NoPublicConstructor):
+    """The sending end of a memory channel.
+
+    Created by `open_memory_channel`. This implements the
+    `~trio.abc.SendChannel` interface.
+
+    See `open_memory_channel` for details, and :ref:`channel-mpmc` for a
+    discussion of channel cloning.
+    """
+
     _state: MemoryChannelState[SendType]
     _closed: bool = False
     # This is just the tasks waiting on *this* object. As compared to
@@ -300,6 +315,15 @@ class MemorySendChannel(SendChannel[SendType], metaclass=NoPublicConstructor):
 @final
 @attrs.define(eq=False, repr=False, slots=False)
 class MemoryReceiveChannel(ReceiveChannel[ReceiveType], metaclass=NoPublicConstructor):
+    """The receiving end of a memory channel.
+
+    Created by `open_memory_channel`. This implements the
+    `~trio.abc.ReceiveChannel` interface.
+
+    See `open_memory_channel` for details, and :ref:`channel-mpmc` for a
+    discussion of channel cloning.
+    """
+
     _state: MemoryChannelState[ReceiveType]
     _closed: bool = False
     _tasks: set[trio._core._run.Task] = attrs.Factory(set)

--- a/src/trio/_core/_parking_lot.py
+++ b/src/trio/_core/_parking_lot.py
@@ -152,6 +152,11 @@ class ParkingLot:
     # items
     _parked: OrderedDict[Task, None] = attrs.field(factory=OrderedDict, init=False)
     broken_by: list[Task] = attrs.field(factory=list, init=False)
+    """List of tasks that have broken this lot via `break_lot`.
+
+    If empty, the lot is not broken. If non-empty, any attempt to
+    `park` in this lot will raise `~trio.BrokenResourceError`.
+    """
 
     def __len__(self) -> int:
         """Returns the number of parked tasks."""

--- a/src/trio/_highlevel_socket.py
+++ b/src/trio/_highlevel_socket.py
@@ -107,6 +107,7 @@ class SocketStream(HalfCloseableStream):
                 self.setsockopt(tsocket.IPPROTO_TCP, tsocket.TCP_NOTSENT_LOWAT, 2**14)
 
     async def send_all(self, data: bytes | bytearray | memoryview) -> None:
+        """See `trio.abc.SendStream.send_all`."""
         if self.socket.did_shutdown_SHUT_WR:
             raise trio.ClosedResourceError("can't send data after sending EOF")
         with self._send_conflict_detector:
@@ -124,6 +125,7 @@ class SocketStream(HalfCloseableStream):
                         total_sent += sent
 
     async def wait_send_all_might_not_block(self) -> None:
+        """See `trio.abc.SendStream.wait_send_all_might_not_block`."""
         with self._send_conflict_detector:
             if self.socket.fileno() == -1:
                 raise trio.ClosedResourceError
@@ -131,6 +133,7 @@ class SocketStream(HalfCloseableStream):
                 await self.socket.wait_writable()
 
     async def send_eof(self) -> None:
+        """See `trio.abc.HalfCloseableStream.send_eof`."""
         with self._send_conflict_detector:
             await trio.lowlevel.checkpoint()
             # On macOS, calling shutdown a second time raises ENOTCONN, but
@@ -141,6 +144,7 @@ class SocketStream(HalfCloseableStream):
                 self.socket.shutdown(tsocket.SHUT_WR)
 
     async def receive_some(self, max_bytes: int | None = None) -> bytes:
+        """See `trio.abc.ReceiveStream.receive_some`."""
         if max_bytes is None:
             max_bytes = DEFAULT_RECEIVE_SIZE
         if max_bytes < 1:
@@ -149,6 +153,7 @@ class SocketStream(HalfCloseableStream):
             return await self.socket.recv(max_bytes)
 
     async def aclose(self) -> None:
+        """See `trio.abc.AsyncResource.aclose`."""
         self.socket.close()
         await trio.lowlevel.checkpoint()
 

--- a/src/trio/_subprocess.py
+++ b/src/trio/_subprocess.py
@@ -98,7 +98,9 @@ else:
 class HasFileno(Protocol):
     """Represents any file-like object that has a file descriptor."""
 
-    def fileno(self) -> int: ...
+    def fileno(self) -> int:
+        """Return the underlying file descriptor as an integer."""
+        ...
 
 
 @final


### PR DESCRIPTION
## Summary

Addresses #3221 by adding docstrings to all items identified as appearing in the Sphinx documentation without a docstring.

**Changes:**

- **`MemorySendChannel`** and **`MemoryReceiveChannel`**: Added class-level docstrings describing these as the sending/receiving ends of a memory channel, with cross-references to `open_memory_channel` and the channel-mpmc section.
- **`MemoryChannelStatistics`**: Added a class docstring explaining it is the return type of `.statistics()` and pointing to `open_memory_channel` for field details.
- **`SocketStream.send_all`**, **`.receive_some`**, **`.send_eof`**, **`.wait_send_all_might_not_block`**, **`.aclose`**: Added brief docstrings that reference the parent ABC method (e.g. "See `trio.abc.SendStream.send_all`."). Also removed `:undoc-members:` from the `SocketStream` autoclass RST directive since all methods now have docstrings.
- **`HasFileno.fileno`**: Added a one-line docstring.
- **`ParkingLot.broken_by`**: Added an attribute docstring explaining what the list contains and its effect on `park`.

Includes a `3221.doc.rst` newsfragment.

## Test plan

- [ ] Verify the Sphinx docs build correctly and all previously-blank entries now show docstrings
- [ ] Verify the Read the Docs preview renders the new docstrings properly
- [ ] Confirm no existing tests are broken by the changes (all changes are docstring-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)