### PR TITLE
Add docstrings for memory channel classes

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -173,9 +173,6 @@ def autodoc_process_signature(
 # currently undocumented things
 logger = getLogger("trio")
 UNDOCUMENTED = {
-    "trio.MemorySendChannel",
-    "trio.MemoryReceiveChannel",
-    "trio.MemoryChannelStatistics",
     "trio._subprocess.HasFileno.fileno",
     "trio.lowlevel.ParkingLot.broken_by",
 }

--- a/src/trio/_channel.py
+++ b/src/trio/_channel.py
@@ -119,31 +119,28 @@ class open_memory_channel(tuple["MemorySendChannel[T]", "MemoryReceiveChannel[T]
 @attrs.frozen
 class MemoryChannelStatistics:
     """Statistics describing the current state of a memory channel.
+
     Returned by :meth:`MemorySendChannel.statistics` and
     :meth:`MemoryReceiveChannel.statistics`.
-
-    Currently, the following fields are defined:
-
-    * ``current_buffer_used`` (int): The number of items currently stored
-      in the channel buffer.
-    * ``max_buffer_size`` (int or math.inf): The maximum number of items
-      that can be buffered in the channel.
-    * ``open_send_channels`` (int): The number of open
-      :class:`MemorySendChannel` endpoints pointing to this channel.
-    * ``open_receive_channels`` (int): The number of open
-      :class:`MemoryReceiveChannel` endpoints pointing to this channel.
-    * ``tasks_waiting_send`` (int): The number of tasks currently blocked
-      waiting to send.
-    * ``tasks_waiting_receive`` (int): The number of tasks currently blocked
-      waiting to receive.
     """
 
     current_buffer_used: int
+    """The number of items currently stored in the channel buffer."""
+
     max_buffer_size: int | float
+    """The maximum number of items that can be buffered in the channel."""
+
     open_send_channels: int
+    """The number of open :class:`MemorySendChannel` endpoints pointing to this channel."""
+
     open_receive_channels: int
+    """The number of open :class:`MemoryReceiveChannel` endpoints pointing to this channel."""
+
     tasks_waiting_send: int
+    """The number of tasks currently blocked waiting to send."""
+
     tasks_waiting_receive: int
+    """The number of tasks currently blocked waiting to receive."""
 
 
 @attrs.define
@@ -327,10 +324,12 @@ class MemorySendChannel(SendChannel[SendType], metaclass=NoPublicConstructor):
 @final
 @attrs.define(eq=False, repr=False, slots=False)
 class MemoryReceiveChannel(ReceiveChannel[ReceiveType], metaclass=NoPublicConstructor):
-    """A memory channel endpoint for receiving Python objects.
+    """
+    A memory channel endpoint for receiving Python objects.
 
     Instances of this class are created by
-    :func:`open_memory_channel` and cannot be instantiated directly."""
+    :func:`open_memory_channel` and cannot be instantiated directly.
+    """
 
     _state: MemoryChannelState[ReceiveType]
     _closed: bool = False

--- a/src/trio/_channel.py
+++ b/src/trio/_channel.py
@@ -118,6 +118,8 @@ class open_memory_channel(tuple["MemorySendChannel[T]", "MemoryReceiveChannel[T]
 
 @attrs.frozen
 class MemoryChannelStatistics:
+    """Statistics for a memory channel."""
+
     current_buffer_used: int
     max_buffer_size: int | float
     open_send_channels: int
@@ -152,6 +154,8 @@ class MemoryChannelState(Generic[T]):
 @final
 @attrs.define(eq=False, repr=False, slots=False)
 class MemorySendChannel(SendChannel[SendType], metaclass=NoPublicConstructor):
+    """A memory channel endpoint for sending Python objects."""
+
     _state: MemoryChannelState[SendType]
     _closed: bool = False
     # This is just the tasks waiting on *this* object. As compared to
@@ -300,6 +304,8 @@ class MemorySendChannel(SendChannel[SendType], metaclass=NoPublicConstructor):
 @final
 @attrs.define(eq=False, repr=False, slots=False)
 class MemoryReceiveChannel(ReceiveChannel[ReceiveType], metaclass=NoPublicConstructor):
+    """A memory channel endpoint for receiving Python objects."""
+
     _state: MemoryChannelState[ReceiveType]
     _closed: bool = False
     _tasks: set[trio._core._run.Task] = attrs.Factory(set)

--- a/src/trio/_channel.py
+++ b/src/trio/_channel.py
@@ -169,8 +169,7 @@ class MemoryChannelState(Generic[T]):
 @final
 @attrs.define(eq=False, repr=False, slots=False)
 class MemorySendChannel(SendChannel[SendType], metaclass=NoPublicConstructor):
-    """
-    A memory channel endpoint for sending Python objects.
+    """A memory channel endpoint for sending Python objects.
 
     Instances of this class are created by
     :func:`open_memory_channel` and cannot be instantiated directly.

--- a/src/trio/_channel.py
+++ b/src/trio/_channel.py
@@ -118,7 +118,25 @@ class open_memory_channel(tuple["MemorySendChannel[T]", "MemoryReceiveChannel[T]
 
 @attrs.frozen
 class MemoryChannelStatistics:
-    """Statistics for a memory channel."""
+    """Statistics describing the current state of a memory channel.
+    Returned by :meth:`MemorySendChannel.statistics` and
+    :meth:`MemoryReceiveChannel.statistics`.
+
+    Currently, the following fields are defined:
+
+    * ``current_buffer_used`` (int): The number of items currently stored
+      in the channel buffer.
+    * ``max_buffer_size`` (int or math.inf): The maximum number of items
+      that can be buffered in the channel.
+    * ``open_send_channels`` (int): The number of open
+      :class:`MemorySendChannel` endpoints pointing to this channel.
+    * ``open_receive_channels`` (int): The number of open
+      :class:`MemoryReceiveChannel` endpoints pointing to this channel.
+    * ``tasks_waiting_send`` (int): The number of tasks currently blocked
+      waiting to send.
+    * ``tasks_waiting_receive`` (int): The number of tasks currently blocked
+      waiting to receive.
+    """
 
     current_buffer_used: int
     max_buffer_size: int | float
@@ -154,7 +172,12 @@ class MemoryChannelState(Generic[T]):
 @final
 @attrs.define(eq=False, repr=False, slots=False)
 class MemorySendChannel(SendChannel[SendType], metaclass=NoPublicConstructor):
-    """A memory channel endpoint for sending Python objects."""
+    """
+    A memory channel endpoint for sending Python objects.
+
+    Instances of this class are created by
+    :func:`open_memory_channel` and cannot be instantiated directly.
+    """
 
     _state: MemoryChannelState[SendType]
     _closed: bool = False
@@ -304,7 +327,10 @@ class MemorySendChannel(SendChannel[SendType], metaclass=NoPublicConstructor):
 @final
 @attrs.define(eq=False, repr=False, slots=False)
 class MemoryReceiveChannel(ReceiveChannel[ReceiveType], metaclass=NoPublicConstructor):
-    """A memory channel endpoint for receiving Python objects."""
+    """A memory channel endpoint for receiving Python objects.
+
+    Instances of this class are created by
+    :func:`open_memory_channel` and cannot be instantiated directly."""
 
     _state: MemoryChannelState[ReceiveType]
     _closed: bool = False

--- a/src/trio/_channel.py
+++ b/src/trio/_channel.py
@@ -324,8 +324,7 @@ class MemorySendChannel(SendChannel[SendType], metaclass=NoPublicConstructor):
 @final
 @attrs.define(eq=False, repr=False, slots=False)
 class MemoryReceiveChannel(ReceiveChannel[ReceiveType], metaclass=NoPublicConstructor):
-    """
-    A memory channel endpoint for receiving Python objects.
+    """A memory channel endpoint for receiving Python objects.
 
     Instances of this class are created by
     :func:`open_memory_channel` and cannot be instantiated directly.

--- a/src/trio/_tests/_check_type_completeness.json
+++ b/src/trio/_tests/_check_type_completeness.json
@@ -18,12 +18,6 @@
     ],
     "Windows": [],
     "all": [
-        "No docstring found for class \"trio.MemoryReceiveChannel\"",
-        "No docstring found for class \"trio._channel.MemoryReceiveChannel\"",
-        "No docstring found for class \"trio.MemoryChannelStatistics\"",
-        "No docstring found for class \"trio._channel.MemoryChannelStatistics\"",
-        "No docstring found for class \"trio.MemorySendChannel\"",
-        "No docstring found for class \"trio._channel.MemorySendChannel\"",
         "No docstring found for class \"trio._core._run.Task\"",
         "No docstring found for class \"trio._socket.SocketType\"",
         "No docstring found for function \"trio._highlevel_socket.SocketStream.send_all\"",


### PR DESCRIPTION
## Summary

Add class docstrings for:

- MemorySendChannel
- MemoryReceiveChannel
- MemoryChannelStatistics

This improves the generated API documentation for these classes.