### PR TITLE
Disallow absolute deadlines for relative cancel scopes

### DIFF
--- a/newsfragments/3403.deprecated.rst
+++ b/newsfragments/3403.deprecated.rst
@@ -1,3 +1,6 @@
 Trying to use absolute deadlines on a `trio.CancelScope` constructed
 with a relative deadline now raises, after being deprecated since Trio
 0.27.0.
+
+To move over, replace the `trio.CancelScope` object instead of mutating
+it.

--- a/newsfragments/3403.deprecated.rst
+++ b/newsfragments/3403.deprecated.rst
@@ -2,5 +2,5 @@ Trying to use absolute deadlines on a `trio.CancelScope` constructed
 with a relative deadline now raises, after being deprecated since Trio
 0.27.0.
 
-To move over, replace the `trio.CancelScope` object instead of mutating
-it.
+To switch a cancel scope from being relative to absolute, replace the
+`trio.CancelScope` object instead of trying to mutate it.

--- a/newsfragments/3403.deprecated.rst
+++ b/newsfragments/3403.deprecated.rst
@@ -1,0 +1,3 @@
+Trying to use absolute deadlines on a `trio.CancelScope` constructed
+with a relative deadline now raises, after being deprecated since Trio
+0.27.0.

--- a/src/trio/_core/_run.py
+++ b/src/trio/_core/_run.py
@@ -808,13 +808,9 @@ class CancelScope:
         """
         if self._relative_deadline != inf:
             assert self._deadline == inf
-            warnings.warn(
-                DeprecationWarning(
-                    "unentered relative cancel scope does not have an absolute deadline. Use `.relative_deadline`",
-                ),
-                stacklevel=2,
+            raise RuntimeError(
+                "Unentered relative cancel scope does not have an absolute deadline."
             )
-            return current_time() + self._relative_deadline
         return self._deadline
 
     @deadline.setter
@@ -823,13 +819,9 @@ class CancelScope:
             raise ValueError("deadline must not be NaN")
         if self._relative_deadline != inf:
             assert self._deadline == inf
-            warnings.warn(
-                DeprecationWarning(
-                    "unentered relative cancel scope does not have an absolute deadline. Transforming into an absolute cancel scope. First set `.relative_deadline = math.inf` if you do want an absolute cancel scope.",
-                ),
-                stacklevel=2,
+            raise RuntimeError(
+                "Unentered relative cancel scope does not have an absolute deadline."
             )
-            self._relative_deadline = inf
         with self._might_change_registered_deadline():
             self._deadline = float(new_deadline)
 
@@ -852,7 +844,7 @@ class CancelScope:
         elif self._deadline != inf:
             assert self._relative_deadline == inf
             raise RuntimeError(
-                "unentered non-relative cancel scope does not have a relative deadline",
+                "Unentered non-relative cancel scope does not have a relative deadline",
             )
         return self._relative_deadline
 
@@ -868,7 +860,7 @@ class CancelScope:
         elif self._deadline != inf:
             assert self._relative_deadline == inf
             raise RuntimeError(
-                "unentered non-relative cancel scope does not have a relative deadline",
+                "Unentered non-relative cancel scope does not have a relative deadline",
             )
         else:
             self._relative_deadline = new_relative_deadline

--- a/src/trio/_tests/test_timeouts.py
+++ b/src/trio/_tests/test_timeouts.py
@@ -246,26 +246,22 @@ async def test_timeout_deadline_on_entry(mock_clock: _core.MockClock) -> None:
 async def test_invalid_access_unentered(mock_clock: _core.MockClock) -> None:
     cs = move_on_after(5)
     mock_clock.jump(3)
-    start = _core.current_time()
 
-    match_str = "^unentered relative cancel scope does not have an absolute deadline"
-    with pytest.warns(DeprecationWarning, match=match_str):
-        assert cs.deadline == start + 5
-    mock_clock.jump(1)
-    # this is hella sketchy, but they *have* been warned
-    with pytest.warns(DeprecationWarning, match=match_str):
-        assert cs.deadline == start + 6
+    match_str = "^Unentered relative cancel scope does not have an absolute deadline"
+    with pytest.raises(RuntimeError, match=match_str):
+        print("SHOULD NOT PRINT! deadline:", cs.deadline)
 
-    with pytest.warns(DeprecationWarning, match=match_str):
+    with pytest.raises(RuntimeError, match=match_str):
         cs.deadline = 7
-    # now transformed into absolute
-    assert cs.deadline == 7
-    assert not cs.is_relative
+
+    # nothing happened!
+    assert cs.relative_deadline == 5
+    assert cs.is_relative
 
     cs = move_on_at(5)
 
     match_str = (
-        "^unentered non-relative cancel scope does not have a relative deadline$"
+        "^Unentered non-relative cancel scope does not have a relative deadline$"
     )
     with pytest.raises(RuntimeError, match=match_str):
         assert cs.relative_deadline

--- a/src/trio/_tests/test_timeouts.py
+++ b/src/trio/_tests/test_timeouts.py
@@ -243,13 +243,12 @@ async def test_timeout_deadline_on_entry(mock_clock: _core.MockClock) -> None:
         assert rcs is cs
 
 
-async def test_invalid_access_unentered(mock_clock: _core.MockClock) -> None:
+async def test_invalid_access_unentered() -> None:
     cs = move_on_after(5)
-    mock_clock.jump(3)
 
     match_str = "^Unentered relative cancel scope does not have an absolute deadline"
     with pytest.raises(RuntimeError, match=match_str):
-        print("SHOULD NOT PRINT! deadline:", cs.deadline)
+        assert cs.deadline
 
     with pytest.raises(RuntimeError, match=match_str):
         cs.deadline = 7


### PR DESCRIPTION
This just converts our deprecations into `RuntimeError`s. It's been long enough!