### PR TITLE
docs: add missing docstrings to MemorySendChannel, MemoryReceiveChannel, MemoryChannelStatistics, SocketStream methods

### DIFF
--- a/newsfragments/3221.doc.rst
+++ b/newsfragments/3221.doc.rst
@@ -1,0 +1,3 @@
+Added docstrings to :class:`MemoryChannelStatistics`, :class:`MemorySendChannel`,
+:class:`MemoryReceiveChannel`, and several :class:`SocketStream` methods that
+were missing from the API reference.

--- a/src/trio/_channel.py
+++ b/src/trio/_channel.py
@@ -118,6 +118,19 @@ class open_memory_channel(tuple["MemorySendChannel[T]", "MemoryReceiveChannel[T]
 
 @attrs.frozen
 class MemoryChannelStatistics:
+    """Statistics about a memory channel, as returned by
+    :meth:`MemorySendChannel.statistics` or
+    :meth:`MemoryReceiveChannel.statistics`.
+
+    Attributes:
+      current_buffer_used: Number of items currently stored in the channel buffer.
+      max_buffer_size: Maximum number of items allowed in the buffer.
+      open_send_channels: Number of open :class:`MemorySendChannel` endpoints.
+      open_receive_channels: Number of open :class:`MemoryReceiveChannel` endpoints.
+      tasks_waiting_send: Number of tasks blocked in ``send`` across all clones.
+      tasks_waiting_receive: Number of tasks blocked in ``receive`` across all clones.
+    """
+
     current_buffer_used: int
     max_buffer_size: int | float
     open_send_channels: int
@@ -152,6 +165,13 @@ class MemoryChannelState(Generic[T]):
 @final
 @attrs.define(eq=False, repr=False, slots=False)
 class MemorySendChannel(SendChannel[SendType], metaclass=NoPublicConstructor):
+    """The send end of a memory channel, as returned by :func:`open_memory_channel`.
+
+    Use :meth:`send` to send objects and :meth:`aclose` (or ``async with``)
+    to close.  Call :meth:`clone` to create additional send endpoints that
+    share the same underlying channel.
+    """
+
     _state: MemoryChannelState[SendType]
     _closed: bool = False
     # This is just the tasks waiting on *this* object. As compared to
@@ -300,6 +320,13 @@ class MemorySendChannel(SendChannel[SendType], metaclass=NoPublicConstructor):
 @final
 @attrs.define(eq=False, repr=False, slots=False)
 class MemoryReceiveChannel(ReceiveChannel[ReceiveType], metaclass=NoPublicConstructor):
+    """The receive end of a memory channel, as returned by :func:`open_memory_channel`.
+
+    Use :meth:`receive` to receive objects and :meth:`aclose` (or ``async with``)
+    to close.  Call :meth:`clone` to create additional receive endpoints that
+    share the same underlying channel.
+    """
+
     _state: MemoryChannelState[ReceiveType]
     _closed: bool = False
     _tasks: set[trio._core._run.Task] = attrs.Factory(set)

--- a/src/trio/_highlevel_socket.py
+++ b/src/trio/_highlevel_socket.py
@@ -107,6 +107,7 @@ class SocketStream(HalfCloseableStream):
                 self.setsockopt(tsocket.IPPROTO_TCP, tsocket.TCP_NOTSENT_LOWAT, 2**14)
 
     async def send_all(self, data: bytes | bytearray | memoryview) -> None:
+        """See :meth:`trio.abc.SendStream.send_all`."""
         if self.socket.did_shutdown_SHUT_WR:
             raise trio.ClosedResourceError("can't send data after sending EOF")
         with self._send_conflict_detector:
@@ -124,6 +125,7 @@ class SocketStream(HalfCloseableStream):
                         total_sent += sent
 
     async def wait_send_all_might_not_block(self) -> None:
+        """See :meth:`trio.abc.HalfCloseableStream.wait_send_all_might_not_block`."""
         with self._send_conflict_detector:
             if self.socket.fileno() == -1:
                 raise trio.ClosedResourceError
@@ -131,6 +133,7 @@ class SocketStream(HalfCloseableStream):
                 await self.socket.wait_writable()
 
     async def send_eof(self) -> None:
+        """See :meth:`trio.abc.HalfCloseableStream.send_eof`."""
         with self._send_conflict_detector:
             await trio.lowlevel.checkpoint()
             # On macOS, calling shutdown a second time raises ENOTCONN, but
@@ -141,6 +144,7 @@ class SocketStream(HalfCloseableStream):
                 self.socket.shutdown(tsocket.SHUT_WR)
 
     async def receive_some(self, max_bytes: int | None = None) -> bytes:
+        """See :meth:`trio.abc.ReceiveStream.receive_some`."""
         if max_bytes is None:
             max_bytes = DEFAULT_RECEIVE_SIZE
         if max_bytes < 1:
@@ -149,6 +153,7 @@ class SocketStream(HalfCloseableStream):
             return await self.socket.recv(max_bytes)
 
     async def aclose(self) -> None:
+        """See :meth:`trio.abc.AsyncResource.aclose`."""
         self.socket.close()
         await trio.lowlevel.checkpoint()
 


### PR DESCRIPTION
## Summary

Contributes to #3221.

Adds docstrings to 8 items listed as missing in the issue:

| Item | File |
|------|------|
| `MemoryChannelStatistics` class | `_channel.py` |
| `MemorySendChannel` class | `_channel.py` |
| `MemoryReceiveChannel` class | `_channel.py` |
| `SocketStream.send_all` | `_highlevel_socket.py` |
| `SocketStream.wait_send_all_might_not_block` | `_highlevel_socket.py` |
| `SocketStream.send_eof` | `_highlevel_socket.py` |
| `SocketStream.receive_some` | `_highlevel_socket.py` |
| `SocketStream.aclose` | `_highlevel_socket.py` |

The `SocketStream` methods use the standard one-liner `See :meth:`...`` pattern pointing to the ABC definition (same style used by other stream implementations in trio). The channel classes get descriptive class-level docstrings.

`trio.lowlevel.ParkingLot.broken_by` and `trio._subprocess.HasFileno.fileno` are left for a follow-up as they require reading private/subprocess internals.