### PR TITLE
Add docstrings for HasFileno.fileno and ParkingLot.broken_by

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -170,12 +170,8 @@ def autodoc_process_signature(
     return signature, return_annotation
 
 
-# currently undocumented things
 logger = getLogger("trio")
-UNDOCUMENTED = {
-    "trio._subprocess.HasFileno.fileno",
-    "trio.lowlevel.ParkingLot.broken_by",
-}
+UNDOCUMENTED: set[str] = set()
 
 
 def autodoc_process_docstring(
@@ -187,7 +183,6 @@ def autodoc_process_docstring(
     lines: list[str],
 ) -> None:
     if not lines:
-        # TODO: document these and remove them from here
         if name in UNDOCUMENTED:
             return
 

--- a/src/trio/_core/_parking_lot.py
+++ b/src/trio/_core/_parking_lot.py
@@ -151,7 +151,16 @@ class ParkingLot:
     # {task: None}, we just want a deque where we can quickly delete random
     # items
     _parked: OrderedDict[Task, None] = attrs.field(factory=OrderedDict, init=False)
-    broken_by: list[Task] = attrs.field(factory=list, init=False)
+    _broken_by: list[Task] = attrs.field(factory=list, init=False)
+
+    @property
+    def broken_by(self) -> list[Task]:
+        """Tasks that have broken this parking lot, in break order."""
+        return self._broken_by
+
+    @broken_by.setter
+    def broken_by(self, new_broken_by: list[Task]) -> None:
+        self._broken_by = new_broken_by
 
     def __len__(self) -> int:
         """Returns the number of parked tasks."""

--- a/src/trio/_subprocess.py
+++ b/src/trio/_subprocess.py
@@ -98,7 +98,9 @@ else:
 class HasFileno(Protocol):
     """Represents any file-like object that has a file descriptor."""
 
-    def fileno(self) -> int: ...
+    def fileno(self) -> int:
+        """Return the underlying file descriptor."""
+        ...
 
 
 @final

--- a/src/trio/_tests/_check_type_completeness.json
+++ b/src/trio/_tests/_check_type_completeness.json
@@ -25,7 +25,6 @@
         "No docstring found for function \"trio._highlevel_socket.SocketStream.send_eof\"",
         "No docstring found for function \"trio._highlevel_socket.SocketStream.receive_some\"",
         "No docstring found for function \"trio._highlevel_socket.SocketStream.aclose\"",
-        "No docstring found for function \"trio._subprocess.HasFileno.fileno\"",
         "No docstring found for class \"trio._sync.AsyncContextManagerMixin\"",
         "No docstring found for function \"trio._sync._HasAcquireRelease.acquire\"",
         "No docstring found for function \"trio._sync._HasAcquireRelease.release\"",


### PR DESCRIPTION
Fixes #3221

## Summary

- add a docstring to `HasFileno.fileno`
- expose `ParkingLot.broken_by` through a documented property backed by `_broken_by`
- remove both names from the undocumented/type-completeness allowlists

## Testing

- `source .venv313/bin/activate && ruff check src/trio/_subprocess.py src/trio/_core/_parking_lot.py docs/source/conf.py`
- `source .venv313/bin/activate && pytest src/trio/_core/_tests/test_parking_lot.py src/trio/_tests/test_subprocess.py -q`
- `source .venv313/bin/activate && python - <<"PY"` targeted `pyright --verifytypes` diagnostics for `trio._subprocess.HasFileno.fileno` and `trio._core._parking_lot.ParkingLot.broken_by`
- `source .venv313/bin/activate && sphinx-build -b dummy -W docs/source /private/tmp/trio-docs-dummy`
