### PR TITLE
Add missing docstrings for ParkingLot.broken_by and HasFileno.fileno

### DIFF
--- a/newsfragments/3221.doc.rst
+++ b/newsfragments/3221.doc.rst
@@ -1,0 +1,2 @@
+Added missing docstrings for :attr:`trio.lowlevel.ParkingLot.broken_by` and
+``trio._subprocess.HasFileno.fileno``.

--- a/src/trio/_core/_parking_lot.py
+++ b/src/trio/_core/_parking_lot.py
@@ -146,6 +146,13 @@ class ParkingLot:
     the number of parked tasks, and ``if parking_lot: ...`` to check whether
     there are any parked tasks.
 
+    Currently, the following attribute is defined:
+
+    * ``broken_by`` (list of :class:`~trio.lowlevel.Task`): The tasks that
+      have broken this lot, in the order :meth:`break_lot` was called on
+      them. Empty if the lot isn't broken. See :meth:`break_lot` for
+      details.
+
     """
 
     # {task: None}, we just want a deque where we can quickly delete random

--- a/src/trio/_subprocess.py
+++ b/src/trio/_subprocess.py
@@ -98,7 +98,9 @@ else:
 class HasFileno(Protocol):
     """Represents any file-like object that has a file descriptor."""
 
-    def fileno(self) -> int: ...
+    def fileno(self) -> int:
+        """Return the object's file descriptor, as an integer."""
+        ...
 
 
 @final


### PR DESCRIPTION
Two of the eleven items in #3221 remained unchecked:

- `trio._subprocess.HasFileno.fileno`
- `trio.lowlevel.ParkingLot.broken_by`

This adds a docstring for each, matching the existing documentation style used elsewhere in these files (e.g. `ParkingLotStatistics`'s field-list style for `broken_by`, and a plain one-line docstring for `fileno`, consistent with how other methods are documented in this codebase).