### PR TITLE
Add impure `flake.nix` dev-shell using `uv` (possibly a proper `<nixpkgs>` overlay coming)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -45,7 +45,7 @@
               # - [ ] extract-n-translate all `[docs|test]-requirements.txt` deps
               #      into their equiv nxpkgs equivalents.
               #
-              # For ex. we can explicitily add them like the below,
+              # For ex. we can explicitly add them like the below,
               # but ideally we use a translator lib (like
               # `pyproject.nix` and/or `uv2nix`).
               #

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,117 @@
+# An "impure" template thx to `pyproject.nix`,
+# https://pyproject-nix.github.io/pyproject.nix/templates.html#impure
+# https://github.com/pyproject-nix/pyproject.nix/blob/master/templates/impure/flake.nix
+{
+  description = "An impure dev-shell (overlay) using `uv`";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable-small";
+  };
+
+  outputs =
+    { nixpkgs, ... }:
+    let
+      inherit (nixpkgs) lib;
+      forAllSystems = lib.genAttrs lib.systems.flakeExposed;
+    in
+    {
+      devShells = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+
+          # XXX NOTE XXX, for now we overlay specific pkgs via
+          # a major-version-pinned-`cpython`
+          cpython = "python313";
+          venv_dir = "py313";
+          pypkgs = pkgs."${cpython}Packages";
+        in
+        {
+          default = pkgs.mkShell {
+
+            packages = [
+              # XXX, ensure sh completions activate!
+              pkgs.bashInteractive
+              pkgs.bash-completion
+
+              # pkgs.xonsh
+              pkgs.uv
+              pkgs.${cpython} # ?TODO^ how to set from `cpython` above?
+              pkgs."${cpython}Packages".setuptools
+
+              # testing-n-tooling
+              # ?TODO, if we want to pull `xxx-requirements.txt` from
+              # nixpkgs directly?
+              # - [ ] extract-n-translate all `[docs|test]-requirements.txt` deps
+              #      into their equiv nxpkgs equivalents.
+              #
+              # For ex. we can explicitily add them like the below,
+              # but ideally we use a translator lib (like
+              # `pyproject.nix` and/or `uv2nix`).
+              #
+              # pkgs."${cpython}Packages".black
+              # pkgs."${cpython}Packages".coverage
+              # pkgs."${cpython}Packages".hypothesis
+              # pkgs."${cpython}Packages".mypy
+              # pkgs."${cpython}Packages".pytest
+              # pkgs."${cpython}Packages".towncrier
+
+              # XXX, pkgs not listed in `-requirements.txt` files.
+              pkgs."${cpython}Packages".tox
+
+              # XXX, on nix(os), use pkgs version to avoid
+              # build/sys-sh-integration issues
+              pkgs.ruff
+              pkgs.pyright
+
+            ];
+
+            shellHook = ''
+              # unmask to debug **this** dev-shell-hook
+              # set -e
+
+              # RUNTIME-SETTINGS
+              # ------ uv ------
+              # - always use and explicit py-version abbreviated
+              #   `${venv_dir}` (like `./py313/`) venv-subdir instead
+              #   the default (and version ambiguous) `.venv` used by
+              #   `uv`.
+              export UV_PROJECT_ENVIRONMENT=${venv_dir}
+
+              # - sync the `uv` env with all extras, namely the test
+              #   and docs deps as required by the full CI/CD
+              #   pipeline used on Github.
+              uv add -r test-requirements.in -c test-requirements.txt --group test
+
+              # ?TODO? next line is unneeded since
+              # `test-requirements.[in|txt]` already is super set of
+              # `docs-requirements.[in|txt]`?
+              # uv add -r docs-requirements.in -c docs-requirements.txt --group docs
+
+              # NOTE, a `tox.ini` is included in repo even though no
+              # explicit dependency is declared elsewhere.
+              uv add --group test tox
+
+              # generate a `uv.lock`
+              uv lock
+
+              # ?TODO, this would update to latest deps versions right?
+              # - [ ] a dev can invoke this explicitly if wanted?
+              # uv sync
+
+              # ?TODO? if core-devs would prefer not (encouraging us)
+              # to use `uv` we can instead use `pip` directly, but it
+              # seems a bit pedantic and less convenient when devving
+              # on nix(os).
+              # pip install -e .
+
+              # ------ HOT-TIPS ------
+              # - to launch the py-venv installed `xonsh` (like your
+              #   fave collab @goodboy) run the `nix develop` cmd with,
+              # >> nix develop -c uv run xonsh
+            '';
+          };
+        }
+      );
+    };
+}


### PR DESCRIPTION
Based on [`pyproject.nix`][pyproject.nix]'s [impure
template][impure_template], this overlays a major-version-pinned
`cpython` (currently `python313`) so `nix(OS)` devs can drop into
a `nix develop` shell with `uv` (via a [`pip`-migration][uv_w_pip])
managing the python virtual-env.

**More thorough description coming once i refine this a bit more!**

[pyproject.nix]: https://pyproject-nix.github.io/pyproject.nix/
[impure_template]: https://pyproject-nix.github.io/pyproject.nix/templates.html#impure
[uv_w_pip]: https://docs.astral.sh/uv/guides/migration/pip-to-project/

---

### Basic usage (will be incrementally updated)

to open a dev-shell for hacking on `trio` core on a nixos system,

```
nix develop [-c <shell you use>]
```

then you will be in a (default `bash`) shell and can interact with
the python venv using,

```bash
# once inside nix dev-shell
uv sync  # update deps to latest
uv sync --group test  # update all "test"-dependency-group deps
uv run pytest  # run full test suite (requires above line ^)
```

---

### Still TODO

first (commit) draft is **very WIP** but by non-draft form we should
at least have,

- [ ] link to relevant docs,
  * [x] `nix`-related extension libs/projects (`pyproject.toml`, `uv2nix`) 
  * [ ] explain/justify *why* a `flake.nix` (is common) to have in repo.
  * [ ] `uv` pkging and import docs (and related alt options to move
    closer to `uv`-styled `pyproject.toml`).

- [ ] how much further `uv` integration do we want?
  * [ ] importing from `requirements.[in|txt]` files can be taken
    further per,
    https://docs.astral.sh/uv/guides/migration/pip-to-project/#importing-requirements-files
  * [ ] do we want an explicit "development" deps set? 
    https://docs.astral.sh/uv/guides/migration/pip-to-project/#importing-development-dependency-files

- [ ] get (AI to help) on refining this to include a proper nixpkgs
      `overlay` output.

- [ ] write proper usage docs for `nix(OS)` users.
  * [ ] something in the/a sub-`README`?
  * [ ] and/or the sphinx docs?
