### PR TITLE
Make sleep() name its own parameter when given NaN

### DIFF
--- a/newsfragments/3511.bugfix.rst
+++ b/newsfragments/3511.bugfix.rst
@@ -1,0 +1,2 @@
+:func:`trio.sleep` now reports ``NaN`` under the name of its own parameter, raising
+```seconds`` must not be NaN`` rather than ``deadline must not be NaN``.

--- a/src/trio/_tests/test_timeouts.py
+++ b/src/trio/_tests/test_timeouts.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import time
 from typing import TYPE_CHECKING, Protocol, TypeVar
 
@@ -182,29 +183,25 @@ async def test_timeouts_raise_value_error() -> None:
 
     nan = float("nan")
 
-    for fun, val in (
-        (sleep, -1),
-        (sleep, nan),
-        (sleep_until, nan),
+    # Each message names the parameter that function actually takes, so the
+    # patterns are exact rather than an alternation over both spellings.
+    for fun, val, message in (
+        (sleep, -1, "`seconds` must be non-negative"),
+        (sleep, nan, "`seconds` must not be NaN"),
+        (sleep_until, nan, "deadline must not be NaN"),
     ):
-        with pytest.raises(
-            ValueError,
-            match=r"^(deadline|`seconds`) must (not )*be (non-negative|NaN)$",
-        ):
+        with pytest.raises(ValueError, match=rf"^{re.escape(message)}$"):
             await fun(val)
 
-    for cm, val in (
-        (fail_after, -1),
-        (fail_after, nan),
-        (fail_at, nan),
-        (move_on_after, -1),
-        (move_on_after, nan),
-        (move_on_at, nan),
+    for cm, val, message in (
+        (fail_after, -1, "`seconds` must be non-negative"),
+        (fail_after, nan, "`seconds` must not be NaN"),
+        (fail_at, nan, "deadline must not be NaN"),
+        (move_on_after, -1, "`seconds` must be non-negative"),
+        (move_on_after, nan, "`seconds` must not be NaN"),
+        (move_on_at, nan, "deadline must not be NaN"),
     ):
-        with pytest.raises(
-            ValueError,
-            match=r"^(deadline|`seconds`) must (not )*be (non-negative|NaN)$",
-        ):
+        with pytest.raises(ValueError, match=rf"^{re.escape(message)}$"):
             with cm(val):
                 pass  # pragma: no cover
 

--- a/src/trio/_timeouts.py
+++ b/src/trio/_timeouts.py
@@ -103,8 +103,12 @@ async def sleep(seconds: float) -> None:
         ValueError: if *seconds* is negative or NaN.
 
     """
+    # Duplicate validation logic, as in move_on_after, so the error names the
+    # parameter the caller passed rather than the deadline derived from it.
     if seconds < 0:
         raise ValueError("`seconds` must be non-negative")
+    if math.isnan(seconds):
+        raise ValueError("`seconds` must not be NaN")
     if seconds == 0:
         await trio.lowlevel.checkpoint()
     else:


### PR DESCRIPTION
`trio.sleep(float("nan"))` raises `ValueError: deadline must not be NaN`, naming a value the caller never passed. `sleep` takes `seconds`.

`sleep` validates `seconds < 0` itself but lets NaN through to the deadline check in `_core`, which is where the wording comes from. Its docstring already promises the error:

```
Raises:
    ValueError: if *seconds* is negative or NaN.
```

`move_on_after` duplicates the same two checks deliberately, with the comment `# duplicate validation logic to have the correct parameter name`. `sleep` never got the same treatment. This adds the missing NaN check there, so all nine paths now name the parameter they actually take: `seconds` for `sleep`, `fail_after` and `move_on_after`, `deadline` for `sleep_until`, `fail_at` and `move_on_at`.

The existing `test_timeouts_raise_value_error` could not have caught this. Its pattern was `^(deadline|`seconds`) must (not )*be (non-negative|NaN)$`, an alternation accepting either spelling for every function, so both the old and new messages pass it. Each case now pins the exact message for its own parameter; reverting `_timeouts.py` fails the test with `- deadline must not be NaN` / `+ `seconds` must not be NaN`.

Context: #2493 reported that `sleep(nan)` slept forever and was fixed at the deadline level, which is why the value is rejected today but under the wrong name.

159 pass across `test_timeouts.py` and `_core/_tests/test_run.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011M5uTyCU4WcNTsPvGrErDo
