### PR TITLE
Fix error message: says stdout but checks stdin

### DIFF
--- a/src/trio/_subprocess.py
+++ b/src/trio/_subprocess.py
@@ -675,7 +675,7 @@ async def _run_process(
     if task_status is trio.TASK_STATUS_IGNORED:
         if stdin is subprocess.PIPE:
             raise ValueError(
-                "stdout=subprocess.PIPE is only valid with nursery.start, "
+                "stdin=subprocess.PIPE is only valid with nursery.start, "
                 "since that's the only way to access the pipe; use nursery.start "
                 "or pass the data you want to write directly",
             )


### PR DESCRIPTION
## Problem

In `_run_process()`, when `stdin=subprocess.PIPE` is passed without using `nursery.start`, the error message incorrectly says:

> stdout=subprocess.PIPE is only valid with nursery.start...

The condition checks `stdin is subprocess.PIPE`, but the message refers to `stdout`. This sends users looking at the wrong argument.

## Fix

Changed `"stdout=subprocess.PIPE"` to `"stdin=subprocess.PIPE"` in the error message so it matches the actual condition being checked.
