### PR TITLE
Document ParkingLot.broken_by

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -174,7 +174,6 @@ def autodoc_process_signature(
 logger = getLogger("trio")
 UNDOCUMENTED = {
     "trio._subprocess.HasFileno.fileno",
-    "trio.lowlevel.ParkingLot.broken_by",
 }
 
 

--- a/src/trio/_core/_parking_lot.py
+++ b/src/trio/_core/_parking_lot.py
@@ -152,6 +152,7 @@ class ParkingLot:
     # items
     _parked: OrderedDict[Task, None] = attrs.field(factory=OrderedDict, init=False)
     broken_by: list[Task] = attrs.field(factory=list, init=False)
+    """The tasks that have broken this parking lot."""
 
     def __len__(self) -> int:
         """Returns the number of parked tasks."""


### PR DESCRIPTION
Closes Part of #3221

Adds documentation for `ParkingLot.broken_by` and removes it from the documentation allowlist.

Validation:
- `python -m pytest src\trio\_core\_tests\test_parking_lot.py`
- `python -m ruff check src\trio\_core\_parking_lot.py docs\source\conf.py`
- `python -m ruff format --check src\trio\_core\_parking_lot.py docs\source\conf.py`
- `python -m compileall src\trio\_core\_parking_lot.py docs\source\conf.py`