### PR TITLE
Add SocketStream method docstrings

### DIFF
--- a/newsfragments/3221.doc.rst
+++ b/newsfragments/3221.doc.rst
@@ -1,0 +1,1 @@
+Add docstrings for ``SocketStream`` methods in the generated API documentation.

--- a/src/trio/_highlevel_socket.py
+++ b/src/trio/_highlevel_socket.py
@@ -107,6 +107,10 @@ class SocketStream(HalfCloseableStream):
                 self.setsockopt(tsocket.IPPROTO_TCP, tsocket.TCP_NOTSENT_LOWAT, 2**14)
 
     async def send_all(self, data: bytes | bytearray | memoryview) -> None:
+        """Send all of the given data on this socket stream.
+
+        See :meth:`trio.abc.SendStream.send_all`.
+        """
         if self.socket.did_shutdown_SHUT_WR:
             raise trio.ClosedResourceError("can't send data after sending EOF")
         with self._send_conflict_detector:
@@ -124,6 +128,10 @@ class SocketStream(HalfCloseableStream):
                         total_sent += sent
 
     async def wait_send_all_might_not_block(self) -> None:
+        """Wait until :meth:`send_all` might not block.
+
+        See :meth:`trio.abc.SendStream.wait_send_all_might_not_block`.
+        """
         with self._send_conflict_detector:
             if self.socket.fileno() == -1:
                 raise trio.ClosedResourceError
@@ -131,6 +139,10 @@ class SocketStream(HalfCloseableStream):
                 await self.socket.wait_writable()
 
     async def send_eof(self) -> None:
+        """Send an end-of-file indication without closing the receive side.
+
+        See :meth:`trio.abc.HalfCloseableStream.send_eof`.
+        """
         with self._send_conflict_detector:
             await trio.lowlevel.checkpoint()
             # On macOS, calling shutdown a second time raises ENOTCONN, but
@@ -141,6 +153,10 @@ class SocketStream(HalfCloseableStream):
                 self.socket.shutdown(tsocket.SHUT_WR)
 
     async def receive_some(self, max_bytes: int | None = None) -> bytes:
+        """Receive up to ``max_bytes`` bytes from this socket stream.
+
+        See :meth:`trio.abc.ReceiveStream.receive_some`.
+        """
         if max_bytes is None:
             max_bytes = DEFAULT_RECEIVE_SIZE
         if max_bytes < 1:
@@ -149,6 +165,7 @@ class SocketStream(HalfCloseableStream):
             return await self.socket.recv(max_bytes)
 
     async def aclose(self) -> None:
+        """Close this socket stream asynchronously."""
         self.socket.close()
         await trio.lowlevel.checkpoint()
 

--- a/src/trio/_tests/_check_type_completeness.json
+++ b/src/trio/_tests/_check_type_completeness.json
@@ -20,11 +20,6 @@
     "all": [
         "No docstring found for class \"trio._core._run.Task\"",
         "No docstring found for class \"trio._socket.SocketType\"",
-        "No docstring found for function \"trio._highlevel_socket.SocketStream.send_all\"",
-        "No docstring found for function \"trio._highlevel_socket.SocketStream.wait_send_all_might_not_block\"",
-        "No docstring found for function \"trio._highlevel_socket.SocketStream.send_eof\"",
-        "No docstring found for function \"trio._highlevel_socket.SocketStream.receive_some\"",
-        "No docstring found for function \"trio._highlevel_socket.SocketStream.aclose\"",
         "No docstring found for function \"trio._subprocess.HasFileno.fileno\"",
         "No docstring found for class \"trio._sync.AsyncContextManagerMixin\"",
         "No docstring found for function \"trio._sync._HasAcquireRelease.acquire\"",


### PR DESCRIPTION
﻿## Summary

- Add short docstrings for the concrete `SocketStream` stream methods.
- Link each method back to the matching `trio.abc` interface documentation.
- Add a documentation newsfragment for issue #3221.

Fixes #3221.

## Tests

- `py -3.14 -m py_compile src\trio\_highlevel_socket.py`
- Runtime docstring smoke check for `SocketStream` methods
- `py -3.14 -m pytest src/trio/_tests/test_highlevel_open_tcp_stream.py -q`
- `git diff --check`
