### PR TITLE
Fix Trio imports on Android without interface helpers

### DIFF
--- a/newsfragments/3493.bugfix.rst
+++ b/newsfragments/3493.bugfix.rst
@@ -1,0 +1,1 @@
+Allow importing Trio on Android API levels where ``socket.if_indextoname`` and ``socket.if_nametoindex`` are unavailable.

--- a/src/trio/_tests/test_socket.py
+++ b/src/trio/_tests/test_socket.py
@@ -4,6 +4,7 @@ import errno
 import inspect
 import os
 import socket as stdlib_socket
+import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -165,6 +166,33 @@ def test_socket_has_some_reexports() -> None:
     assert tsocket.TCP_NODELAY == stdlib_socket.TCP_NODELAY
     assert tsocket.gaierror == stdlib_socket.gaierror
     assert tsocket.ntohs == stdlib_socket.ntohs
+
+
+def test_imports_without_android_interface_helpers() -> None:
+    script = """
+import socket as real_socket
+import sys
+import types
+
+fake_socket = types.ModuleType("socket")
+fake_socket.__dict__.update(real_socket.__dict__)
+del fake_socket.if_indextoname
+del fake_socket.if_nametoindex
+sys.modules["socket"] = fake_socket
+
+import trio.socket
+"""
+    environment = os.environ.copy()
+    source_path = str(Path(__file__).parents[2])
+    environment["PYTHONPATH"] = os.pathsep.join(
+        [source_path, environment.get("PYTHONPATH", "")]
+    )
+    subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=Path(__file__).parents[3],
+        env=environment,
+        check=True,
+    )
 
 
 ################################################################

--- a/src/trio/socket.py
+++ b/src/trio/socket.py
@@ -69,10 +69,12 @@ from socket import (
 )
 
 if sys.implementation.name == "cpython":
-    from socket import (
-        if_indextoname as if_indextoname,
-        if_nametoindex as if_nametoindex,
-    )
+    # These functions are not available on all Android API levels.
+    with _suppress(ImportError):
+        from socket import (
+            if_indextoname as if_indextoname,
+            if_nametoindex as if_nametoindex,
+        )
 
     # For android devices, if_nameindex support was introduced in API 24,
     # so it doesn't exist for any version prior.


### PR DESCRIPTION
## Summary

Fix Trio imports on Android API levels where CPython does not expose `socket.if_indextoname` and `socket.if_nametoindex`.

## Changes

- Make both interface-name helpers optional at runtime, matching the existing handling for `if_nameindex`.
- Add a regression test that imports `trio.socket` with the two standard-library helpers removed.
- Add a bugfix news fragment for issue #3493.

## Validation

- `PYTHONPATH=src python -m pytest src/trio/_tests/test_socket.py -q` — 31 passed, 4 skipped.
- `uv run --with 'ruff>=0.14' ruff check src/trio/socket.py src/trio/_tests/test_socket.py` — passed.
- `python -m black --check src/trio/socket.py src/trio/_tests/test_socket.py` — passed.
- `uv run --with 'mypy>=1.18' mypy src/trio/socket.py` — passed.
- `uv run --with build --with setuptools python -m build --wheel --no-isolation` — passed.
- `git diff --check` — passed.

The repository's system Ruff 0.15.0 cannot parse the current configuration's newer `builtin-argument-shadowing` selector, so the compatible Ruff version was supplied through `uv`. Type checking the whole test module with `--follow-imports=skip` reports pre-existing test/decorator and ignored-import diagnostics; the changed production module passes mypy.

## Compatibility

On platforms that provide these functions, Trio continues to re-export them unchanged. On platforms that do not, importing `trio.socket` succeeds and the unavailable names are simply absent, consistent with existing platform-specific exports.

Fixes #3493.
