### PR TITLE
Update ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.21
+    rev: v0.15.22
     hooks:
       - id: ruff-check
         types: [file]
@@ -56,7 +56,7 @@ repos:
         language: python
         entry: python src/trio/_tools/gen_exports.py
         pass_filenames: false
-        additional_dependencies: ["astor", "attrs", "black", "ruff"]
+        additional_dependencies: ["astor", "attrs", "black", "ruff>=0.15.22"]
         files: ^src\/trio\/_core\/(_run|(_i(o_(common|epoll|kqueue|windows)|nstrumentation)))\.py$
       - id: regenerate-windows-cffi
         name: regenerate windows CFFI

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
         types_or: [python, pyi, toml]
         args: ["--show-fixes"]
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.2
+    rev: v2.4.3
     hooks:
       - id: codespell
         additional_dependencies:
@@ -46,7 +46,7 @@ repos:
     hooks:
       - id: sphinx-lint
   - repo: https://github.com/woodruffw/zizmor-pre-commit
-    rev: v1.26.1
+    rev: v1.28.0
     hooks:
       - id: zizmor
   - repo: local
@@ -73,7 +73,7 @@ repos:
         additional_dependencies: ["pyyaml"]
         files: ^(test-requirements\.txt)|(\.pre-commit-config\.yaml)$
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.11.28
+    rev: 0.11.31
     hooks:
       # Compile requirements
       - id: pip-compile

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,31 +146,32 @@ select = [
     "YTT",   # flake8-2020
 ]
 extend-ignore = [
-    "A002",    # builtin-argument-shadowing
-    "ANN401",  # any-type (mypy's `disallow_any_explicit` is better)
-    "E402",    # module-import-not-at-top-of-file (usually OS-specific)
-    "E501",    # line-too-long
-    "F403",    # undefined-local-with-import-star
-    "F405",    # undefined-local-with-import-star-usage
-    "PERF203", # try-except-in-loop (not always possible to refactor)
-    "PT012",   # multiple statements in pytest.raises block
-    "SIM117",  # multiple-with-statements (messes up lots of context-based stuff and looks bad)
-    "RUF067",  # non-empty-init-module, since we need lots of logic in our __init__
+    "builtin-argument-shadowing",    # builtin-argument-shadowing
+    "any-type",  # any-type (mypy's `disallow_any_explicit` is better)
+    "module-import-not-at-top-of-file",    # module-import-not-at-top-of-file (usually OS-specific)
+    "line-too-long",    # line-too-long
+    "undefined-local-with-import-star",    # undefined-local-with-import-star
+    "undefined-local-with-import-star-usage",    # undefined-local-with-import-star-usage
+    "try-except-in-loop", # try-except-in-loop (not always possible to refactor)
+    "pytest-raises-with-multiple-statements",   # multiple statements in pytest.raises block
+    "multiple-with-statements",  # multiple-with-statements (messes up lots of context-based stuff and looks bad)
+    "non-empty-init-module",  # non-empty-init-module, since we need lots of logic in our __init__
+    "noqa-comments",  # replaces noqa with ruff:ignore, which is ugly and doesn't have support in black
 
     # conflicts with formatter (ruff recommends these be disabled)
-    "COM812",
+    "missing-trailing-comma",
 ]
 
 [tool.ruff.lint.per-file-ignores]
 # F401 is ignoring unused imports. For these particular files,
 # these are public APIs where we are importing everything we want
 # to export for public use.
-'src/trio/__init__.py' = ['F401']
-'src/trio/_core/__init__.py' = ['F401']
-'src/trio/abc.py' = ['F401', 'A005']
-'src/trio/lowlevel.py' = ['F401']
-'src/trio/socket.py' = ['F401', 'A005']
-'src/trio/testing/__init__.py' = ['F401']
+'src/trio/__init__.py' = ['unused-import']
+'src/trio/_core/__init__.py' = ['unused-import']
+'src/trio/abc.py' = ['unused-import', 'stdlib-module-shadowing']
+'src/trio/lowlevel.py' = ['unused-import']
+'src/trio/socket.py' = ['unused-import', 'stdlib-module-shadowing']
+'src/trio/testing/__init__.py' = ['unused-import']
 
 # RUF029 is ignoring tests that are marked as async functions but
 # do not use an await in their function bodies. There are several
@@ -179,12 +180,12 @@ extend-ignore = [
 #
 # RUF069 is ignoring exact float comparison, because we use that
 # in combination with autojump clocks
-'src/trio/_tests/*.py' = ['RUF029', 'RUF069']
-'src/trio/_core/_tests/*.py' = ['RUF029', 'RUF069']
+'src/trio/_tests/*.py' = ['unused-async', 'float-equality-comparison']
+'src/trio/_core/_tests/*.py' = ['unused-async', 'float-equality-comparison']
 # A005 is ignoring modules that shadow stdlib modules.
-'src/trio/_abc.py' = ['A005']
-'src/trio/_socket.py' = ['A005']
-'src/trio/_ssl.py' = ['A005']
+'src/trio/_abc.py' = ['stdlib-module-shadowing']
+'src/trio/_socket.py' = ['stdlib-module-shadowing']
+'src/trio/_ssl.py' = ['stdlib-module-shadowing']
 
 [tool.ruff.lint.isort]
 combine-as-imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,26 +146,26 @@ select = [
     "YTT",   # flake8-2020
 ]
 extend-ignore = [
-    "builtin-argument-shadowing",    # builtin-argument-shadowing
-    "any-type",  # any-type (mypy's `disallow_any_explicit` is better)
-    "module-import-not-at-top-of-file",    # module-import-not-at-top-of-file (usually OS-specific)
-    "line-too-long",    # line-too-long
-    "undefined-local-with-import-star",    # undefined-local-with-import-star
-    "undefined-local-with-import-star-usage",    # undefined-local-with-import-star-usage
-    "try-except-in-loop", # try-except-in-loop (not always possible to refactor)
-    "pytest-raises-with-multiple-statements",   # multiple statements in pytest.raises block
-    "multiple-with-statements",  # multiple-with-statements (messes up lots of context-based stuff and looks bad)
-    "non-empty-init-module",  # non-empty-init-module, since we need lots of logic in our __init__
-    "noqa-comments",  # replaces noqa with ruff:ignore, which is ugly and doesn't have support in black
+    "builtin-argument-shadowing",  # A002
+    "any-type",  # ANN401 (mypy's `disallow_any_explicit` is better)
+    "module-import-not-at-top-of-file",  # E402(usually OS-specific)
+    "line-too-long",  # E501
+    "undefined-local-with-import-star",  # F403
+    "undefined-local-with-import-star-usage",  # F405
+    "try-except-in-loop",  # PERF203(not always possible to refactor)
+    "pytest-raises-with-multiple-statements",  # PT012 multiple statements in pytest.raises block
+    "multiple-with-statements",  # SIM117 (messes up lots of context-based stuff and looks bad)
+    "non-empty-init-module",  # RUF067 we need lots of logic in our __init__
+    "noqa-comments",  # RUF105 replaces noqa with ruff:ignore, which is ugly and doesn't have support in black
 
     # conflicts with formatter (ruff recommends these be disabled)
-    "missing-trailing-comma",
+    "missing-trailing-comma",  # COM812
 ]
 
 [tool.ruff.lint.per-file-ignores]
-# F401 is ignoring unused imports. For these particular files,
-# these are public APIs where we are importing everything we want
-# to export for public use.
+# Ignoring unused imports (F401) for these particular files, these are
+# public APIs where we are importing everything we want to export for
+# public use. stdlib module shadowing is A005.
 'src/trio/__init__.py' = ['unused-import']
 'src/trio/_core/__init__.py' = ['unused-import']
 'src/trio/abc.py' = ['unused-import', 'stdlib-module-shadowing']
@@ -173,13 +173,13 @@ extend-ignore = [
 'src/trio/socket.py' = ['unused-import', 'stdlib-module-shadowing']
 'src/trio/testing/__init__.py' = ['unused-import']
 
-# RUF029 is ignoring tests that are marked as async functions but
-# do not use an await in their function bodies. There are several
-# places where internal trio synchronous code relies on being
-# called from an async function, where current task is set up.
+# Ignoring tests that are marked as async functions (RUF029) but do not
+# use an await in their function bodies. There are several places where
+# internal trio synchronous code relies on being called from an async
+# function, where current task is set up.
 #
-# RUF069 is ignoring exact float comparison, because we use that
-# in combination with autojump clocks
+# Ignoring exact float comparison (RUF029), because we use that in
+# combination with autojump clocks
 'src/trio/_tests/*.py' = ['unused-async', 'float-equality-comparison']
 'src/trio/_core/_tests/*.py' = ['unused-async', 'float-equality-comparison']
 # A005 is ignoring modules that shadow stdlib modules.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,20 +146,20 @@ select = [
     "YTT",   # flake8-2020
 ]
 extend-ignore = [
-    "builtin-argument-shadowing",  # A002
-    "any-type",  # ANN401 (mypy's `disallow_any_explicit` is better)
-    "module-import-not-at-top-of-file",  # E402(usually OS-specific)
-    "line-too-long",  # E501
-    "undefined-local-with-import-star",  # F403
-    "undefined-local-with-import-star-usage",  # F405
-    "try-except-in-loop",  # PERF203(not always possible to refactor)
-    "pytest-raises-with-multiple-statements",  # PT012 multiple statements in pytest.raises block
-    "multiple-with-statements",  # SIM117 (messes up lots of context-based stuff and looks bad)
-    "non-empty-init-module",  # RUF067 we need lots of logic in our __init__
-    "noqa-comments",  # RUF105 replaces noqa with ruff:ignore, which is ugly and doesn't have support in black
+    "builtin-argument-shadowing",             # A002
+    "any-type",                               # ANN401 (mypy's `disallow_any_explicit` is better)
+    "module-import-not-at-top-of-file",       # E402(usually OS-specific)
+    "line-too-long",                          # E501
+    "undefined-local-with-import-star",       # F403
+    "undefined-local-with-import-star-usage", # F405
+    "try-except-in-loop",                     # PERF203(not always possible to refactor)
+    "pytest-raises-with-multiple-statements", # PT012 multiple statements in pytest.raises block
+    "multiple-with-statements",               # SIM117 (messes up lots of context-based stuff and looks bad)
+    "non-empty-init-module",                  # RUF067 we need lots of logic in our __init__
+    "noqa-comments",                          # RUF105 replaces noqa with ruff:ignore, which is ugly and doesn't have support in black
 
     # conflicts with formatter (ruff recommends these be disabled)
-    "missing-trailing-comma",  # COM812
+    "missing-trailing-comma",                 # COM812
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -30,7 +30,7 @@ charset-normalizer==3.4.7
     # via requests
 click==8.4.2 ; implementation_name == 'cpython'
     # via black
-codespell==2.4.2
+codespell==2.4.3
     # via -r test-requirements.in
 colorama==0.4.6 ; sys_platform == 'win32'
     # via
@@ -205,7 +205,7 @@ typing-extensions==4.15.0
     #   virtualenv
 urllib3==2.7.0
     # via requests
-uv==0.11.28
+uv==0.11.31
     # via -r test-requirements.in
 virtualenv==21.5.1
     # via pre-commit

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -143,7 +143,7 @@ requests==2.34.2
     # via sphinx
 roman-numerals==4.1.0 ; python_full_version >= '3.11'
     # via sphinx
-ruff==0.15.21
+ruff==0.15.22
     # via -r test-requirements.in
 sniffio==1.3.1
     # via -r test-requirements.in


### PR DESCRIPTION
RUF105 in particular was being bad, because it would change our `noqa` to `ruff:ignore`, which then `black` looks at and reformats, which ruff would see being on the wrong line and remove + apply fixes arbitrarily around the codebase. Basically a giant mess.

I've disabled it. I wish we could get the nice human readable names (RUF106) without using `ruff:ignore`, but that doesn't seem possible.