### PR TITLE
Update how many codecov builds we upload

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,7 +6,7 @@ codecov:
   notify:
     # This number needs to be changed whenever the number of runs in CI is changed.
     # Another option is codecov-cli: https://github.com/codecov/codecov-cli#send-notifications
-    after_n_builds: 31
+    after_n_builds: 35
     wait_for_ci: false
     notify_error: true # if uploads fail, replace cov comment with a comment with errors.
   require_ci_to_pass: false


### PR DESCRIPTION
I noticed this number seems to be out of date! I'm not sure if there's a better thing... Maybe `wait_for_ci` started working?