### PR TITLE
docs: drop undocumented SocketStream method stubs from the API ref

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -176,11 +176,6 @@ UNDOCUMENTED = {
     "trio.MemorySendChannel",
     "trio.MemoryReceiveChannel",
     "trio.MemoryChannelStatistics",
-    "trio.SocketStream.aclose",
-    "trio.SocketStream.receive_some",
-    "trio.SocketStream.send_all",
-    "trio.SocketStream.send_eof",
-    "trio.SocketStream.wait_send_all_might_not_block",
     "trio._subprocess.HasFileno.fileno",
     "trio.lowlevel.ParkingLot.broken_by",
 }

--- a/docs/source/reference-io.rst
+++ b/docs/source/reference-io.rst
@@ -218,7 +218,6 @@ abstraction.
 
 .. autoclass:: SocketStream
    :members:
-   :undoc-members:
    :show-inheritance:
 
 .. autoclass:: SocketListener
@@ -432,7 +431,7 @@ Socket objects
    * :meth:`~socket.socket.sendall`: Could be supported, but you're
      better off using the higher-level
      :class:`~trio.SocketStream`, and specifically its
-     :meth:`~trio.SocketStream.send_all` method, which also does
+     :meth:`~trio.abc.SendStream.send_all` method, which also does
      additional error checking.
 
    In addition, the following methods are similar to the equivalents

--- a/newsfragments/3221.doc.rst
+++ b/newsfragments/3221.doc.rst
@@ -1,0 +1,4 @@
+Stopped listing :class:`trio.SocketStream`'s undocumented overrides of
+``send_all``, ``wait_send_all_might_not_block``, ``send_eof``, ``receive_some``,
+and ``aclose`` in the API reference. The base contracts on the
+:mod:`trio.abc` classes remain the canonical reference.


### PR DESCRIPTION
Per A5rocks's review, this now removes `:undoc-members:` from the `SocketStream` autoclass directive instead of adding docstrings. The five overrides (`send_all`, `wait_send_all_might_not_block`, `send_eof`, `receive_some`, `aclose`) no longer show up as empty rows in the API table; users follow the inheritance link to the `trio.abc` contracts.

Two extras that fell out of doing it that way: the cross-reference further down in `reference-io.rst` pointed at `trio.SocketStream.send_all`, which no longer has a target, so it now points at `trio.abc.SendStream.send_all`; and the five matching entries in `UNDOCUMENTED` in `conf.py` were silencing warnings for things that aren't autodoc'd anymore, so I removed them too.

`make html` runs clean with `-W`. Refs #3221.
