### PR TITLE
Fix exception cause/context lost before task_status.started()

### DIFF
--- a/newsfragments/3261.bugfix.rst
+++ b/newsfragments/3261.bugfix.rst
@@ -1,0 +1,2 @@
+``Nursery.start()`` now preserves the ``__cause__`` and ``__context__`` of
+exceptions raised before ``task_status.started()`` is called.

--- a/src/trio/_core/_run.py
+++ b/src/trio/_core/_run.py
@@ -33,7 +33,7 @@ from sortedcontainers import SortedDict
 from .. import _core
 from .._abc import Clock, Instrument
 from .._deprecate import warn_deprecated
-from .._util import NoPublicConstructor, coroutine_or_error, final
+from .._util import NoPublicConstructor, coroutine_or_error, final, raise_saving_context
 from ._asyncgens import AsyncGenerators
 from ._concat_tb import concat_tb
 from ._entry_queue import EntryQueue, TrioToken
@@ -1466,7 +1466,7 @@ class Nursery(metaclass=NoPublicConstructor):
                     # cancel this nursery:
             except BaseExceptionGroup as exc:
                 if len(exc.exceptions) == 1:
-                    raise exc.exceptions[0] from None
+                    raise_saving_context(exc.exceptions[0])
                 raise TrioInternalError(
                     "Internal nursery should not have multiple tasks. This can be "
                     'caused by the user managing to access the "old" nursery in '

--- a/src/trio/_core/_tests/test_run.py
+++ b/src/trio/_core/_tests/test_run.py
@@ -2920,6 +2920,26 @@ def test_trio_run_strict_before_started(
         assert should_be_raiser_exc.exceptions == raiser_exc.exceptions
 
 
+async def test_start_exception_preserves_cause_and_context() -> None:
+    """Regression test for #3261: exceptions raised before task_status.started()
+    should preserve __cause__ and __context__."""
+
+    async def task(*, task_status: _core.TaskStatus[None]) -> None:
+        e = ValueError("foo")
+        e.__cause__ = SyntaxError("bar")
+        e.__context__ = TypeError("baz")
+        raise e
+
+    with pytest.raises(BaseExceptionGroup) as exc_info:
+        async with _core.open_nursery() as nursery:
+            await nursery.start(task)
+    assert len(exc_info.value.exceptions) == 1
+    exc = exc_info.value.exceptions[0]
+    assert isinstance(exc, ValueError)
+    assert isinstance(exc.__cause__, SyntaxError)
+    assert isinstance(exc.__context__, TypeError)
+
+
 async def test_internal_error_old_nursery_multiple_tasks() -> None:
     async def error_func() -> None:
         raise ValueError

--- a/src/trio/_core/_tests/test_run.py
+++ b/src/trio/_core/_tests/test_run.py
@@ -2930,14 +2930,15 @@ async def test_start_exception_preserves_cause_and_context() -> None:
         e.__context__ = TypeError("baz")
         raise e
 
-    with pytest.raises(BaseExceptionGroup) as exc_info:
+    with pytest.RaisesGroup(
+        pytest.RaisesExc(
+            ValueError,
+            check=lambda exc: isinstance(exc.__cause__, SyntaxError)
+            and isinstance(exc.__context__, TypeError),
+        ),
+    ):
         async with _core.open_nursery() as nursery:
             await nursery.start(task)
-    assert len(exc_info.value.exceptions) == 1
-    exc = exc_info.value.exceptions[0]
-    assert isinstance(exc, ValueError)
-    assert isinstance(exc.__cause__, SyntaxError)
-    assert isinstance(exc.__context__, TypeError)
 
 
 async def test_internal_error_old_nursery_multiple_tasks() -> None:


### PR DESCRIPTION
## Summary

Fixes #3261.

When a task raises an exception before calling `task_status.started()`, `Nursery.start()` unwraps it from the internal `ExceptionGroup` using:
```python
raise exc.exceptions[0] from None
```

The `from None` explicitly sets `__cause__` to `None` and `__suppress_context__` to `True`, destroying any cause or context the original exception carried.

### Fix

Replace the bare `raise ... from None` with `raise_saving_context()`, which preserves both `__cause__` and `__context__`. This is the same utility already used by `raise_single_exception_from_group()` for the same pattern.

### Before
```python
>>> excgroup.exceptions[0].__cause__   # should be SyntaxError, was None
>>> excgroup.exceptions[0].__context__ # should be TypeError, was the ExceptionGroup
```

### After
```python
>>> excgroup.exceptions[0].__cause__   # SyntaxError("bar")
>>> excgroup.exceptions[0].__context__ # TypeError("baz")
```

### Test plan

- [x] New regression test `test_start_exception_preserves_cause_and_context`
- [x] All 28 start-related tests pass
- [x] All 154 `test_run.py` tests pass