### PR TITLE
Clarify wrap_file lifecycle docs

### DIFF
--- a/docs/source/reference-io.rst
+++ b/docs/source/reference-io.rst
@@ -690,6 +690,12 @@ Asynchronous file objects
      guaranteed to close the file before returning, even if it is
      cancelled or otherwise raises an error.
 
+     Calling ``aclose`` on an async file object also closes the
+     underlying synchronous file object. Trio does not add a
+     synchronous ``close`` method to the async wrapper, and does not
+     guarantee that the wrapped file will be closed automatically when
+     the async wrapper is garbage collected.
+
    * Using the same async file object from multiple tasks
      simultaneously: because the async methods on async file objects
      are implemented using threads, it's only safe to call two of them
@@ -701,6 +707,12 @@ Asynchronous file objects
      mode: `binary mode files are task-safe/thread-safe, text mode
      files are not
      <https://docs.python.org/3/library/io.html#multi-threading>`__.
+
+     The same caveat applies if you keep using the original
+     synchronous file object after wrapping it with
+     :func:`trio.wrap_file`: direct synchronous operations can run at
+     the same time as the wrapper's async operations, so this is only
+     safe when the wrapped object supports that kind of concurrent use.
 
    * Async file objects can be used as async iterators to iterate over
      the lines of the file:

--- a/newsfragments/3379.doc.rst
+++ b/newsfragments/3379.doc.rst
@@ -1,0 +1,1 @@
+Clarified how :func:`trio.wrap_file` async wrappers interact with the wrapped synchronous file object's close lifecycle and concurrent use.


### PR DESCRIPTION
Fixes #3379.

This clarifies the asynchronous file object notes for `trio.wrap_file()`:

- `aclose()` on the async wrapper closes the wrapped synchronous file object.
- the async wrapper does not expose a synchronous `close()` shortcut.
- Trio does not guarantee that garbage collection of the async wrapper closes the wrapped file.
- continuing to use the original synchronous file object while also using the async wrapper has the same concurrency caveat as using the async wrapper from multiple tasks.

I also added a `3379.doc.rst` newsfragment.

Validation:

- `PATH=/Volumes/STOREJET/2/Dependencies/trio/docs-venv-313/bin:$PATH /Volumes/STOREJET/2/Dependencies/trio/docs-venv-313/bin/sphinx-build -b html -D 'exclude_patterns=._*' source build/html`

Notes:

- The docs environment was installed from `docs-requirements.txt` into an external SSD venv using Python 3.13.
- A Python 3.14 docs environment failed while building the pinned `immutables==0.21` wheel, before Sphinx ran. Python 3.13 installed the pinned docs requirements cleanly.
- The `exclude_patterns=._*` override is only for this local external drive, which creates AppleDouble `._*` metadata files that Sphinx otherwise treats as source files.
