### PR TITLE
Clarify run_process Ctrl+C documentation

### DIFF
--- a/src/trio/_subprocess.py
+++ b/src/trio/_subprocess.py
@@ -663,10 +663,12 @@ async def _run_process(
           which is deprecated, then single exceptions will be collapsed.
 
     .. note:: The child process runs in the same process group as the parent
-       Trio process, so a Ctrl+C will be delivered simultaneously to both
-       parent and child. If you don't want this behavior, consult your
-       platform's documentation for starting child processes in a different
-       process group.
+       Trio process, so a Ctrl+C will normally be delivered to both parent
+       and child.
+
+       Python's ``subprocess`` API provides platform-specific options such as
+       ``process_group`` and ``start_new_session`` to control how child
+       processes are started.
 
     """
 


### PR DESCRIPTION
## Summary

Clarify the `run_process` documentation around Ctrl+C behavior.

The note now explains that child processes normally receive Ctrl+C along with the parent process. It also points readers to Python's `process_group` and `start_new_session` options for cases where different behavior is needed.

Closes #3300
