### PR TITLE
Fix Path.as_uri on Python 3.14

### DIFF
--- a/newsfragments/3460.bugfix.rst
+++ b/newsfragments/3460.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``trio.Path.as_uri()`` on Python 3.14+ to avoid the deprecated ``pathlib.PurePath.as_uri()`` path.

--- a/src/trio/_path.py
+++ b/src/trio/_path.py
@@ -263,9 +263,8 @@ class Path(pathlib.PurePath):
     if sys.version_info >= (3, 13):
         full_match = _wrap_method(pathlib.Path.full_match)
 
-    # TODO: only allow this for Python <3.19.
     def as_uri(self) -> str:
-        return pathlib.PurePath.as_uri(self)
+        return self._wrapped_cls(self).as_uri()
 
 
 if Path.relative_to.__doc__:  # pragma: no branch

--- a/src/trio/_tests/test_path.py
+++ b/src/trio/_tests/test_path.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 import pathlib
-import sys
 from typing import TYPE_CHECKING
 
 import pytest
@@ -231,9 +230,6 @@ async def test_globmethods(path: trio.Path) -> None:
     assert entries == {"_bar.txt", "bar.txt"}
 
 
-@pytest.mark.xfail(
-    sys.version_info >= (3, 14), reason="we need to update `as_uri` to use Path.as_uri"
-)
 async def test_as_uri(path: trio.Path) -> None:
     path = await path.parent.resolve()
 


### PR DESCRIPTION
## Summary

- route `trio.Path.as_uri()` through the concrete wrapped `pathlib.Path` class
- remove the Python 3.14 xfail now that the method no longer calls the deprecated `PurePath.as_uri()` path

## Tests

- `uv run pytest src/trio/_tests/test_path.py -q`
- `git diff --check`