### PR TITLE
Ignore stale kqueue events for an already-deregistered key

### DIFF
--- a/newsfragments/3500.bugfix.rst
+++ b/newsfragments/3500.bugfix.rst
@@ -1,0 +1,1 @@
+On the kqueue backend (macOS/BSD), `~trio.lowlevel.notify_closing` could race with an already-fetched batch of kernel events under guest mode, causing `TrioInternalError: internal error in Trio - please file a bug!` wrapping a `KeyError` from inside `process_events`. Such stale events are now ignored instead of crashing the run.

--- a/src/trio/_core/_io_kqueue.py
+++ b/src/trio/_core/_io_kqueue.py
@@ -90,7 +90,15 @@ class KqueueIOManager:
             if event.ident == self._force_wakeup_fd:
                 self._force_wakeup.drain()
                 continue
-            receiver = self._registered[key]
+            receiver = self._registered.get(key)
+            if receiver is None:
+                # In guest mode, get_events() can fetch a batch of kernel
+                # events ahead of when they actually reach process_events()
+                # on a later tick. notify_closing() (or a completed
+                # wait_kevent abort) can deregister this same key in that
+                # window, so by the time the stale event gets here there's
+                # nothing left to deliver it to.
+                continue
             if event.flags & select.KQ_EV_ONESHOT:  # TODO: test this branch
                 del self._registered[key]
             if isinstance(receiver, _core.Task):

--- a/src/trio/_core/_tests/test_io.py
+++ b/src/trio/_core/_tests/test_io.py
@@ -426,6 +426,7 @@ async def test_io_manager_kqueue_monitors_statistics() -> None:
     sys.platform == "win32" or sys.platform == "linux",
     reason="only the kqueue backend has this failure mode",
 )
+@pytest.mark.filterwarnings("ignore:.*UnboundedQueue:trio.TrioDeprecationWarning")
 async def test_kqueue_process_events_tolerates_stale_deregistered_key() -> None:
     # The pytest.mark.skipif above keeps this from running on Linux/Windows,
     # but mypy doesn't understand that decorator and still type-checks this
@@ -442,22 +443,28 @@ async def test_kqueue_process_events_tolerates_stale_deregistered_key() -> None:
         # used to look it up with a bare `self._registered[key]` and blow up
         # with a KeyError instead of just treating it as "nothing left to
         # wake up here."
+        #
+        # This goes through monitor_kevent (the same public registration API
+        # notify_closing's own deregistration relies on) rather than poking
+        # at _registered directly, so the test exercises the real code path
+        # instead of just asserting against internal state.
         from trio._core._io_kqueue import KqueueIOManager
 
         manager = KqueueIOManager()
         try:
             with stdlib_socket.socket() as s:
                 fileno = s.fileno()
-            # The socket is closed now, so this fileno is free, but we're not
-            # actually doing any real kqueue registration here, we just care
-            # about the dict lookup process_events() does against _registered.
-            key = (fileno, select.KQ_FILTER_WRITE)
-
-            manager._registered[key] = object()
-            del manager._registered[key]  # e.g. notify_closing() already ran
-
-            stale_event = select.kevent(fileno, select.KQ_FILTER_WRITE)
-            manager.process_events([stale_event])  # must not raise KeyError
+                filter = select.KQ_FILTER_WRITE
+                with manager.monitor_kevent(fileno, filter):
+                    pass  # registered, then deregistered on context exit below
+                # The context manager's __exit__ already removed
+                # (fileno, filter) from _registered, the same way
+                # notify_closing removes a key for a task waiting in
+                # wait_kevent. A kqueue batch fetched just before that exit
+                # can still hand process_events() an event for this now-
+                # stale key.
+                stale_event = select.kevent(fileno, filter)
+                manager.process_events([stale_event])  # must not raise KeyError
         finally:
             manager.close()
 

--- a/src/trio/_core/_tests/test_io.py
+++ b/src/trio/_core/_tests/test_io.py
@@ -427,32 +427,39 @@ async def test_io_manager_kqueue_monitors_statistics() -> None:
     reason="only the kqueue backend has this failure mode",
 )
 async def test_kqueue_process_events_tolerates_stale_deregistered_key() -> None:
-    # In guest mode, GuestState.guest_tick can fetch a batch of ready kqueue
-    # events with get_events(0) ahead of when they're actually delivered to
-    # process_events() on a later tick. notify_closing() can run in that
-    # window and deregister the same key, since it's a plain synchronous
-    # function that isn't tied to a checkpoint the way task cancellation is.
-    # When the stale event then arrives, process_events() used to look it up
-    # with a bare `self._registered[key]` and blow up with a KeyError instead
-    # of just treating it as "nothing left to wake up here."
-    from trio._core._io_kqueue import KqueueIOManager
+    # The pytest.mark.skipif above keeps this from running on Linux/Windows,
+    # but mypy doesn't understand that decorator and still type-checks this
+    # body under --platform linux, where select.kevent/KQ_FILTER_WRITE don't
+    # exist. Narrow with the same static sys.platform check the rest of this
+    # file already uses so mypy skips the body too, matching the check above.
+    if sys.platform != "win32" and sys.platform != "linux":
+        # In guest mode, GuestState.guest_tick can fetch a batch of ready
+        # kqueue events with get_events(0) ahead of when they're actually
+        # delivered to process_events() on a later tick. notify_closing() can
+        # run in that window and deregister the same key, since it's a plain
+        # synchronous function that isn't tied to a checkpoint the way task
+        # cancellation is. When the stale event then arrives, process_events()
+        # used to look it up with a bare `self._registered[key]` and blow up
+        # with a KeyError instead of just treating it as "nothing left to
+        # wake up here."
+        from trio._core._io_kqueue import KqueueIOManager
 
-    manager = KqueueIOManager()
-    try:
-        with stdlib_socket.socket() as s:
-            fileno = s.fileno()
-        # The socket is closed now, so this fileno is free, but we're not
-        # actually doing any real kqueue registration here, we just care
-        # about the dict lookup process_events() does against _registered.
-        key = (fileno, select.KQ_FILTER_WRITE)
+        manager = KqueueIOManager()
+        try:
+            with stdlib_socket.socket() as s:
+                fileno = s.fileno()
+            # The socket is closed now, so this fileno is free, but we're not
+            # actually doing any real kqueue registration here, we just care
+            # about the dict lookup process_events() does against _registered.
+            key = (fileno, select.KQ_FILTER_WRITE)
 
-        manager._registered[key] = object()
-        del manager._registered[key]  # e.g. notify_closing() already ran
+            manager._registered[key] = object()
+            del manager._registered[key]  # e.g. notify_closing() already ran
 
-        stale_event = select.kevent(fileno, select.KQ_FILTER_WRITE)
-        manager.process_events([stale_event])  # must not raise KeyError
-    finally:
-        manager.close()
+            stale_event = select.kevent(fileno, select.KQ_FILTER_WRITE)
+            manager.process_events([stale_event])  # must not raise KeyError
+        finally:
+            manager.close()
 
 
 async def test_can_survive_unnotified_close() -> None:

--- a/src/trio/_core/_tests/test_io.py
+++ b/src/trio/_core/_tests/test_io.py
@@ -422,6 +422,39 @@ async def test_io_manager_kqueue_monitors_statistics() -> None:
             check(expected_monitors=0, expected_readers=1, expected_writers=0)
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32" or sys.platform == "linux",
+    reason="only the kqueue backend has this failure mode",
+)
+async def test_kqueue_process_events_tolerates_stale_deregistered_key() -> None:
+    # In guest mode, GuestState.guest_tick can fetch a batch of ready kqueue
+    # events with get_events(0) ahead of when they're actually delivered to
+    # process_events() on a later tick. notify_closing() can run in that
+    # window and deregister the same key, since it's a plain synchronous
+    # function that isn't tied to a checkpoint the way task cancellation is.
+    # When the stale event then arrives, process_events() used to look it up
+    # with a bare `self._registered[key]` and blow up with a KeyError instead
+    # of just treating it as "nothing left to wake up here."
+    from trio._core._io_kqueue import KqueueIOManager
+
+    manager = KqueueIOManager()
+    try:
+        with stdlib_socket.socket() as s:
+            fileno = s.fileno()
+        # The socket is closed now, so this fileno is free, but we're not
+        # actually doing any real kqueue registration here, we just care
+        # about the dict lookup process_events() does against _registered.
+        key = (fileno, select.KQ_FILTER_WRITE)
+
+        manager._registered[key] = object()
+        del manager._registered[key]  # e.g. notify_closing() already ran
+
+        stale_event = select.kevent(fileno, select.KQ_FILTER_WRITE)
+        manager.process_events([stale_event])  # must not raise KeyError
+    finally:
+        manager.close()
+
+
 async def test_can_survive_unnotified_close() -> None:
     # An "unnotified" close is when the user closes an fd/socket/handle
     # directly, without calling notify_closing first. This should never happen


### PR DESCRIPTION
Closes #3500.

With a PySide6 app running trio in guest mode, `process_events()` in the kqueue backend can occasionally blow up with `KeyError: (46, -2)`, which guest mode then wraps into a fatal `TrioInternalError`.

The root cause is a timing gap between `get_events()` and `process_events()`. In guest mode, `GuestState.guest_tick` fetches a batch of ready kqueue events with a non-blocking `get_events(0)` right after resuming the scheduler for the current tick, then hands that batch off to be delivered on the *next* tick, once the host loop gets around to scheduling it. `notify_closing()` is a plain synchronous function, not tied to a checkpoint, so it can run in that gap and remove the fd/filter key from `_registered` before the already-fetched event for that same key gets delivered. `process_events()` looked the key up with a bare `self._registered[key]`, so a stale event for a since-deregistered key crashed the whole run.

The epoll backend doesn't have this problem because its `_registered` is a `defaultdict`, so a lookup for a missing key just returns an empty waiter set instead of raising. This PR gives kqueue the same tolerance: a missing key means there's nothing left to wake up, so the event is skipped.

Added a regression test that constructs a `KqueueIOManager` directly, registers then deregisters a key (mimicking what `notify_closing` does), and feeds a matching event straight into `process_events()`. It reproduces the exact `KeyError` on the old code and passes with the fix. Ran the full `_core` test suite locally on macOS (arm64), 277 passed.