### PR TITLE
Add project maintainers metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ build-backend = "setuptools.build_meta"
 name = "trio"
 description = "A friendly Python library for async concurrency and I/O"
 authors = [{name = "Nathaniel J. Smith", email = "njs@pobox.com"}]
+maintainers = [{name = "Nathaniel J. Smith", email = "njs@pobox.com"}]
 license = "MIT OR Apache-2.0"
 license-files = ["LICENSE*"]
 keywords = [


### PR DESCRIPTION
Fixes #2868.

## Summary
- add the project maintainers metadata field to `pyproject.toml` using the existing public project contact

## Tests
- Python `tomllib` assertion for `project.maintainers`
- `git diff --check -- pyproject.toml`
