### PR TITLE
fix: correct error message for stdout pipe check in run_process

### DIFF
--- a/newsfragments/3409.bugfix.rst
+++ b/newsfragments/3409.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed incorrect error message in `run_process`: the `stdout` pipe check now correctly says "stdout" instead of "stdin".
+Fixed incorrect error message in ``run_process``: the ``stdout`` pipe check now correctly says "stdout" instead of "stdin".

--- a/newsfragments/3409.bugfix.rst
+++ b/newsfragments/3409.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed incorrect error message in `run_process`: the `stdout` pipe check now correctly says "stdout" instead of "stdin".

--- a/src/trio/_subprocess.py
+++ b/src/trio/_subprocess.py
@@ -675,7 +675,7 @@ async def _run_process(
     if task_status is trio.TASK_STATUS_IGNORED:
         if stdin is subprocess.PIPE:
             raise ValueError(
-                "stdout=subprocess.PIPE is only valid with nursery.start, "
+                "stdin=subprocess.PIPE is only valid with nursery.start, "
                 "since that's the only way to access the pipe; use nursery.start "
                 "or pass the data you want to write directly",
             )

--- a/src/trio/_tests/test_subprocess.py
+++ b/src/trio/_tests/test_subprocess.py
@@ -367,9 +367,10 @@ async def test_run() -> None:
     with pytest.raises(UnicodeError):
         await run_process(CAT, stdin="oh no, it's text")
 
-    pipe_stdout_error = r"^stdout=subprocess\.PIPE is only valid with nursery\.start, since that's the only way to access the pipe(; use nursery\.start or pass the data you want to write directly)*$"
-    with pytest.raises(ValueError, match=pipe_stdout_error):
+    pipe_stdin_error = r"^stdin=subprocess\.PIPE is only valid with nursery\.start, since that's the only way to access the pipe(; use nursery\.start or pass the data you want to write directly)*$"
+    with pytest.raises(ValueError, match=pipe_stdin_error):
         await run_process(CAT, stdin=subprocess.PIPE)
+    pipe_stdout_error = r"^stdout=subprocess\.PIPE is only valid with nursery\.start, since that's the only way to access the pipe(; use nursery\.start or pass the data you want to write directly)*$"
     with pytest.raises(ValueError, match=pipe_stdout_error):
         await run_process(CAT, stdout=subprocess.PIPE)
     with pytest.raises(

--- a/src/trio/_tests/test_subprocess.py
+++ b/src/trio/_tests/test_subprocess.py
@@ -367,10 +367,10 @@ async def test_run() -> None:
     with pytest.raises(UnicodeError):
         await run_process(CAT, stdin="oh no, it's text")
 
-    pipe_stdin_error = r"^stdin=subprocess\.PIPE is only valid with nursery\.start, since that's the only way to access the pipe(; use nursery\.start or pass the data you want to write directly)*$"
+    pipe_stdin_error = r"^stdin=subprocess\.PIPE is only valid with nursery\.start, since that's the only way to access the pipe(; use nursery\.start or pass the data you want to write directly)?$"
     with pytest.raises(ValueError, match=pipe_stdin_error):
         await run_process(CAT, stdin=subprocess.PIPE)
-    pipe_stdout_error = r"^stdout=subprocess\.PIPE is only valid with nursery\.start, since that's the only way to access the pipe(; use nursery\.start or pass the data you want to write directly)*$"
+    pipe_stdout_error = r"^stdout=subprocess\.PIPE is only valid with nursery\.start, since that's the only way to access the pipe(; use nursery\.start or pass the data you want to write directly)?$"
     with pytest.raises(ValueError, match=pipe_stdout_error):
         await run_process(CAT, stdout=subprocess.PIPE)
     with pytest.raises(

--- a/src/trio/_tests/test_subprocess.py
+++ b/src/trio/_tests/test_subprocess.py
@@ -367,10 +367,10 @@ async def test_run() -> None:
     with pytest.raises(UnicodeError):
         await run_process(CAT, stdin="oh no, it's text")
 
-    pipe_stdin_error = r"^stdin=subprocess\.PIPE is only valid with nursery\.start, since that's the only way to access the pipe(; use nursery\.start or pass the data you want to write directly)?$"
+    pipe_stdin_error = r"^stdin=subprocess\.PIPE is only valid with nursery\.start, since that's the only way to access the pipe; use nursery\.start or pass the data you want to write directly$"
     with pytest.raises(ValueError, match=pipe_stdin_error):
         await run_process(CAT, stdin=subprocess.PIPE)
-    pipe_stdout_error = r"^stdout=subprocess\.PIPE is only valid with nursery\.start, since that's the only way to access the pipe(; use nursery\.start or pass the data you want to write directly)?$"
+    pipe_stdout_error = r"^stdout=subprocess\.PIPE is only valid with nursery\.start, since that's the only way to access the pipe$"
     with pytest.raises(ValueError, match=pipe_stdout_error):
         await run_process(CAT, stdout=subprocess.PIPE)
     with pytest.raises(

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -141,7 +141,7 @@ requests==2.33.1
     # via sphinx
 roman-numerals==4.1.0 ; python_full_version >= '3.11'
     # via sphinx
-ruff==0.15.8
+ruff==0.15.9
     # via -r test-requirements.in
 sniffio==1.3.1
     # via -r test-requirements.in
@@ -203,7 +203,7 @@ typing-extensions==4.15.0
     #   virtualenv
 urllib3==2.6.3
     # via requests
-uv==0.11.2
+uv==0.11.3
     # via -r test-requirements.in
 virtualenv==21.2.0
     # via pre-commit


### PR DESCRIPTION
Fixes #3409

The error message for the `stdout=subprocess.PIPE` check in `run_process` incorrectly said "stdin=subprocess.PIPE". This fixes it to say "stdout=subprocess.PIPE".

This is a recreation of #3398 with the same fix plus a newsfragment.