### PR TITLE
Fix CapacityLimiter._pending_borrowers leak on non-Cancelled exceptions

### DIFF
--- a/src/trio/_sync.py
+++ b/src/trio/_sync.py
@@ -377,8 +377,8 @@ class CapacityLimiter(AsyncContextManagerMixin):
             self._pending_borrowers[task] = borrower
             try:
                 await self._lot.park()
-            except trio.Cancelled:
-                self._pending_borrowers.pop(task)
+            except BaseException:
+                self._pending_borrowers.pop(task, None)
                 raise
         else:
             await trio.lowlevel.cancel_shielded_checkpoint()


### PR DESCRIPTION
## Problem

`CapacityLimiter.acquire_on_behalf_of` only cleans up `_pending_borrowers` when `park()` raises `trio.Cancelled`. If `park()` raises any other exception — such as `KeyboardInterrupt` delivered to a parked task via the abort mechanism — the task's entry stays in `_pending_borrowers` permanently.

The relevant code:

```python
try:
    await self._lot.park()
except trio.Cancelled:
    self._pending_borrowers.pop(task)
    raise
```

When `KeyboardInterrupt` is delivered to the task, the abort function succeeds and the task is rescheduled with `raise_cancel()` which raises `KeyboardInterrupt`, not `trio.Cancelled`. The stale entry leaks.

## Fix

Broadened the exception handler to `BaseException` and use `pop(task, None)` for safety against double-removal:

```python
except BaseException:
    self._pending_borrowers.pop(task, None)
    raise
```
