### PR TITLE
Try fixing RTD failure

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -86,7 +86,8 @@ Vital statistics:
    contributing.rst
    releasing.rst
    code-of-conduct.rst
-   genindex
+
+.. once https://github.com/sphinx-doc/sphinx/issues/13733 is merged, add `genindex` above
 
 ====================
  Indices and tables


### PR DESCRIPTION
This should fix that [RTD is currently failing](https://app.readthedocs.org/projects/trio/builds/31605010/). I checked with `make singlehtml` before and after this change -- before it failed, now it succeeds.

Ideally we could work around this e.g. with the `only` directive, but I tried:

```
.. toctree
   ...

   .. only:: html
      genindex
```

and that didn't work, so I think we should just wait on https://github.com/sphinx-doc/sphinx/issues/13733. (one other possible workaround would be to modify the templates, but that's a bit much, don't you think?)