### PR TITLE
Upgrade all actions

### DIFF
--- a/.github/workflows/autodeps.yml
+++ b/.github/workflows/autodeps.yml
@@ -20,11 +20,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: true  # credentials are needed to push commits
       - name: Setup python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 

--- a/.github/workflows/check-newsfragment.yml
+++ b/.github/workflows/check-newsfragment.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: 'ubuntu-latest'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           python-version: 3.11
 
       - name: Grab the source from Git
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -74,7 +74,7 @@ jobs:
           SDIST: ${{ steps.artifact-name.outputs.sdist }}
           WHEEL: ${{ steps.artifact-name.outputs.wheel }}
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.dists-artifact-name }}
           # NOTE: Exact expected file names are specified here
@@ -117,7 +117,7 @@ jobs:
 
       - name: >-
           Smoke-test: grab the source from Git into git-src
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           path: git-src
           persist-credentials: false
@@ -224,7 +224,7 @@ jobs:
           LSP: '${{ matrix.lsp }}'
           LSP_EXTRACT_FILE: '${{ matrix.lsp_extract_file }}'
       - if: always()
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           name: Windows (${{ matrix.python }}, ${{ matrix.arch }}${{ matrix.extra_name }})
           # multiple flags is marked as an error in codecov UI, but is actually fine
@@ -272,7 +272,7 @@ jobs:
           workflow-artifact-name: ${{ env.dists-artifact-name }}
       - name: Grab the source from Git
         if: matrix.check_formatting == '1'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: Setup Python
@@ -304,7 +304,7 @@ jobs:
       - if: >-
           always()
           && matrix.check_formatting != '1'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           name: Ubuntu (${{ matrix.python }}${{ matrix.extra_name }})
           flags: Ubuntu,${{ matrix.python }}
@@ -347,7 +347,7 @@ jobs:
       - name: Run tests
         run: ./ci.sh
       - if: always()
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           name: macOS (${{ matrix.python }})
           flags: macOS,${{ matrix.python }}
@@ -393,7 +393,7 @@ jobs:
             f.write("\n")
 
       - if: always()
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           name: Alpine
           flags: Alpine,${{ steps.get-version.outputs.version }}
@@ -464,7 +464,7 @@ jobs:
           coverage report
 
       - if: always()
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           name: Cython
           flags: Cython,${{ steps.get-version.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,16 +11,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.10"
       - run: python -m pip install build
       - run: python -m build
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: trio-dist
           path: |
@@ -38,7 +38,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: trio-*
           path: dist


### PR DESCRIPTION
I kind of blindly just updated everything to their latest available version. We can do something better in autodeps once we have pinning enabled, but I figure this is enough for now.

(anyways, if anything fails, that's ok... we can just fix it.)