### PR TITLE
[WIP] Allow cancellation between reschedule() called and task resumed

### DIFF
--- a/src/trio/_sync.py
+++ b/src/trio/_sync.py
@@ -73,7 +73,7 @@ class Event:
         if not self._flag:
             self._flag = True
             for task in self._tasks:
-                _core.reschedule(task)
+                _core.reschedule(task, allow_abort=True)
             self._tasks.clear()
 
     async def wait(self) -> None:
@@ -89,7 +89,7 @@ class Event:
             self._tasks.add(task)
 
             def abort_fn(_: RaiseCancelT) -> Abort:
-                self._tasks.remove(task)
+                self._tasks.discard(task)
                 return _core.Abort.SUCCEEDED
 
             await _core.wait_task_rescheduled(abort_fn)


### PR DESCRIPTION
Fixes #2973

* `reschedule()` gets a new parameter `allow_abort: bool` which, if True, still allows the abort function to be called right up until the task actually resumed. It is False by default so it's backwards compatible.
* When `Event.wait()` is woken by `Event.set()` it uses this parameter, so cancellation of it always succeeds

**Not ready to merge** I think the code is fine but:

* No tests 
* No docs