### PR TITLE
Fix Cancelled.__context__ leaking from other tasks

### DIFF
--- a/newsfragments/2649.bugfix.rst
+++ b/newsfragments/2649.bugfix.rst
@@ -1,0 +1,3 @@
+:exc:`Cancelled` exceptions no longer inherit ``__context__`` from
+unrelated exceptions being handled in the task that called
+:meth:`CancelScope.cancel`.

--- a/src/trio/_core/_run.py
+++ b/src/trio/_core/_run.py
@@ -1649,7 +1649,13 @@ class Task(metaclass=NoPublicConstructor):  # type: ignore[explicit-any]
         # whether we succeeded or failed.
         self._abort_func = None
         if success is Abort.SUCCEEDED:
-            self._runner.reschedule(self, capture(raise_cancel))
+            # Clear __context__ to prevent exception state from the task
+            # that called cancel() from leaking into the cancelled task's
+            # Cancelled exception. See https://github.com/python-trio/trio/issues/2649
+            error = capture(raise_cancel)
+            error.error.__context__ = None
+            self._runner.reschedule(self, error)
+            del error
 
     def _attempt_delivery_of_any_pending_cancel(self) -> None:
         if self._abort_func is None:

--- a/src/trio/_core/_tests/test_run.py
+++ b/src/trio/_core/_tests/test_run.py
@@ -603,6 +603,42 @@ async def test_cancel_shield_abort() -> None:
                 assert record == ["sleeping", "cancelled"]
 
 
+async def test_cancelled_context_does_not_leak_from_other_task() -> None:
+    # https://github.com/python-trio/trio/issues/2649
+    # When task 1 calls cancel() while handling an exception,
+    # task 2's Cancelled exception should NOT have task 1's
+    # exception as __context__.
+    task2_cancelled: _core.Cancelled | None = None
+
+    async def task2(cancel_scope: _core.CancelScope) -> None:
+        nonlocal task2_cancelled
+        with cancel_scope:
+            try:
+                await sleep_forever()
+            except _core.Cancelled as exc:
+                task2_cancelled = exc
+                raise
+
+    async with _core.open_nursery() as nursery:
+        cancel_scope = _core.CancelScope()
+        nursery.start_soon(task2, cancel_scope)
+        await wait_all_tasks_blocked()
+
+        # Task 1 cancels the scope while handling an exception
+        try:
+            raise RuntimeError("task1 error")
+        except RuntimeError:
+            cancel_scope.cancel()
+
+        # Give task2 a chance to run and handle the cancellation
+        await wait_all_tasks_blocked()
+
+    assert task2_cancelled is not None
+    # The key assertion: task2's Cancelled should not have
+    # task1's RuntimeError as __context__
+    assert task2_cancelled.__context__ is None
+
+
 async def test_basic_timeout(mock_clock: _core.MockClock) -> None:
     start = _core.current_time()
     with _core.CancelScope() as scope:


### PR DESCRIPTION
## Summary

Fixes #2649

When task 1 calls `cancel()` on a scope while handling an exception, the `Cancelled` exception delivered to task 2 (sleeping in that scope) incorrectly inherits task 1's exception as `__context__`. This is because `capture(raise_cancel)` is called within task 1's exception handling context, so Python automatically sets `__context__` on the newly-raised `Cancelled`.

### Before
```python
async with trio.open_nursery() as nursery:
    cancel_scope = trio.CancelScope()
    nursery.start_soon(task2, cancel_scope)
    await trio.testing.wait_all_tasks_blocked()

    try:
        raise RuntimeError("task1 error")
    except RuntimeError:
        cancel_scope.cancel()
    # task2's Cancelled.__context__ == RuntimeError("task1 error")  ← wrong!
```

### After
```python
    # task2's Cancelled.__context__ is None  ← correct
```

## Fix

Clear `__context__` on the captured error in `_attempt_abort` before rescheduling the cancelled task. This matches the behavior of other abort pathways (deferred cancellation like IOCP/io_uring) where the `Cancelled` exception naturally gets `__context__ = None`.

The local variable is explicitly deleted to avoid creating cyclic garbage (verified by the existing `test_simple_cancel_scope_usage_doesnt_create_cyclic_garbage` test).

## Test

Added `test_cancelled_context_does_not_leak_from_other_task` which:
1. Starts task 2 sleeping in a cancel scope
2. Has task 1 cancel the scope while handling a RuntimeError
3. Verifies task 2's Cancelled exception has `__context__ is None`

The test fails without the fix (Cancelled.__context__ == RuntimeError) and passes with it.