### PR TITLE
Fix _Once.ensure() to propagate handshake failure to concurrent waiters

### DIFF
--- a/src/trio/_ssl.py
+++ b/src/trio/_ssl.py
@@ -223,7 +223,7 @@ class NeedHandshakeError(Exception):
 
 
 class _Once:
-    __slots__ = ("_afn", "_args", "_done", "started")
+    __slots__ = ("_afn", "_args", "_done", "_failure", "started")
 
     def __init__(
         self,
@@ -234,16 +234,26 @@ class _Once:
         self._args = args
         self.started = False
         self._done = _sync.Event()
+        self._failure: BaseException | None = None
 
     async def ensure(self, *, checkpoint: bool) -> None:
         if not self.started:
             self.started = True
-            await self._afn(*self._args)
+            try:
+                await self._afn(*self._args)
+            except BaseException as exc:
+                self._failure = exc
+                self._done.set()
+                raise
             self._done.set()
         elif not checkpoint and self._done.is_set():
+            if self._failure is not None:
+                raise trio.BrokenResourceError from self._failure
             return
         else:
             await self._done.wait()
+            if self._failure is not None:
+                raise trio.BrokenResourceError from self._failure
 
     @property
     def done(self) -> bool:


### PR DESCRIPTION
## Problem

`_Once.ensure()` in `SSLStream` can leave concurrent waiters hanging forever when the handshake fails.

When two tasks share an `SSLStream` (one sending, one receiving), both call `ensure()` to lazily perform the TLS handshake. The first task sets `started = True` and begins the handshake. The second task sees `started=True`, finds `_done` not yet set, and enters `_done.wait()`.

If the handshake **fails** (certificate error, connection reset, etc.), the exception propagates to the first task — but `_done.set()` is never called. The second task is stuck forever in `_done.wait()`: the Event will never be signalled, and `started` is permanently `True`, so re-entry won't help either.

### Reproduction scenario

1. Task A calls `send_all()` → enters `ensure()`, starts handshake
2. Task B calls `receive_some()` → enters `ensure()`, waits on `_done`
3. Handshake fails (remote peer rejects cert)
4. Task A gets `BrokenResourceError` — correct
5. Task B **hangs indefinitely**

## Fix

Store the exception on failure and still signal `_done`, so that concurrent waiters (and any future callers) wake up and receive a `BrokenResourceError` chained from the original handshake exception.
