### PR TITLE
Add spawn_in_current_thread option to run_process/open_process

### DIFF
--- a/newsfragments/3360.feature.rst
+++ b/newsfragments/3360.feature.rst
@@ -1,0 +1,8 @@
+`trio.run_process` and `trio.lowlevel.open_process` now accept a
+``spawn_in_current_thread`` keyword argument. By default the child process is
+spawned from a worker thread in trio's internal thread pool, so OS-level
+per-thread state on the calling thread (network namespace, capabilities, CPU
+affinity, etc.) is not necessarily reflected in the child. Passing
+``spawn_in_current_thread=True`` spawns the child directly from the calling
+thread instead, at the cost of briefly blocking the event loop while
+``subprocess.Popen`` runs.

--- a/src/trio/_subprocess.py
+++ b/src/trio/_subprocess.py
@@ -309,6 +309,7 @@ async def _open_process(
     stdin: int | HasFileno | None = None,
     stdout: int | HasFileno | None = None,
     stderr: int | HasFileno | None = None,
+    spawn_in_current_thread: bool = False,
     **options: object,
 ) -> Process:
     r"""Execute a child program in a new process.
@@ -327,6 +328,16 @@ async def _open_process(
     Unlike `trio.run_process`, this function doesn't do any kind of automatic
     management of the child process. It's up to you to implement whatever semantics you
     want.
+
+    .. note:: By default, the child process is spawned from a worker thread
+       drawn from Trio's internal thread pool, not from the thread that calls
+       `open_process`. Most Python-level state (e.g. context variables) is
+       copied across, but OS-level per-thread state is not: things like the
+       Linux network namespace (:manpage:`setns(2)`), capabilities, and CPU
+       affinity (:manpage:`pthreads(7)`) on the worker thread can differ from
+       what you set up on the calling thread, and the child inherits the
+       worker thread's state instead. Pass ``spawn_in_current_thread=True``
+       if your child process needs to inherit this kind of state faithfully.
 
     Args:
       command: The command to run. Typically this is a sequence of strings or
@@ -351,6 +362,13 @@ async def _open_process(
           which causes the child's standard output and standard error
           messages to be intermixed on a single standard output stream,
           attached to whatever the ``stdout`` option says to attach it to.
+      spawn_in_current_thread: If true, spawn the child process directly on
+          the thread that calls `open_process`, instead of on a worker
+          thread. This makes the child inherit OS-level thread state (e.g.
+          a network namespace set with :manpage:`setns(2)`) from the calling
+          thread, at the cost of briefly blocking the calling thread (and,
+          if called from Trio's main thread, the whole event loop) while
+          `subprocess.Popen` does its work.
       **options: Other :ref:`general subprocess options <subprocess-options>`
           are also accepted.
 
@@ -414,16 +432,21 @@ async def _open_process(
             always_cleanup.callback(os.close, stderr)
             cleanup_on_fail.callback(trio_stderr.close)
 
-        popen = await trio.to_thread.run_sync(
-            partial(
-                subprocess.Popen,
-                command,
-                stdin=stdin,
-                stdout=stdout,
-                stderr=stderr,
-                **options,
-            ),
+        spawn_subprocess = partial(
+            subprocess.Popen,
+            command,
+            stdin=stdin,
+            stdout=stdout,
+            stderr=stderr,
+            **options,
         )
+        if spawn_in_current_thread:
+            # Caller accepts brief event-loop blocking in exchange for
+            # spawning in *this* thread's OS context (namespaces, caps,
+            # affinity) instead of a worker thread's.
+            popen = spawn_subprocess()
+        else:
+            popen = await trio.to_thread.run_sync(spawn_subprocess)
         # We did not fail, so dismiss the stack for the trio ends
         cleanup_on_fail.pop_all()
 
@@ -472,6 +495,7 @@ async def _run_process(
     check: bool = True,
     deliver_cancel: Callable[[Process], Awaitable[object]] | None = None,
     task_status: TaskStatus[Process] = trio.TASK_STATUS_IGNORED,
+    spawn_in_current_thread: bool = False,
     **options: object,
 ) -> subprocess.CompletedProcess[bytes]:
     """Run ``command`` in a subprocess and wait for it to complete.
@@ -567,6 +591,16 @@ async def _run_process(
 
        To get the `subprocess.run` semantics, use ``check=False, stdin=None``.
 
+    .. note:: By default, the child process is spawned from a worker thread
+       drawn from Trio's internal thread pool, not from the thread that calls
+       `run_process`. Most Python-level state (e.g. context variables) is
+       copied across, but OS-level per-thread state is not: things like the
+       Linux network namespace (:manpage:`setns(2)`), capabilities, and CPU
+       affinity (:manpage:`pthreads(7)`) on the worker thread can differ from
+       what you set up on the calling thread, and the child inherits the
+       worker thread's state instead. Pass ``spawn_in_current_thread=True``
+       if your child process needs to inherit this kind of state faithfully.
+
     Args:
       command (list or str): The command to run. Typically this is a
           sequence of strings such as ``['ls', '-l', 'directory with spaces']``,
@@ -632,6 +666,14 @@ async def _run_process(
 
           In any case, `run_process` will always wait for the child process to
           exit before raising `Cancelled`.
+
+      spawn_in_current_thread: If true, spawn the child process directly on
+          the thread that calls `run_process`, instead of on a worker
+          thread. This makes the child inherit OS-level thread state (e.g.
+          a network namespace set with :manpage:`setns(2)`) from the calling
+          thread, at the cost of briefly blocking the calling thread (and,
+          if called from Trio's main thread, the whole event loop) while
+          `subprocess.Popen` does its work.
 
       **options: :func:`run_process` also accepts any :ref:`general subprocess
           options <subprocess-options>` and passes them on to the
@@ -736,7 +778,11 @@ async def _run_process(
 
     # Opening the process does not need to be inside the nursery, so we put it outside
     # so any exceptions get directly seen by users.
-    proc = await _open_process(command, **options)  # type: ignore[arg-type]
+    proc = await _open_process(
+        command,
+        spawn_in_current_thread=spawn_in_current_thread,
+        **options,  # type: ignore[arg-type]
+    )
     async with trio.open_nursery() as nursery:
         try:
             if input_ is not None:
@@ -825,6 +871,7 @@ if TYPE_CHECKING:
             command: StrOrBytesPath | Sequence[StrOrBytesPath],
             *,
             stdin: int | HasFileno | None = None,
+            spawn_in_current_thread: bool = False,
             **kwargs: Unpack[WindowsProcessArgs],
         ) -> trio.Process:
             r"""Execute a child program in a new process.
@@ -843,6 +890,16 @@ if TYPE_CHECKING:
             Unlike `trio.run_process`, this function doesn't do any kind of automatic
             management of the child process. It's up to you to implement whatever semantics you
             want.
+
+            .. note:: By default, the child process is spawned from a worker thread
+               drawn from Trio's internal thread pool, not from the thread that calls
+               `open_process`. Most Python-level state (e.g. context variables) is
+               copied across, but OS-level per-thread state is not: things like
+               capabilities and CPU affinity (:manpage:`pthreads(7)`) on the worker
+               thread can differ from what you set up on the calling thread, and the
+               child inherits the worker thread's state instead. Pass
+               ``spawn_in_current_thread=True`` if your child process needs to
+               inherit this kind of state faithfully.
 
             Args:
               command (list or str): The command to run. Typically this is a
@@ -866,6 +923,10 @@ if TYPE_CHECKING:
                   which causes the child's standard output and standard error
                   messages to be intermixed on a single standard output stream,
                   attached to whatever the ``stdout`` option says to attach it to.
+              spawn_in_current_thread: If true, spawn the child process directly on
+                  the thread that calls `open_process`, instead of on a worker
+                  thread, at the cost of briefly blocking the calling thread while
+                  `subprocess.Popen` does its work.
               **options: Other :ref:`general subprocess options <subprocess-options>`
                   are also accepted.
 
@@ -888,6 +949,7 @@ if TYPE_CHECKING:
             capture_stderr: bool = False,
             check: bool = True,
             deliver_cancel: Callable[[Process], Awaitable[object]] | None = None,
+            spawn_in_current_thread: bool = False,
             **kwargs: Unpack[WindowsProcessArgs],
         ) -> subprocess.CompletedProcess[bytes]:
             """Run ``command`` in a subprocess and wait for it to complete.
@@ -983,6 +1045,16 @@ if TYPE_CHECKING:
 
                To get the `subprocess.run` semantics, use ``check=False, stdin=None``.
 
+            .. note:: By default, the child process is spawned from a worker thread
+               drawn from Trio's internal thread pool, not from the thread that calls
+               `run_process`. Most Python-level state (e.g. context variables) is
+               copied across, but OS-level per-thread state is not: things like
+               capabilities and CPU affinity (:manpage:`pthreads(7)`) on the worker
+               thread can differ from what you set up on the calling thread, and the
+               child inherits the worker thread's state instead. Pass
+               ``spawn_in_current_thread=True`` if your child process needs to
+               inherit this kind of state faithfully.
+
             Args:
               command (list or str): The command to run. Typically this is a
                   sequence of strings such as ``['ls', '-l', 'directory with spaces']``,
@@ -1048,6 +1120,11 @@ if TYPE_CHECKING:
 
                   In any case, `run_process` will always wait for the child process to
                   exit before raising `Cancelled`.
+
+              spawn_in_current_thread: If true, spawn the child process directly on
+                  the thread that calls `run_process`, instead of on a worker
+                  thread, at the cost of briefly blocking the calling thread while
+                  `subprocess.Popen` does its work.
 
               **options: :func:`run_process` also accepts any :ref:`general subprocess
                   options <subprocess-options>` and passes them on to the
@@ -1139,6 +1216,7 @@ if TYPE_CHECKING:
             *,
             stdin: int | HasFileno | None = None,
             shell: Literal[True],
+            spawn_in_current_thread: bool = False,
             **kwargs: Unpack[UnixProcessArgs],
         ) -> trio.Process: ...
 
@@ -1148,6 +1226,7 @@ if TYPE_CHECKING:
             *,
             stdin: int | HasFileno | None = None,
             shell: bool = False,
+            spawn_in_current_thread: bool = False,
             **kwargs: Unpack[UnixProcessArgs],
         ) -> trio.Process: ...
 
@@ -1157,6 +1236,7 @@ if TYPE_CHECKING:
             *,
             stdin: bytes | bytearray | memoryview | int | HasFileno | None = b"",
             shell: Literal[True],
+            spawn_in_current_thread: bool = False,
             **kwargs: Unpack[UnixRunProcessArgs],
         ) -> subprocess.CompletedProcess[bytes]: ...
 
@@ -1166,6 +1246,7 @@ if TYPE_CHECKING:
             *,
             stdin: bytes | bytearray | memoryview | int | HasFileno | None = b"",
             shell: bool = False,
+            spawn_in_current_thread: bool = False,
             **kwargs: Unpack[UnixRunProcessArgs],
         ) -> subprocess.CompletedProcess[bytes]: ...
 

--- a/src/trio/_tests/test_subprocess.py
+++ b/src/trio/_tests/test_subprocess.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import gc
+import json
 import os
 import random
 import signal
@@ -766,3 +767,73 @@ async def test_subprocess_pidfd_unnotified() -> None:
             # for everything to notice
             await noticed_exit.wait()
         assert noticed_exit.is_set(), "child task wasn't woken after poll, DEADLOCK"
+
+
+async def test_spawn_in_current_thread_equivalence() -> None:
+    # spawn_in_current_thread only changes which thread calls Popen();
+    # it shouldn't change anything about the resulting subprocess.
+    for in_current_thread in (False, True):
+        result = await run_process(
+            CAT,
+            stdin=b"hello",
+            capture_stdout=True,
+            spawn_in_current_thread=in_current_thread,
+        )
+        assert result.returncode == 0
+        assert result.stdout == b"hello"
+
+        proc = await open_process(
+            EXIT_TRUE,
+            spawn_in_current_thread=in_current_thread,
+        )
+        try:
+            assert await proc.wait() == 0
+        finally:
+            proc.kill()
+            await proc.wait()
+
+
+# regression test for #3360
+@pytest.mark.skipif(
+    not hasattr(os, "sched_getaffinity"),
+    reason="sched_getaffinity/sched_setaffinity are Linux-only",
+)
+async def test_spawn_in_current_thread_affinity() -> None:
+    # By default, run_process spawns the child from a worker thread out of
+    # trio's thread cache, so a child can inherit stale OS-level thread state
+    # (here, CPU affinity) from whatever thread happens to be reused, instead
+    # of from the thread that actually called run_process.
+    # spawn_in_current_thread=True should avoid that by spawning directly on
+    # the calling thread.
+    original_mask = os.sched_getaffinity(0)  # type: ignore[attr-defined,unused-ignore]
+    if len(original_mask) < 2:
+        pytest.skip("need at least 2 available CPUs to exercise this")
+
+    # warm up trio's worker thread cache while affinity is unrestricted, so
+    # there's a cached worker thread whose affinity doesn't match what we're
+    # about to set below
+    await run_process(EXIT_TRUE)
+
+    restricted_mask = {next(iter(original_mask))}
+    os.sched_setaffinity(0, restricted_mask)  # type: ignore[attr-defined,unused-ignore]
+    try:
+        check_affinity = python(
+            "import json, os; print(json.dumps(sorted(os.sched_getaffinity(0))))",
+        )
+
+        default_result = await run_process(check_affinity, capture_stdout=True)
+        default_mask = set(json.loads(default_result.stdout))
+
+        current_thread_result = await run_process(
+            check_affinity,
+            capture_stdout=True,
+            spawn_in_current_thread=True,
+        )
+        current_thread_mask = set(json.loads(current_thread_result.stdout))
+    finally:
+        os.sched_setaffinity(0, original_mask)  # type: ignore[attr-defined,unused-ignore]
+
+    # the cached worker thread still has the old, unrestricted affinity
+    assert default_mask != restricted_mask
+    # but spawning from the calling thread picks up the restriction
+    assert current_thread_mask == restricted_mask

--- a/src/trio/_tests/type_tests/subprocesses.py
+++ b/src/trio/_tests/type_tests/subprocesses.py
@@ -21,3 +21,7 @@ async def test() -> None:
         # 3.11+:
         await trio.run_process("python", process_group=5)  # type: ignore
         await trio.lowlevel.open_process("python", process_group=5)  # type: ignore
+
+    # spawn_in_current_thread is accepted on every platform/overload shape
+    await trio.run_process("python", spawn_in_current_thread=True)
+    await trio.lowlevel.open_process("python", spawn_in_current_thread=True)


### PR DESCRIPTION
Fixes #3360

## Root cause

`run_process`/`open_process` call `subprocess.Popen()` via
`trio.to_thread.run_sync`. Trio's `to_thread.run_sync` doesn't spin up
a fresh OS thread per call — it pulls an existing worker thread out of
`THREAD_CACHE` (`src/trio/_core/_thread_cache.py`) if one is idle, and
only falls back to creating a new one if the cache is empty
(`ThreadCache.start_thread_soon`, which does `self._idle_workers.popitem()`
before deciding to spawn). That cache is what makes `to_thread.run_sync`
cheap to call repeatedly, but it also means the thread that ends up
calling `Popen()` for any given `run_process` call is whatever thread
happened to finish its previous job and get parked in the cache. It is
not the thread that called `run_process`, and it's not a fresh thread
either.

Python-level state (contextvars, etc.) gets propagated to that worker
thread correctly, which is why this is easy to miss. But OS-level
per-thread state is a kernel-level property of the specific thread,
not something Python copies around: `setns(2)` to move a thread into a
different Linux network namespace, thread-directed capabilities, and
CPU affinity (`pthreads(7)`) all stick to whichever OS thread you set
them on. If you set one of those up on your own thread and then call
`run_process`, the child is actually forked from a leftover cached
worker thread that never had your namespace/capabilities/affinity
applied to it in the first place, so it silently inherits whatever
that worker thread's state happens to be instead. That's exactly the
network namespace problem the issue reporter (tik-stbuehler) ran into.

The issue thread also discusses spawning a dedicated thread per call
with `clone(2)` so it can inherit the caller's namespace, but
tik-stbuehler pushed back on that in the comments since it throws away
the whole point of having a thread cache (or requires a per-trio-loop
thread-local pool, which is a much bigger structural change and was
posted as a workaround, not a proposed fix). The issue itself asks for
two more modest things instead: document the behavior, and add a flag
to spawn from the current thread. This PR does both.

## Fix

Added `spawn_in_current_thread: bool = False` to both `run_process`
and `open_process`. When `True`, `Popen()` is called synchronously on
the calling thread instead of being handed off to
`trio.to_thread.run_sync`, so the child reliably gets the calling
thread's OS-level state because it really is forked from that thread.
This obviously blocks the calling thread (and the event loop, if
called from Trio's main task) for as long as `Popen()` takes, which is
normally fast but is still a real synchronous blocking call, so it's
opt-in and the default behavior/performance is completely unchanged.

Also added the `.. note::` docs paragraph the issue asked for on both
`run_process` and `open_process` (and on the `TYPE_CHECKING` stubs
used for Windows / the Unix overloads, so docs stay consistent across
the type-stub split this module already has).

## Testing

The namespace scenario from the issue needs root/`CAP_SYS_ADMIN` and
real network namespace setup, which isn't practical to run in CI. CPU
affinity is gated by the exact same bug mechanism (it's also per-thread
OS state that doesn't follow a thread cache hand-off) but is settable
by an unprivileged process via `os.sched_setaffinity`, so I used that
as a stand-in to get an actual reproduction instead of just testing
that the option exists:

- `test_spawn_in_current_thread_affinity` (Linux-only, skipped on
  macOS/Windows since `sched_getaffinity`/`sched_setaffinity` aren't
  available there): runs one `run_process` call first to warm up
  `THREAD_CACHE` with a worker thread while affinity is unrestricted,
  then restricts the *calling* thread's affinity to a single CPU and
  checks that a child spawned the default way still reports the old,
  unrestricted mask (because it came from the stale cached worker
  thread), while a child spawned with `spawn_in_current_thread=True`
  reports the restricted mask. This fails without the fix and passes
  with it.
- `test_spawn_in_current_thread_equivalence`: cross-platform sanity
  check that `run_process`/`open_process` behave the same with the
  flag on vs. off (stdin/stdout/return code), since the flag should
  only change which thread calls `Popen()`, nothing about the
  resulting process.
- Added the matching `Unpack[...]` kwarg to the Windows/Unix
  `TYPE_CHECKING` overloads and a `type_tests/subprocesses.py` entry so
  the new kwarg type-checks on every overload shape.
- Added `newsfragments/3360.feature.rst`.

Ran the project's full check suite locally before opening this:
`pytest src` (825 passed, 71 skipped, 2 xfailed — all pre-existing,
unrelated to this change), `mypy --platform linux/darwin/win32`,
`pyright` on both `type_tests` dirs, `check_type_completeness.py`,
`gen_exports.py --test`, and `pre-commit run --all-files`. All green.