### PR TITLE
Document subprocess worker-thread context inheritance

### DIFF
--- a/newsfragments/3360.doc.rst
+++ b/newsfragments/3360.doc.rst
@@ -1,0 +1,3 @@
+Document that `trio.run_process` and `trio.lowlevel.open_process` create
+subprocesses from a worker thread, which affects the per-thread operating-system
+state inherited by the child.

--- a/src/trio/_subprocess.py
+++ b/src/trio/_subprocess.py
@@ -328,6 +328,12 @@ async def _open_process(
     management of the child process. It's up to you to implement whatever semantics you
     want.
 
+    .. note:: `subprocess.Popen` runs in a worker thread to avoid blocking Trio's
+       event loop. Any per-thread operating-system state inherited by the child
+       therefore comes from that worker thread, not the thread running Trio. On Linux,
+       for example, changes to the Trio thread's namespaces or CPU affinity may not be
+       reflected in the child process.
+
     Args:
       command: The command to run. Typically this is a sequence of strings or
           bytes such as ``['ls', '-l', 'directory with spaces']``, where the
@@ -554,6 +560,12 @@ async def _run_process(
     **Cancellation:** If cancelled, `run_process` sends a termination
     request to the subprocess, then waits for it to fully exit. The
     ``deliver_cancel`` argument lets you control how the process is terminated.
+
+    .. note:: `subprocess.Popen` runs in a worker thread to avoid blocking Trio's
+       event loop. Any per-thread operating-system state inherited by the child
+       therefore comes from that worker thread, not the thread running Trio. On Linux,
+       for example, changes to the Trio thread's namespaces or CPU affinity may not be
+       reflected in the child process.
 
     .. note:: `run_process` is intentionally similar to the standard library
        `subprocess.run`, but some of the defaults are different. Specifically, we


### PR DESCRIPTION
## Summary

- document that `trio.run_process` and `trio.lowlevel.open_process` call
  `subprocess.Popen` from a worker thread
- explain that applicable per-thread operating-system state is therefore
  inherited from the worker thread, with Linux namespaces and CPU affinity as
  examples
- add the corresponding documentation release note

This addresses the documentation request in #3360. It leaves the API and
spawning behavior unchanged; #3462's synchronous-spawn option was closed because
blocking the Trio event loop is unacceptable.

## Validation

- a focused runtime probe wrapped the real `subprocess.Popen`, launched a child,
  and confirmed that `Popen` ran on a different OS thread from Trio's event loop
- `sphinx-build -W --keep-going -b html docs/source ...`
- `towncrier build --draft`
- file-scoped `pre-commit` checks for the two changed files
