### PR TITLE
Skip SSL tests on Windows x86

### DIFF
--- a/src/trio/_tests/test_dtls.py
+++ b/src/trio/_tests/test_dtls.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import random
+import struct
+import sys
 from contextlib import asynccontextmanager
 from itertools import count
 from typing import TYPE_CHECKING, NoReturn
@@ -23,6 +25,11 @@ from trio import DTLSChannel, DTLSEndpoint
 from trio.testing._fake_net import FakeNet, UDPPacket
 
 from .._core._tests.tutil import binds_ipv6, gc_collect_harder, slow
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32" and struct.calcsize("P") == 4,
+    reason="SSL tests are not supported on 32-bit Windows",
+)
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator

--- a/src/trio/_tests/test_highlevel_ssl_helpers.py
+++ b/src/trio/_tests/test_highlevel_ssl_helpers.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import struct
+import sys
 from functools import partial
 from typing import TYPE_CHECKING, NoReturn, cast
 
@@ -17,6 +19,11 @@ from .._highlevel_ssl_helpers import (
 
 # using noqa because linters don't understand how pytest fixtures work.
 from .test_ssl import SERVER_CTX, client_ctx  # noqa: F401
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32" and struct.calcsize("P") == 4,
+    reason="SSL tests are not supported on 32-bit Windows",
+)
 
 if TYPE_CHECKING:
     from socket import AddressFamily, SocketKind

--- a/src/trio/_tests/test_ssl.py
+++ b/src/trio/_tests/test_ssl.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import socket as stdlib_socket
 import ssl
+import struct
 import sys
 import threading
 from contextlib import asynccontextmanager, contextmanager, suppress
@@ -40,6 +41,11 @@ from ..testing import (
     check_two_way_stream,
     lockstep_stream_pair,
     memory_stream_pair,
+)
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32" and struct.calcsize("P") == 4,
+    reason="SSL tests are not supported on 32-bit Windows",
 )
 
 if TYPE_CHECKING:


### PR DESCRIPTION
Fixes #3466

## Summary

- skip the SSL, DTLS, and high-level SSL helper test modules on Windows x86
- keep the rest of the Windows x86 CI job coverage intact
- make the skip decision in pytest instead of adding more ci.sh branching

## Testing

- source .venv313/bin/activate && ruff check src/trio/_tests/test_ssl.py src/trio/_tests/test_dtls.py src/trio/_tests/test_highlevel_ssl_helpers.py
- source .venv313/bin/activate && PYTHONPATH=src pytest src/trio/_tests/test_ssl.py src/trio/_tests/test_dtls.py src/trio/_tests/test_highlevel_ssl_helpers.py -q
- source .venv313/bin/activate && PRE_COMMIT_HOME=/private/tmp/pre-commit-trio pre-commit run --files src/trio/_tests/test_ssl.py src/trio/_tests/test_dtls.py src/trio/_tests/test_highlevel_ssl_helpers.py
