### PR TITLE
Give the Windows IO backend the error messages its siblings have

### DIFF
--- a/newsfragments/3509.bugfix.rst
+++ b/newsfragments/3509.bugfix.rst
@@ -1,0 +1,4 @@
+On Windows, :func:`trio.lowlevel.wait_readable`, :func:`trio.lowlevel.wait_writable`
+and :func:`trio.lowlevel.notify_closing` raised ``BusyResourceError`` and
+``ClosedResourceError`` without any message. They now explain themselves, as they
+already did on the epoll and kqueue backends.

--- a/src/trio/_core/_io_windows.py
+++ b/src/trio/_core/_io_windows.py
@@ -740,7 +740,9 @@ class WindowsIOManager:
             waiters = AFDWaiters()
             self._afd_waiters[base_handle] = waiters
         if getattr(waiters, mode) is not None:
-            raise _core.BusyResourceError
+            raise _core.BusyResourceError(
+                "another task is already reading / writing this socket",
+            )
         setattr(waiters, mode, _core.current_task())
         # Could potentially raise if the handle is somehow invalid; that's OK,
         # we let it escape.
@@ -822,7 +824,10 @@ class WindowsIOManager:
         handle = _get_base_socket(handle)
         waiters = self._afd_waiters.get(handle)
         if waiters is not None:
-            wake_all(waiters, _core.ClosedResourceError())
+            wake_all(
+                waiters,
+                _core.ClosedResourceError("another task closed this socket"),
+            )
             self._refresh_afd(handle)
 
     ################################################################


### PR DESCRIPTION
On Windows, `wait_readable` / `wait_writable` raise `BusyResourceError` with no message, and `notify_closing` raises `ClosedResourceError` with no message. Both carry a description on the other two backends:

- `_io_epoll.py`: `BusyResourceError("another task is already reading / writing this fd")` and `ClosedResourceError("another task closed this fd")`
- `_io_kqueue.py`: the same `ClosedResourceError` text
- `_io_windows.py`: `raise _core.BusyResourceError` (the bare class) and `ClosedResourceError()`

`_io_windows.py` already passes a message for the `lpOverlapped` case, so it was inconsistent with itself as well.

I used "socket" rather than epoll's "fd" because `_afd_poll` and `notify_closing` both resolve their argument through `_get_base_socket`. Say the word and I'll make them character-identical to the epoll strings instead.

Nothing changes but the message text, and no existing test asserts either string. I'm on macOS so I could not run the Windows suite; this is checked with `ruff check`, `ruff format` and `py_compile` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011M5uTyCU4WcNTsPvGrErDo
